### PR TITLE
Runtime contract updates

### DIFF
--- a/Library/Include/Babylon/Runtime.h
+++ b/Library/Include/Babylon/Runtime.h
@@ -67,19 +67,12 @@ namespace babylon
         void Eval(const std::string& string, const std::string& sourceUrl);
 
         /**
-         * Execute an arbitrary function on the same thread that drives the JavaScript environment.
+         * Dispatch an arbitrary function on the same thread that drives the JavaScript environment.
          * This method is thread-safe, but it is implicitly asynchronous: order of execution is
          * guaranteed, but not immediacy of execution. This is the correct way to force code to be
          * run in a particular order relative to calls to LoadScript() and Eval().
          */
-        void Execute(std::function<void(Runtime&)>);
-
-        /**
-         * Retrieves the JavaScript environment. This method is NOT thread-safe, and the environment
-         * itself is not thread-safe. Consequently, this method can only be safely used inside a call
-         * to Execute().
-         */
-        babylon::Env& Env() const;
+        void Dispatch(std::function<void(Env&)> callback);
 
         /**
          * Retrieves the root URL provided at the time the Runtime was created (a default value may

--- a/Library/Source/NativeEngine.cpp
+++ b/Library/Source/NativeEngine.cpp
@@ -1317,7 +1317,7 @@ namespace babylon
         // put into a kind of function which requires a copy constructor for all of its captured variables.  Because
         // the Napi::FunctionReference is not copyable, this breaks when trying to capture the callback directly, so we
         // wrap it in a std::shared_ptr to allow the capture to function correctly.
-        m_runtimeImpl.Execute([this, callbackPtr = std::make_shared<Napi::FunctionReference>(std::move(callback))](auto&)
+        m_runtimeImpl.Dispatch([this, callbackPtr = std::make_shared<Napi::FunctionReference>(std::move(callback))](auto&)
         {
             //bgfx_test(static_cast<uint16_t>(m_size.Width), static_cast<uint16_t>(m_size.Height));
 
@@ -1335,7 +1335,7 @@ namespace babylon
 
     void NativeEngine::Dispatch(std::function<void()> function)
     {
-        m_runtimeImpl.Execute([function = std::move(function)](auto&)
+        m_runtimeImpl.Dispatch([function = std::move(function)](auto&)
         {
             function();
         });

--- a/Library/Source/NativeWindow.cpp
+++ b/Library/Source/NativeWindow.cpp
@@ -107,7 +107,7 @@ namespace babylon
         }
         else
         {
-            m_runtimeImpl.Execute([this, function = std::move(function), whenToRun](auto&)
+            m_runtimeImpl.Dispatch([this, function = std::move(function), whenToRun](auto&)
             {
                 RecursiveWaitOrCall(std::move(function), whenToRun);
             });

--- a/Library/Source/Runtime.cpp
+++ b/Library/Source/Runtime.cpp
@@ -38,17 +38,9 @@ namespace babylon
         m_impl->Eval(string, url);
     }
 
-    void Runtime::Execute(std::function<void(Runtime&)> func)
+    void Runtime::Dispatch(std::function<void(Env&)> func)
     {
-        m_impl->Execute([this, func = std::move(func)](auto&)
-        {
-            func(*this);
-        });
-    }
-
-    babylon::Env& Runtime::Env() const
-    {
-        return m_impl->Env();
+        m_impl->Dispatch(func);
     }
 
     const std::string& Runtime::RootUrl() const

--- a/Library/Source/RuntimeImpl.h
+++ b/Library/Source/RuntimeImpl.h
@@ -27,17 +27,14 @@ namespace babylon
         void UpdateSize(float width, float height);
         void Suspend();
         void Resume();
+        void LoadScript(const std::string& url);
+        void Eval(const std::string& string, const std::string& sourceUrl);
+        void Dispatch(std::function<void(Env&)> callback);
+        const std::string& RootUrl() const;
 
         std::string GetAbsoluteUrl(const std::string& url);
         template<typename T> arcana::task<T, std::exception_ptr> LoadUrlAsync(const std::string& url);
 
-        void LoadScript(const std::string& url);
-        void Eval(const std::string& string, const std::string& url);
-
-        void Execute(std::function<void(RuntimeImpl&)>);
-
-        babylon::Env& Env();
-        const std::string& RootUrl() const;
         arcana::manual_dispatcher<babylon_dispatcher::work_size>& Dispatcher();
         arcana::cancellation& Cancellation();
 

--- a/Library/Source/RuntimeUWP.cpp
+++ b/Library/Source/RuntimeUWP.cpp
@@ -29,9 +29,9 @@ namespace babylon
 
     void RuntimeImpl::ThreadProcedure()
     {
-        this->Execute([](RuntimeImpl& runtimeImpl)
+        this->Dispatch([](Env& env)
         {
-            InitializeNativeXr(runtimeImpl.Env());
+            InitializeNativeXr(env);
         });
 
         RuntimeImpl::BaseThreadProcedure();

--- a/Library/Source/RuntimeWin32.cpp
+++ b/Library/Source/RuntimeWin32.cpp
@@ -30,9 +30,9 @@ namespace babylon
         assert(SUCCEEDED(hr));
         auto coInitializeScopeGuard = gsl::finally([] { CoUninitialize(); });
 
-        Execute([](RuntimeImpl& runtime)
+        Dispatch([](Env& env)
         {
-            InitializeNativeXr(runtime.Env());
+            InitializeNativeXr(env);
         });
 
         RuntimeImpl::BaseThreadProcedure();

--- a/TestApp/Source/Shared/InputManager.h
+++ b/TestApp/Source/Shared/InputManager.h
@@ -11,15 +11,15 @@ public:
     class InputBuffer
     {
     public:
-        InputBuffer(babylon::Runtime& rt)
-            : m_runtime{ rt }
+        InputBuffer(babylon::Runtime& runtime)
+            : m_runtime{ runtime }
         {}
         InputBuffer(const InputBuffer&) = delete;
         InputBuffer& operator=(const InputBuffer&) = delete;
 
         void SetPointerPosition(int x, int y)
         {
-            m_runtime.Execute([x, y, this](const auto&)
+            m_runtime.Dispatch([x, y, this](const auto&)
             {
                 m_pointerX = x;
                 m_pointerY = y;
@@ -28,7 +28,7 @@ public:
 
         void SetPointerDown(bool isPointerDown)
         {
-            m_runtime.Execute([isPointerDown, this](const auto&)
+            m_runtime.Dispatch([isPointerDown, this](const auto&)
             {
                 m_isPointerDown = isPointerDown;
             });
@@ -57,11 +57,10 @@ public:
         bool m_isPointerDown{};
     };
 
-    static void Initialize(babylon::Runtime& rt, InputBuffer& inputBuffer)
+    static void Initialize(babylon::Runtime& runtime, InputBuffer& inputBuffer)
     {
-        rt.Execute([data = &inputBuffer](const auto& runtime)
+        runtime.Dispatch([data = &inputBuffer](auto& env)
         {
-            auto& env = runtime.Env();
             Napi::HandleScope scope{ env };
 
             Napi::Function func = DefineClass(


### PR DESCRIPTION
Fixes #63 

* Rename `Execute` to `Dispatch`
* Remove `Env`
* Update `LoadScript` to be more parallel

We had a discussion about changing the contract more, but after trying to implement it, I think this is the right contract. We had originally thought there was an ordering issue with LoadScript, but I've confirmed that it works as intended (calling runtime methods guarantees order of execution on the JavaScript thread). It should be perhaps documented better than it is currently written.