### PR TITLE
Added minor safeguards to enforce the proper lifecycle.

### DIFF
--- a/Library/Source/RuntimeImpl.cpp
+++ b/Library/Source/RuntimeImpl.cpp
@@ -101,6 +101,7 @@ namespace Babylon
 
     void RuntimeImpl::Dispatch(std::function<void(Env&)> func)
     {
+        assert(!m_cancelSource.cancelled());
         auto lock = AcquireTaskLock();
         Task = Task.then(m_dispatcher, m_cancelSource, [func = std::move(func), this]()
         {
@@ -255,6 +256,9 @@ namespace Babylon
             }
             m_dispatcher.blocking_tick(m_cancelSource);
         }
+
+        // Force the dispatcher to drain. Since all tasks should now be cancelled, this should do no actual work.
+        m_dispatcher.blocking_tick(arcana::cancellation::none());
     }
 
     template arcana::task<std::string, std::exception_ptr> RuntimeImpl::LoadUrlAsync(const std::string& url);


### PR DESCRIPTION
Addressing #70.

The issue described is something that appeared in early versions and reared its head again in an intermediate state in October, but it no longer repros now (nor in the non-intermediate states I synced back to from October). However, I believe the potential for lifecycle problems is valid, and the problem can be prevented with a few relatively straightforward safeguards, so the following are prophylactic changes to address the identified vulnerability.