### PR TITLE
clang format script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,47 @@
+# https://releases.llvm.org/7.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+
+---
+Language: Cpp
+
+BasedOnStyle: WebKit
+
+AlignAfterOpenBracket: Align
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakConstructorInitializersBeforeComma: true
+ColumnLimit: 120
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+Cpp11BracedListStyle: true
+FixNamespaceComments: true
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^["<](stdafx|pch)\.h[">]$'
+    Priority:        -1
+  - Regex:           '^<Windows\.h>$'
+    Priority:        3
+  - Regex:           '^<(WinIoCtl|winhttp|Shellapi)\.h>$'
+    Priority:        4
+  - Regex:           '.*'
+    Priority:        2
+IndentCaseLabels: true
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: All
+PenaltyReturnTypeOnItsOwnLine: 1000
+PointerAlignment: Left
+SpaceAfterTemplateKeyword: false
+Standard: Cpp11
+UseTab: Never
+SortIncludes: false


### PR DESCRIPTION
.clang-format stub. 
bootstrapped from https://github.com/Microsoft/cpprestsdk/blob/master/.clang-format
3 possibilities:
- set VS to use it. It formats the code as you type.
- add a target in CMake to use clang-format
- make a ps script to format files

A good practice would be to do a clang format pass once your PR is approved and not spend time tracking poorly placed braces, missing spaces ,... during PR reviews

What's your take on that?