### PR TITLE
mutex for flushing rendering commands

### DIFF
--- a/Library/Source/RuntimeImpl.cpp
+++ b/Library/Source/RuntimeImpl.cpp
@@ -61,6 +61,7 @@ namespace Babylon
     void RuntimeImpl::Suspend()
     {
         std::unique_lock<std::mutex> lockSuspension(m_suspendMutex);
+        // Lock block ticking so no rendering will happen once we exit Suspend method
         std::unique_lock<std::mutex> lockTicking(m_blockTickingMutex);
         m_suspended = true;
         m_suspendVariable.notify_one();

--- a/Library/Source/RuntimeImpl.cpp
+++ b/Library/Source/RuntimeImpl.cpp
@@ -60,7 +60,8 @@ namespace Babylon
 
     void RuntimeImpl::Suspend()
     {
-        std::unique_lock<std::mutex> lock(m_suspendMutex);
+        std::unique_lock<std::mutex> lockSuspension(m_suspendMutex);
+        std::unique_lock<std::mutex> lockTicking(m_blockTickingMutex);
         m_suspended = true;
         m_suspendVariable.notify_one();
     }
@@ -235,7 +236,10 @@ namespace Babylon
                 std::unique_lock<std::mutex> lock(m_suspendMutex);
                 m_suspendVariable.wait(lock, [this]() { return !m_suspended; });
             }
-            m_dispatcher.blocking_tick(m_cancelSource);
+            {
+                std::unique_lock<std::mutex> lock(m_blockTickingMutex);
+                m_dispatcher.blocking_tick(m_cancelSource);
+            }
         }
     }
 

--- a/Library/Source/RuntimeImpl.h
+++ b/Library/Source/RuntimeImpl.h
@@ -59,6 +59,9 @@ namespace Babylon
         arcana::cancellation_source m_cancelSource{};
         std::mutex m_taskMutex;
         std::mutex m_suspendMutex;
+        // when asking for suspension, we need to ensure no rendering is on going.
+        // This mutex is used to be sure no rendering is happening after Suspend method returns.
+        std::mutex m_blockTickingMutex;
         std::condition_variable m_suspendVariable;
         bool m_suspended{false};
 


### PR DESCRIPTION
I need to flush rendering commands and be sure that no draw call is being performed when I suspend the app.
No need for this with d3d11.
On Android, the surface is destroyed when the app is in background. Any drawcall will crash the app or put it in unstable state.
On Mac, I also have to do it when resizing the window (disable rendering->let UI Kit resize the window ->enable rendering)