### PR TITLE
Fix UWP refresh render size

### DIFF
--- a/TestApp/Source/UWP/App.cpp
+++ b/TestApp/Source/UWP/App.cpp
@@ -123,13 +123,10 @@ void App::OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^
         m_fileActivatedArgs = nullptr;
     }
 
-    RestartRuntimeAsync();
-
-    const auto& bounds = applicationView->CoreWindow->Bounds;
-    m_runtime->UpdateSize(bounds.Width, bounds.Height);
+    RestartRuntimeAsync(applicationView->CoreWindow->Bounds);
 }
 
-concurrency::task<void> App::RestartRuntimeAsync()
+concurrency::task<void> App::RestartRuntimeAsync(Windows::Foundation::Rect bounds)
 {
     m_inputBuffer.reset();
     m_runtime.reset();
@@ -171,6 +168,8 @@ concurrency::task<void> App::RestartRuntimeAsync()
 
         m_runtime->LoadScript(appUrl + "/Scripts/playground_runner.js");
     }
+
+    m_runtime->UpdateSize(bounds.Width, bounds.Height);
 }
 
 void App::OnSuspending(Platform::Object^ sender, SuspendingEventArgs^ args)
@@ -226,11 +225,11 @@ void App::OnPointerReleased(CoreWindow^, PointerEventArgs^)
     m_inputBuffer->SetPointerDown(false);
 }
 
-void App::OnKeyPressed(CoreWindow^, KeyEventArgs^ args)
+void App::OnKeyPressed(CoreWindow^ window, KeyEventArgs^ args)
 {
     if (args->VirtualKey == VirtualKey::R)
     {
-        RestartRuntimeAsync();
+        RestartRuntimeAsync(window->Bounds);
     }
 }
 

--- a/TestApp/Source/UWP/App.h
+++ b/TestApp/Source/UWP/App.h
@@ -38,7 +38,7 @@ private:
     void OnOrientationChanged(Windows::Graphics::Display::DisplayInformation^ sender, Platform::Object^ args);
     void OnDisplayContentsInvalidated(Windows::Graphics::Display::DisplayInformation^ sender, Platform::Object^ args);
 
-    concurrency::task<void> RestartRuntimeAsync();
+    concurrency::task<void> RestartRuntimeAsync(Windows::Foundation::Rect);
 
     std::unique_ptr<babylon::RuntimeUWP> m_runtime{};
     std::unique_ptr<InputManager::InputBuffer> m_inputBuffer{};


### PR DESCRIPTION
Fixed UWP so that pressing "R" correctly sets the backbuffer size after recreating the runtime.