### PR TITLE
Fix hack for inverting dFdy

### DIFF
--- a/Library/CMakeLists.txt
+++ b/Library/CMakeLists.txt
@@ -97,6 +97,7 @@ set(SOURCES
     "Source/RuntimeImpl.h"
     "Source/Runtime${BABYLON_NATIVE_PLATFORM}.cpp"
     "Source/ShaderCompiler.h"
+    "Source/ShaderCompiler.cpp"
     "Source/XMLHttpRequest.cpp"
     "Source/XMLHttpRequest.h"
     "Source/XMLHttpRequest${BABYLON_NATIVE_PLATFORM}.cpp")

--- a/Library/Source/NativeEngine.cpp
+++ b/Library/Source/NativeEngine.cpp
@@ -507,9 +507,7 @@ namespace babylon
     Napi::Value NativeEngine::CreateProgram(const Napi::CallbackInfo& info)
     {
         const auto vertexSource = info[0].As<Napi::String>().Utf8Value();
-        // TODO: This is a HACK to account for the fact that DirectX and OpenGL disagree about the vertical orientation of screen space.
-        // Remove this ASAP when we have a more long-term plan to account for this behavior.
-        const auto fragmentSource = std::regex_replace(info[1].As<Napi::String>().Utf8Value(), std::regex("dFdy\\("), "-dFdy(");
+        const auto fragmentSource = info[1].As<Napi::String>().Utf8Value();
 
         auto programData = new ProgramData();
 

--- a/Library/Source/ShaderCompiler.cpp
+++ b/Library/Source/ShaderCompiler.cpp
@@ -20,7 +20,7 @@ namespace babylon
                     auto op = unary->getOp();
                     if (op == glslang::EOpDPdy || op == glslang::EOpDPdyFine || op == glslang::EOpDPdyCoarse)
                     {
-                        unary->setOperand(intermediate->addUnaryNode(glslang::EOpNegative, unary->getOperand(), {}));
+                        unary->setOperand(m_intermediate->addUnaryNode(glslang::EOpNegative, unary->getOperand(), {}));
                         return false;
                     }
                 }

--- a/Library/Source/ShaderCompiler.cpp
+++ b/Library/Source/ShaderCompiler.cpp
@@ -1,0 +1,42 @@
+#include "ShaderCompiler.h"
+#include <glslang/Public/ShaderLang.h>
+#include <glslang/MachineIndependent/localintermediate.h>
+
+namespace babylon
+{
+    namespace
+    {
+        class InvertYDerivativeOperandsTraverser : public glslang::TIntermTraverser
+        {
+        public:
+            InvertYDerivativeOperandsTraverser(glslang::TIntermediate* intermediate) : intermediate(intermediate)
+            {
+            }
+
+            virtual bool visitUnary(glslang::TVisit visit, glslang::TIntermUnary* unary) override
+            {
+                if (visit == glslang::EvPreVisit)
+                {
+                    auto op = unary->getOp();
+                    if (op == glslang::EOpDPdy || op == glslang::EOpDPdyFine || op == glslang::EOpDPdyCoarse)
+                    {
+                        unary->setOperand(intermediate->addUnaryNode(glslang::EOpNegative, unary->getOperand(), {}));
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+        private:
+            glslang::TIntermediate* intermediate;
+        };
+    }
+
+    void ShaderCompiler::InvertYDerivativeOperands(glslang::TShader& shader)
+    {
+        auto intermediate = shader.getIntermediate();
+        InvertYDerivativeOperandsTraverser invertYDerivativeOperandsTraverser{ shader.getIntermediate() };
+        intermediate->getTreeRoot()->traverse(&invertYDerivativeOperandsTraverser);
+    }
+}

--- a/Library/Source/ShaderCompiler.cpp
+++ b/Library/Source/ShaderCompiler.cpp
@@ -9,7 +9,7 @@ namespace babylon
         class InvertYDerivativeOperandsTraverser : public glslang::TIntermTraverser
         {
         public:
-            InvertYDerivativeOperandsTraverser(glslang::TIntermediate* intermediate) : intermediate(intermediate)
+            InvertYDerivativeOperandsTraverser(glslang::TIntermediate* intermediate) : m_intermediate(intermediate)
             {
             }
 

--- a/Library/Source/ShaderCompiler.cpp
+++ b/Library/Source/ShaderCompiler.cpp
@@ -29,7 +29,7 @@ namespace babylon
             }
 
         private:
-            glslang::TIntermediate* intermediate;
+            glslang::TIntermediate* m_intermediate;
         };
     }
 

--- a/Library/Source/ShaderCompiler.h
+++ b/Library/Source/ShaderCompiler.h
@@ -4,6 +4,11 @@
 #include <gsl/span>
 #include <spirv_cross.hpp>
 
+namespace glslang
+{
+    class TShader;
+}
+
 namespace babylon
 {
     class ShaderCompiler
@@ -19,5 +24,11 @@ namespace babylon
         };
 
         void Compile(std::string_view vertexSource, std::string_view fragmentSource, std::function<void (ShaderInfo, ShaderInfo)> onCompiled);
+
+    protected:
+        // Invert dFdy operands similar to bgfx_shader.sh
+        // https://github.com/bkaradzic/bgfx/blob/7be225bf490bb1cd231cfb4abf7e617bf35b59cb/src/bgfx_shader.sh#L44-L45
+        // https://github.com/bkaradzic/bgfx/blob/7be225bf490bb1cd231cfb4abf7e617bf35b59cb/src/bgfx_shader.sh#L62-L65
+        static void InvertYDerivativeOperands(glslang::TShader& shader);
     };
 }

--- a/Library/Source/ShaderCompilerD3D.cpp
+++ b/Library/Source/ShaderCompilerD3D.cpp
@@ -26,9 +26,6 @@ namespace babylon
             shader.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetVulkan_1_0);
             shader.setEnvTarget(glslang::EShTargetSpv, glslang::EShTargetSpv_1_0);
 
-            // TODO: Do this to avoid the work around for dFdy?
-            //shader->setInvertY(true);
-
             if (!shader.parse(&DefaultTBuiltInResource, 450, false, EShMsgDefault))
             {
                 throw std::exception(shader.getInfoDebugLog());
@@ -92,6 +89,7 @@ namespace babylon
 
         glslang::TShader fragmentShader{ EShLangFragment };
         AddShader(program, fragmentShader, fragmentSource);
+        InvertYDerivativeOperands(fragmentShader);
 
         if (!program.link(EShMsgDefault))
         {

--- a/Library/Source/ShaderCompilerMetal.cpp
+++ b/Library/Source/ShaderCompilerMetal.cpp
@@ -17,9 +17,6 @@ namespace glslang
         shader.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetVulkan_1_0);
         shader.setEnvTarget(glslang::EShTargetSpv, glslang::EShTargetSpv_1_0);
 
-        // TODO: Do this to avoid the work around for dFdy?
-        //shader->setInvertY(true);
-
         if (!shader.parse(&babylon::DefaultTBuiltInResource, 450, false, EShMsgDefault))
         {
             throw std::exception();//shader.getInfoDebugLog());
@@ -111,6 +108,7 @@ namespace babylon
 
         glslang::TShader fragmentShader{ EShLangFragment };
         AddShader(program, fragmentShader, fragmentSource);
+        InvertYDerivativeOperands(fragmentShader);
 
         if (!program.link(EShMsgDefault))
         {


### PR DESCRIPTION
Use syntax tree from glslang instead of a string replace to invert dFdy operand.