### PR TITLE
Call bgfx::shutdown() when destroying the NativeEngine

### DIFF
--- a/Library/Source/NativeEngine.cpp
+++ b/Library/Source/NativeEngine.cpp
@@ -386,6 +386,11 @@ namespace Babylon
         UpdateSize(static_cast<uint32_t>(nativeWindow.GetWidth()), static_cast<uint32_t>(nativeWindow.GetHeight()));
     }
 
+    NativeEngine::~NativeEngine()
+    {
+        bgfx::shutdown();
+    }
+
     void NativeEngine::UpdateSize(size_t width, size_t height)
     {
         const auto w = static_cast<uint16_t>(width);

--- a/Library/Source/NativeEngine.h
+++ b/Library/Source/NativeEngine.h
@@ -298,6 +298,7 @@ namespace Babylon
     public:
         NativeEngine(const Napi::CallbackInfo& info);
         NativeEngine(const Napi::CallbackInfo& info, NativeWindow& nativeWindow);
+        ~NativeEngine();
 
         static void InitializeWindow(void* nativeWindowPtr, uint32_t width, uint32_t height);
         static Napi::FunctionReference CreateConstructor(Napi::Env&);


### PR DESCRIPTION
… forgot to do that.