### PR TITLE
Xr workaround

### DIFF
--- a/Library/Source/NativeEngine.cpp
+++ b/Library/Source/NativeEngine.cpp
@@ -1366,17 +1366,21 @@ namespace babylon
             //bgfx_test(static_cast<uint16_t>(m_size.Width), static_cast<uint16_t>(m_size.Height));
 
             callbackPtr->Call({});
-
-            // recycle viewIds used as viewports
-            for (auto id : m_viewportIds)
-            {
-                m_viewidSet.Recycle(id);
-            }
-            m_viewportIds.clear();
-            m_currentBackbufferViewId = 0;
-
-            bgfx::frame();
+            EndFrame();
         });
+    }
+
+    void NativeEngine::EndFrame()
+    {
+        // recycle viewIds used as viewports
+        for (auto id : m_viewportIds)
+        {
+            m_viewidSet.Recycle(id);
+        }
+        m_viewportIds.clear();
+        m_currentBackbufferViewId = 0;
+
+        bgfx::frame();
     }
 
     void NativeEngine::Dispatch(std::function<void()> function)

--- a/Library/Source/NativeEngine.h
+++ b/Library/Source/NativeEngine.h
@@ -329,6 +329,7 @@ namespace babylon
 
         FrameBufferManager& GetFrameBufferManager();
         void Dispatch(std::function<void()>);
+        void EndFrame();
 
     private:
         Napi::Value GetEngine(const Napi::CallbackInfo& info); // TODO: Hack, temporary method. Remove as part of the change to get rid of NapiBridge.

--- a/Library/Source/NativeXr.cpp
+++ b/Library/Source/NativeXr.cpp
@@ -132,6 +132,8 @@ namespace babylon
                 BeginFrame();
                 callback(*m_frame);
                 EndFrame();
+
+                m_engineImpl->EndFrame();
             });
         }
 
@@ -832,7 +834,6 @@ namespace babylon
                 {
                     m_xrFrame.Update(frame);
                     func->Call({ Napi::Value::From(env, -1), m_jsXRFrame.Value() });
-                    bgfx::frame();
                 });
 
                 // TODO: Timestamp, I think? Or frame handle? Look up what this return value is and return the right thing.

--- a/Library/Source/NativeXr.cpp
+++ b/Library/Source/NativeXr.cpp
@@ -131,9 +131,8 @@ namespace babylon
 
                 BeginFrame();
                 callback(*m_frame);
-                EndFrame();
-
                 m_engineImpl->EndFrame();
+                EndFrame();
             });
         }
 


### PR DESCRIPTION
Quick workaround to get XR working in master. Note that this is a temporary fix, intended to be undone once the reworked architecture for working with `ViewID`s is finished.