### PR TITLE
Handle screen scale

### DIFF
--- a/TestApp/Source/UWP/App.cpp
+++ b/TestApp/Source/UWP/App.cpp
@@ -83,7 +83,6 @@ void App::SetWindow(CoreWindow^ window)
 
     window->KeyDown +=
         ref new TypedEventHandler<CoreWindow^, KeyEventArgs^>(this, &App::OnKeyPressed);
-
 }
 
 // Initializes scene resources, or loads a previously saved app state.
@@ -169,7 +168,10 @@ concurrency::task<void> App::RestartRuntimeAsync(Windows::Foundation::Rect bound
         m_runtime->LoadScript(appUrl + "/Scripts/playground_runner.js");
     }
 
-    m_runtime->UpdateSize(bounds.Width, bounds.Height);
+    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+    m_displayScale = static_cast<float>(displayInformation->RawPixelsPerViewPixel);
+
+    m_runtime->UpdateSize(bounds.Width * m_displayScale, bounds.Height * m_displayScale);
 }
 
 void App::OnSuspending(Platform::Object^ sender, SuspendingEventArgs^ args)
@@ -196,7 +198,7 @@ void App::OnResuming(Platform::Object^ sender, Platform::Object^ args)
 
 void App::OnWindowSizeChanged(CoreWindow^ /*sender*/, WindowSizeChangedEventArgs^ args)
 {
-    m_runtime->UpdateSize(args->Size.Width, args->Size.Height);
+    m_runtime->UpdateSize(args->Size.Width * m_displayScale, args->Size.Height * m_displayScale);
 }
 
 void App::OnVisibilityChanged(CoreWindow^ sender, VisibilityChangedEventArgs^ args)
@@ -237,8 +239,9 @@ void App::OnKeyPressed(CoreWindow^ window, KeyEventArgs^ args)
 
 void App::OnDpiChanged(DisplayInformation^ /*sender*/, Object^ /*args*/)
 {
-    // TODO: Implement.
-    //m_runtime->UpdateRenderTarget();
+    DisplayInformation^ displayInformation = DisplayInformation::GetForCurrentView();
+    m_displayScale = static_cast<float>(displayInformation->RawPixelsPerViewPixel);
+    // resize event happens after. No need to force resize here.
 }
 
 void App::OnOrientationChanged(DisplayInformation^ sender, Object^ args)

--- a/TestApp/Source/UWP/App.cpp
+++ b/TestApp/Source/UWP/App.cpp
@@ -191,7 +191,7 @@ void App::OnResuming(Platform::Object^ sender, Platform::Object^ args)
     // and state are persisted when resuming from suspend. Note that this event
     // does not occur if the app was previously terminated.
 
-    // Insert your code here.
+    m_runtime->Resume();
 }
 
 // Window event handlers.

--- a/TestApp/Source/UWP/App.h
+++ b/TestApp/Source/UWP/App.h
@@ -45,6 +45,7 @@ private:
     Windows::ApplicationModel::Activation::FileActivatedEventArgs^ m_fileActivatedArgs;
     bool m_windowClosed;
     bool m_windowVisible;
+    float m_displayScale{ 1.f };
 };
 
 ref class Direct3DApplicationSource sealed : Windows::ApplicationModel::Core::IFrameworkViewSource


### PR DESCRIPTION
Fix issue for https://github.com/BabylonJS/BabylonNative/issues/103
Added resume call or application hangs when restored from minimized state.
Do you know how to disable background drawing? Window flashes blue when resizing.