### PR TITLE
Windows Mixed Reality color space workaround

### DIFF
--- a/Library/Dependencies/xr/Include/XR.h
+++ b/Library/Dependencies/xr/Include/XR.h
@@ -19,7 +19,7 @@ namespace xr
     enum class TextureFormat
     {
         RGBA8,
-        RGBA8S,
+        RGBA8_NONLINEAR,
         D24S8
     };
 

--- a/Library/Dependencies/xr/Include/XR.h
+++ b/Library/Dependencies/xr/Include/XR.h
@@ -18,8 +18,8 @@ namespace xr
 
     enum class TextureFormat
     {
-        RGBA8,
-        RGBA8_NONLINEAR,
+        RGBA8_SRGB,
+        BGRA8_SRGB,
         D24S8
     };
 

--- a/Library/Dependencies/xr/Source/Windows/XrPlatform.h
+++ b/Library/Dependencies/xr/Source/Windows/XrPlatform.h
@@ -46,7 +46,7 @@ namespace xr
         case DXGI_FORMAT_R8G8B8A8_UNORM:
             return xr::TextureFormat::RGBA8;
         case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
-            return xr::TextureFormat::RGBA8S;
+            return xr::TextureFormat::RGBA8;
         case DXGI_FORMAT_D24_UNORM_S8_UINT:
             return xr::TextureFormat::D24S8;
         default:

--- a/Library/Dependencies/xr/Source/Windows/XrPlatform.h
+++ b/Library/Dependencies/xr/Source/Windows/XrPlatform.h
@@ -46,7 +46,7 @@ namespace xr
         case DXGI_FORMAT_R8G8B8A8_UNORM:
             return xr::TextureFormat::RGBA8;
         case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
-            return xr::TextureFormat::RGBA8;
+            return xr::TextureFormat::RGBA8_NONLINEAR;
         case DXGI_FORMAT_D24_UNORM_S8_UINT:
             return xr::TextureFormat::D24S8;
         default:

--- a/Library/Dependencies/xr/Source/Windows/XrPlatform.h
+++ b/Library/Dependencies/xr/Source/Windows/XrPlatform.h
@@ -30,7 +30,7 @@ namespace xr
 
     constexpr std::array<SwapchainFormat, 2> SUPPORTED_COLOR_FORMATS
     {
-        DXGI_FORMAT_R8G8B8A8_UNORM,
+        DXGI_FORMAT_B8G8R8A8_UNORM_SRGB,
         DXGI_FORMAT_R8G8B8A8_UNORM_SRGB
     };
 
@@ -43,10 +43,10 @@ namespace xr
     {
         switch (format)
         {
-        case DXGI_FORMAT_R8G8B8A8_UNORM:
-            return xr::TextureFormat::RGBA8;
+        case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+            return xr::TextureFormat::BGRA8_SRGB;
         case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
-            return xr::TextureFormat::RGBA8_NONLINEAR;
+            return xr::TextureFormat::RGBA8_SRGB;
         case DXGI_FORMAT_D24_UNORM_S8_UINT:
             return xr::TextureFormat::D24S8;
         default:

--- a/Library/Dependencies/xr/Source/XR.cpp
+++ b/Library/Dependencies/xr/Source/XR.cpp
@@ -584,6 +584,19 @@ namespace xr
             layersPtr = reinterpret_cast<XrCompositionLayerBaseHeader*>(&layer);
         }
 
+#ifdef _DEBUG
+        if (!Views.empty())
+        {
+            // 'SetPrivateData' is intercepted by the special fork of RenderDoc in order to detect that
+            // a frame is being presented. This can be done to any swapchain image texture returned
+            // by xrEnumerateSwapchainImages. This should be done after all rendering is complete for the
+            // frame (and not for each eye backbuffer).
+            ID3D11Texture2D* texture = reinterpret_cast<ID3D11Texture2D*>(Views.front().ColorTexturePointer);
+            int dummy;
+            texture->SetPrivateData({0xD4544440, 0x90B9, 0x4815, 0x8B, 0x99, 0x18, 0xC0, 0x23, 0xA5, 0x73, 0xF1}, sizeof(dummy), &dummy);
+        }
+#endif
+
         // Submit the composition layers for the predicted display time.
         XrFrameEndInfo frameEndInfo{ XR_TYPE_FRAME_END_INFO };
         frameEndInfo.displayTime = m_displayTime;

--- a/Library/Source/NativeXr.cpp
+++ b/Library/Source/NativeXr.cpp
@@ -8,16 +8,22 @@
 
 namespace
 {
-    std::pair<bgfx::TextureFormat::Enum, uint64_t> XrTextureFormatToBgfxFormat(xr::TextureFormat format)
+    bgfx::TextureFormat::Enum XrTextureFormatToBgfxFormat(xr::TextureFormat format)
     {
         switch (format)
         {
-        case xr::TextureFormat::RGBA8:
-            return{ bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT };
-        case xr::TextureFormat::RGBA8_NONLINEAR:
-            return{ bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT /*| BGFX_TEXTURE_SRGB*/ };
+        // Color Formats
+        // NOTE: Use linear formats even though XR requests sRGB to match what happens on the web.
+        //       WebGL shaders expect sRGB output while native shaders expect linear output.
+        case xr::TextureFormat::BGRA8_SRGB:
+            return bgfx::TextureFormat::BGRA8;
+        case xr::TextureFormat::RGBA8_SRGB:
+            return bgfx::TextureFormat::RGBA8;
+
+        // Depth Formats
         case xr::TextureFormat::D24S8:
-            return{ bgfx::TextureFormat::D24S8, BGFX_TEXTURE_RT };
+            return bgfx::TextureFormat::D24S8;
+
         default:
             throw std::exception{ /* Unsupported texture format */ };
         }
@@ -239,14 +245,11 @@ namespace babylon
                 assert(view.ColorTextureSize.Width == view.DepthTextureSize.Width);
                 assert(view.ColorTextureSize.Height == view.DepthTextureSize.Height);
 
-                auto [colorTextureFormat, colorTextureFlags] = XrTextureFormatToBgfxFormat(view.ColorTextureFormat);
-                auto [depthTextureFormat, depthTextureFlags] = XrTextureFormatToBgfxFormat(view.DepthTextureFormat);
+                auto colorTextureFormat = XrTextureFormatToBgfxFormat(view.ColorTextureFormat);
+                auto colorTex = bgfx::createTexture2D(1, 1, false, 1, colorTextureFormat, BGFX_TEXTURE_RT);
 
-                assert(bgfx::isTextureValid(0, false, 1, colorTextureFormat, colorTextureFlags));
-                assert(bgfx::isTextureValid(0, false, 1, depthTextureFormat, depthTextureFlags));
-
-                auto colorTex = bgfx::createTexture2D(1, 1, false, 1, colorTextureFormat, colorTextureFlags);
-                auto depthTex = bgfx::createTexture2D(1, 1, false, 1, depthTextureFormat, depthTextureFlags);
+                auto depthTextureFormat = XrTextureFormatToBgfxFormat(view.DepthTextureFormat);
+                auto depthTex = bgfx::createTexture2D(1, 1, false, 1, depthTextureFormat, BGFX_TEXTURE_RT);
 
                 // Force BGFX to create the texture now, which is necessary in order to use overrideInternal.
                 bgfx::frame();

--- a/Library/Source/NativeXr.cpp
+++ b/Library/Source/NativeXr.cpp
@@ -8,16 +8,16 @@
 
 namespace
 {
-    bgfx::TextureFormat::Enum XrTextureFormatToBgfxFormat(xr::TextureFormat format)
+    std::pair<bgfx::TextureFormat::Enum, uint64_t> XrTextureFormatToBgfxFormat(xr::TextureFormat format)
     {
         switch (format)
         {
         case xr::TextureFormat::RGBA8:
-            return bgfx::TextureFormat::RGBA8;
-        case xr::TextureFormat::RGBA8S:
-            return bgfx::TextureFormat::RGBA8S;
+            return{ bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT };
+        case xr::TextureFormat::RGBA8_NONLINEAR:
+            return{ bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT /*| BGFX_TEXTURE_SRGB*/ };
         case xr::TextureFormat::D24S8:
-            return bgfx::TextureFormat::D24S8;
+            return{ bgfx::TextureFormat::D24S8, BGFX_TEXTURE_RT };
         default:
             throw std::exception{ /* Unsupported texture format */ };
         }
@@ -239,14 +239,14 @@ namespace babylon
                 assert(view.ColorTextureSize.Width == view.DepthTextureSize.Width);
                 assert(view.ColorTextureSize.Height == view.DepthTextureSize.Height);
 
-                auto colorTextureFormat = XrTextureFormatToBgfxFormat(view.ColorTextureFormat);
-                auto depthTextureFormat = XrTextureFormatToBgfxFormat(view.DepthTextureFormat);
+                auto [colorTextureFormat, colorTextureFlags] = XrTextureFormatToBgfxFormat(view.ColorTextureFormat);
+                auto [depthTextureFormat, depthTextureFlags] = XrTextureFormatToBgfxFormat(view.DepthTextureFormat);
 
-                assert(bgfx::isTextureValid(0, false, 1, colorTextureFormat, BGFX_TEXTURE_RT));
-                assert(bgfx::isTextureValid(0, false, 1, depthTextureFormat, BGFX_TEXTURE_RT));
+                assert(bgfx::isTextureValid(0, false, 1, colorTextureFormat, colorTextureFlags));
+                assert(bgfx::isTextureValid(0, false, 1, depthTextureFormat, depthTextureFlags));
 
-                auto colorTex = bgfx::createTexture2D(1, 1, false, 1, colorTextureFormat, BGFX_TEXTURE_RT);
-                auto depthTex = bgfx::createTexture2D(1, 1, false, 1, depthTextureFormat, BGFX_TEXTURE_RT);
+                auto colorTex = bgfx::createTexture2D(1, 1, false, 1, colorTextureFormat, colorTextureFlags);
+                auto depthTex = bgfx::createTexture2D(1, 1, false, 1, depthTextureFormat, depthTextureFlags);
 
                 // Force BGFX to create the texture now, which is necessary in order to use overrideInternal.
                 bgfx::frame();

--- a/TestApp/Scripts/experience.js
+++ b/TestApp/Scripts/experience.js
@@ -1,9 +1,9 @@
 var wireframe = false;
 var turntable = false;
 var logfps = true;
-var ibl = false;
+var ibl = true;
 var rtt = false;
-var xr = false;
+var xr = true;
 
 function CreateBoxAsync() {
     BABYLON.Mesh.CreateBox("box1", 0.7);
@@ -49,13 +49,13 @@ function CreateInputHandling(scene) {
 var engine = new BABYLON.NativeEngine();
 var scene = new BABYLON.Scene(engine);
 
-CreateBoxAsync().then(function () {
+//CreateBoxAsync().then(function () {
 //CreateSpheresAsync().then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box/glTF/Box.gltf").then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTextured/glTF/BoxTextured.gltf").then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Suzanne/glTF/Suzanne.gltf").then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF/Avocado.gltf").then(function () {
-//BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF/BoomBox.gltf").then(function () {
+BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF/BoomBox.gltf").then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/Sponza.gltf").then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BrainStem/glTF/BrainStem.gltf").then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet.gltf").then(function () {
@@ -134,6 +134,7 @@ CreateBoxAsync().then(function () {
                 setTimeout(function () {
                     scene.meshes[0].position = scene.activeCamera.getFrontPosition(2);
                     scene.meshes[0].rotate(BABYLON.Vector3.Up(), 3.14159);
+                    scene.meshes[0].scaling.scaleInPlace(10.0);
                 }, 5000);
                 return xr.baseExperience.enterXRAsync("immersive-vr", "unbounded", xr.renderTarget);
             });

--- a/TestApp/Scripts/experience.js
+++ b/TestApp/Scripts/experience.js
@@ -1,9 +1,9 @@
 var wireframe = false;
 var turntable = false;
 var logfps = true;
-var ibl = true;
+var ibl = false;
 var rtt = false;
-var xr = true;
+var xr = false;
 
 function CreateBoxAsync() {
     BABYLON.Mesh.CreateBox("box1", 0.7);
@@ -49,13 +49,13 @@ function CreateInputHandling(scene) {
 var engine = new BABYLON.NativeEngine();
 var scene = new BABYLON.Scene(engine);
 
-//CreateBoxAsync().then(function () {
+CreateBoxAsync().then(function () {
 //CreateSpheresAsync().then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box/glTF/Box.gltf").then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTextured/glTF/BoxTextured.gltf").then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Suzanne/glTF/Suzanne.gltf").then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF/Avocado.gltf").then(function () {
-BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF/BoomBox.gltf").then(function () {
+//BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF/BoomBox.gltf").then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/Sponza.gltf").then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BrainStem/glTF/BrainStem.gltf").then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet.gltf").then(function () {
@@ -134,7 +134,6 @@ BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/
                 setTimeout(function () {
                     scene.meshes[0].position = scene.activeCamera.getFrontPosition(2);
                     scene.meshes[0].rotate(BABYLON.Vector3.Up(), 3.14159);
-                    scene.meshes[0].scaling.scaleInPlace(10.0);
                 }, 5000);
                 return xr.baseExperience.enterXRAsync("immersive-vr", "unbounded", xr.renderTarget);
             });


### PR DESCRIPTION
So here's a weird thing. After talking with @sebavan and fiddling with the color spaces a bit, we found that if we lie to the OpenXR runtime about the color space of the swapchain it's receiving, we can get the rendering output we expect from the latest runtimes---neither too dark nor too light. I'm pretty sure this isn't something we want to be in the business of doing long-term, and maybe not even short-term, but I thought this draft PR might be a good place to discuss it and figure out where we want to go from here.