### PR TITLE
Disassociate AppRuntime from JsRuntime

### DIFF
--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -113,7 +113,10 @@ Java_BabylonNative_Wrapper_surfaceChanged(JNIEnv* env, jobject obj, jint width, 
     if (runtime)
     {
         ANativeWindow *window = ANativeWindow_fromSurface(env, surface);
-        Babylon::ReinitializeNativeEngine(*runtime, window, static_cast<size_t>(width), static_cast<size_t>(height));
+        runtime->Dispatch([window, width, height](Napi::Env env)
+        {
+            Babylon::ReinitializeNativeEngine(env, window, static_cast<size_t>(width), static_cast<size_t>(height));
+        });
     }
 }
 

--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -82,18 +82,20 @@ Java_BabylonNative_Wrapper_surfaceCreated(JNIEnv* env, jobject obj, jobject surf
         ANativeWindow *window = ANativeWindow_fromSurface(env, surface);
         int32_t width  = ANativeWindow_getWidth(window);
         int32_t height = ANativeWindow_getHeight(window);
+        Babylon::InitializeGraphics(window, width, height);
         runtime->Dispatch([window, width, height](Napi::Env env)
         {
             Babylon::NativeWindow::Initialize(env, window, width, height);
+
+            Babylon::InitializeNativeEngine(env);
+
+            Babylon::InitializeXMLHttpRequest(env, runtime->RootUrl());
+
+            auto& jsRuntime = Babylon::JsRuntime::GetFromJavaScript(env);
+
+            inputBuffer = std::make_unique<InputManager::InputBuffer>(jsRuntime);
+            InputManager::Initialize(jsRuntime, *inputBuffer);
         });
-
-        Babylon::InitializeNativeEngine(*runtime, window, width, height);
-
-        // Initialize XMLHttpRequest plugin.
-        Babylon::InitializeXMLHttpRequest(*runtime, runtime->RootUrl());
-
-        inputBuffer = std::make_unique<InputManager::InputBuffer>(*runtime);
-        InputManager::Initialize(*runtime, *inputBuffer);
 
         loader = std::make_unique<Babylon::ScriptLoader>(*runtime, runtime->RootUrl());
         loader->Eval("document = {}", "");

--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -82,13 +82,13 @@ Java_BabylonNative_Wrapper_surfaceCreated(JNIEnv* env, jobject obj, jobject surf
         ANativeWindow *window = ANativeWindow_fromSurface(env, surface);
         int32_t width  = ANativeWindow_getWidth(window);
         int32_t height = ANativeWindow_getHeight(window);
-        Babylon::InitializeGraphics(window, width, height);
         runtime->Dispatch([window, width, height](Napi::Env env)
         {
             Babylon::NativeWindow::Initialize(env, window, width, height);
 
             Babylon::InitializeNativeEngine(env);
 
+            Babylon::InitializeGraphics(window, width, height);
             Babylon::InitializeXMLHttpRequest(env, runtime->RootUrl());
 
             auto& jsRuntime = Babylon::JsRuntime::GetFromJavaScript(env);

--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -60,7 +60,10 @@ Java_BabylonNative_Wrapper_surfaceCreated(JNIEnv* env, jobject obj, jobject surf
     {
         runtime = std::make_unique<Babylon::AppRuntime>("");
 
-        runtime->Dispatch([](Napi::Env env)
+        ANativeWindow *window = ANativeWindow_fromSurface(env, surface);
+        int32_t width  = ANativeWindow_getWidth(window);
+        int32_t height = ANativeWindow_getHeight(window);
+        runtime->Dispatch([window, width, height](Napi::Env env)
         {
             Babylon::Console::CreateInstance(env, [](const char* message, Babylon::Console::LogLevel level)
             {
@@ -77,13 +80,7 @@ Java_BabylonNative_Wrapper_surfaceCreated(JNIEnv* env, jobject obj, jobject surf
                     break;
                 }
             });
-        });
 
-        ANativeWindow *window = ANativeWindow_fromSurface(env, surface);
-        int32_t width  = ANativeWindow_getWidth(window);
-        int32_t height = ANativeWindow_getHeight(window);
-        runtime->Dispatch([window, width, height](Napi::Env env)
-        {
             Babylon::NativeWindow::Initialize(env, window, width, height);
 
             Babylon::InitializeNativeEngine(env);

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -181,13 +181,13 @@ concurrency::task<void> App::RestartRuntimeAsync(Windows::Foundation::Rect bound
         Babylon::InitializeNativeEngine(jsRuntime, windowPtr, width, height);
 
         // Initialize XMLHttpRequest plugin.
-        Babylon::InitializeXMLHttpRequest(jsRuntime, runtime->RootUrl());
+        Babylon::InitializeXMLHttpRequest(env, runtime->RootUrl());
 
         inputBuffer = std::make_unique<InputManager::InputBuffer>(jsRuntime);
-        InputManager::Initialize(jsRuntime, *inputBuffer);    
+        InputManager::Initialize(jsRuntime, *inputBuffer);
     });
 
-    Babylon::ScriptLoader loader{[& runtime = m_runtime](auto func) { runtime->Dispatch(std::move(func)); }, m_runtime->RootUrl()};
+    Babylon::ScriptLoader loader{*m_runtime, m_runtime->RootUrl()};
     loader.Eval("document = {}", "");
     loader.LoadScript(appUrl + "/Scripts/ammo.js");
     loader.LoadScript(appUrl + "/Scripts/recast.js");

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -178,7 +178,8 @@ concurrency::task<void> App::RestartRuntimeAsync(Windows::Foundation::Rect bound
         auto& jsRuntime = Babylon::JsRuntime::GetFromJavaScript(env);
         
         // Initialize NativeEngine plugin.
-        Babylon::InitializeNativeEngine(jsRuntime, windowPtr, width, height);
+        Babylon::InitializeGraphics(windowPtr, width, height);
+        Babylon::InitializeNativeEngine(env);
 
         // Initialize XMLHttpRequest plugin.
         Babylon::InitializeXMLHttpRequest(env, runtime->RootUrl());

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -153,6 +153,9 @@ concurrency::task<void> App::RestartRuntimeAsync(Windows::Foundation::Rect bound
         m_runtime = std::make_unique<Babylon::AppRuntime>(std::move(rootUrl));
     }
 
+    // Ensure this is properly uninitialized since it depends on state of the runtime.
+    m_inputBuffer.reset();
+
     // Create the console plugin.
     m_runtime->Dispatch([](Napi::Env env)
     {
@@ -168,21 +171,23 @@ concurrency::task<void> App::RestartRuntimeAsync(Windows::Foundation::Rect bound
     size_t width = static_cast<size_t>(bounds.Width * m_displayScale);
     size_t height = static_cast<size_t>(bounds.Height * m_displayScale);
     auto* windowPtr = reinterpret_cast<ABI::Windows::UI::Core::ICoreWindow*>(CoreWindow::GetForCurrentThread());
-    m_runtime->Dispatch([windowPtr, width, height](Napi::Env env)
+    m_runtime->Dispatch([&runtime = m_runtime, &inputBuffer = m_inputBuffer, windowPtr, width, height](Napi::Env env)
     {
         Babylon::NativeWindow::Initialize(env, windowPtr, width, height);
+
+        auto& jsRuntime = Babylon::JsRuntime::GetFromJavaScript(env);
+        
+        // Initialize NativeEngine plugin.
+        Babylon::InitializeNativeEngine(jsRuntime, windowPtr, width, height);
+
+        // Initialize XMLHttpRequest plugin.
+        Babylon::InitializeXMLHttpRequest(jsRuntime, runtime->RootUrl());
+
+        inputBuffer = std::make_unique<InputManager::InputBuffer>(jsRuntime);
+        InputManager::Initialize(jsRuntime, *inputBuffer);    
     });
 
-    // Initialize NativeEngine plugin.
-    Babylon::InitializeNativeEngine(*m_runtime, windowPtr, width, height);
-
-    // Initialize XMLHttpRequest plugin.
-    Babylon::InitializeXMLHttpRequest(*m_runtime, m_runtime->RootUrl());
-
-    m_inputBuffer = std::make_unique<InputManager::InputBuffer>(*m_runtime);
-    InputManager::Initialize(*m_runtime, *m_inputBuffer);
-
-    Babylon::ScriptLoader loader{ *m_runtime, m_runtime->RootUrl() };
+    Babylon::ScriptLoader loader{[& runtime = m_runtime](auto func) { runtime->Dispatch(std::move(func)); }, m_runtime->RootUrl()};
     loader.Eval("document = {}", "");
     loader.LoadScript(appUrl + "/Scripts/ammo.js");
     loader.LoadScript(appUrl + "/Scripts/recast.js");
@@ -198,7 +203,7 @@ concurrency::task<void> App::RestartRuntimeAsync(Windows::Foundation::Rect bound
     {
         for (unsigned int idx = 0; idx < m_fileActivatedArgs->Files->Size; idx++)
         {
-            auto file = static_cast<Windows::Storage::IStorageFile^>(m_fileActivatedArgs->Files->GetAt(idx));
+            auto file = static_cast<Windows::Storage::IStorageFile ^>(m_fileActivatedArgs->Files->GetAt(idx));
             const auto path = winrt::to_string(file->Path->Data());
             auto text = co_await Windows::Storage::FileIO::ReadTextAsync(file);
             // TODO m_runtime->Eval(winrt::to_string(text->Data()), path);
@@ -254,18 +259,27 @@ void App::OnWindowClosed(CoreWindow^ sender, CoreWindowEventArgs^ args)
 
 void App::OnPointerMoved(CoreWindow^, PointerEventArgs^ args)
 {
-    const auto& point = args->CurrentPoint->RawPosition;
-    m_inputBuffer->SetPointerPosition(static_cast<int>(point.X), static_cast<int>(point.Y));
+    if (m_inputBuffer != nullptr)
+    {
+        const auto& point = args->CurrentPoint->RawPosition;
+        m_inputBuffer->SetPointerPosition(static_cast<int>(point.X), static_cast<int>(point.Y));
+    }
 }
 
 void App::OnPointerPressed(CoreWindow^, PointerEventArgs^)
 {
-    m_inputBuffer->SetPointerDown(true);
+    if (m_inputBuffer != nullptr)
+    {
+        m_inputBuffer->SetPointerDown(true);
+    }
 }
 
 void App::OnPointerReleased(CoreWindow^, PointerEventArgs^)
 {
-    m_inputBuffer->SetPointerDown(false);
+    if (m_inputBuffer != nullptr)
+    {
+        m_inputBuffer->SetPointerDown(false);
+    }
 }
 
 void App::OnKeyPressed(CoreWindow^ window, KeyEventArgs^ args)

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -106,7 +106,8 @@ namespace
             Babylon::NativeWindow::Initialize(env, hWnd, width, height);
 
             // Initialize NativeEngine plugin.
-            Babylon::InitializeNativeEngine(jsRuntime, hWnd, width, height);
+            Babylon::InitializeGraphics(hWnd, width, height);
+            Babylon::InitializeNativeEngine(env);
 
             // Initialize XMLHttpRequest plugin.
             Babylon::InitializeXMLHttpRequest(env, runtime->RootUrl());

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -93,7 +93,7 @@ namespace
         runtime = std::make_unique<Babylon::AppRuntime>(scripts.empty() ? moduleRootUrl : GetUrlFromPath(std::filesystem::path{scripts.back()}.parent_path()));
 
         // Initialize console plugin.
-        runtime->Dispatch([rect, hWnd, moduleRootUrl = std::move(moduleRootUrl), scripts = std::move(scripts)](Napi::Env env) {
+        runtime->Dispatch([rect, hWnd](Napi::Env env) {
             auto& jsRuntime = Babylon::JsRuntime::GetFromJavaScript(env);
 
             Babylon::Console::CreateInstance(env, [](const char* message, auto) {
@@ -113,29 +113,29 @@ namespace
 
             inputBuffer = std::make_unique<InputManager::InputBuffer>(jsRuntime);
             InputManager::Initialize(jsRuntime, *inputBuffer);
-
-            Babylon::ScriptLoader loader{jsRuntime, runtime->RootUrl()};
-            loader.Eval("document = {}", "");
-            loader.LoadScript(moduleRootUrl + "/Scripts/ammo.js");
-            loader.LoadScript(moduleRootUrl + "/Scripts/recast.js");
-            loader.LoadScript(moduleRootUrl + "/Scripts/babylon.max.js");
-            loader.LoadScript(moduleRootUrl + "/Scripts/babylon.glTF2FileLoader.js");
-            loader.LoadScript(moduleRootUrl + "/Scripts/babylonjs.materials.js");
-
-            if (scripts.empty())
-            {
-                loader.LoadScript("Scripts/experience.js");
-            }
-            else
-            {
-                for (const auto& script : scripts)
-                {
-                    loader.LoadScript(GetUrlFromPath(script));
-                }
-
-                loader.LoadScript(moduleRootUrl + "/Scripts/playground_runner.js");
-            }
         });
+
+        Babylon::ScriptLoader loader{[](auto func) { runtime->Dispatch(std::move(func)); }, runtime->RootUrl()};
+        loader.Eval("document = {}", "");
+        loader.LoadScript(moduleRootUrl + "/Scripts/ammo.js");
+        loader.LoadScript(moduleRootUrl + "/Scripts/recast.js");
+        loader.LoadScript(moduleRootUrl + "/Scripts/babylon.max.js");
+        loader.LoadScript(moduleRootUrl + "/Scripts/babylon.glTF2FileLoader.js");
+        loader.LoadScript(moduleRootUrl + "/Scripts/babylonjs.materials.js");
+
+        if (scripts.empty())
+        {
+            loader.LoadScript("Scripts/experience.js");
+        }
+        else
+        {
+            for (const auto& script : scripts)
+            {
+                loader.LoadScript(GetUrlFromPath(script));
+            }
+
+            loader.LoadScript(moduleRootUrl + "/Scripts/playground_runner.js");
+        }
     }
 
     void UpdateWindowSize(float width, float height)

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -19,17 +19,17 @@
 #define MAX_LOADSTRING 100
 
 // Global Variables:
-HINSTANCE hInst;                                // current instance
-WCHAR szTitle[MAX_LOADSTRING];                  // The title bar text
-WCHAR szWindowClass[MAX_LOADSTRING];            // the main window class name
+HINSTANCE hInst;                     // current instance
+WCHAR szTitle[MAX_LOADSTRING];       // The title bar text
+WCHAR szWindowClass[MAX_LOADSTRING]; // the main window class name
 std::unique_ptr<Babylon::AppRuntime> runtime{};
 std::unique_ptr<InputManager::InputBuffer> inputBuffer{};
 
 // Forward declarations of functions included in this code module:
-ATOM                MyRegisterClass(HINSTANCE hInstance);
-BOOL                InitInstance(HINSTANCE, int);
-LRESULT CALLBACK    WndProc(HWND, UINT, WPARAM, LPARAM);
-INT_PTR CALLBACK    About(HWND, UINT, WPARAM, LPARAM);
+ATOM MyRegisterClass(HINSTANCE hInstance);
+BOOL InitInstance(HINSTANCE, int);
+LRESULT CALLBACK WndProc(HWND, UINT, WPARAM, LPARAM);
+INT_PTR CALLBACK About(HWND, UINT, WPARAM, LPARAM);
 
 namespace
 {
@@ -37,7 +37,7 @@ namespace
     {
         char buffer[1024];
         ::GetModuleFileNameA(nullptr, buffer, ARRAYSIZE(buffer));
-        return std::filesystem::path{ buffer };
+        return std::filesystem::path{buffer};
     }
 
     std::string GetUrlFromPath(const std::filesystem::path& path)
@@ -50,7 +50,7 @@ namespace
             throw std::exception("Failed to create url from path", hr);
         }
 
-        return { url };
+        return {url};
     }
 
     std::vector<std::string> GetCommandLineArguments()
@@ -63,7 +63,7 @@ namespace
 
         for (int idx = 1; idx < argc; idx++)
         {
-            std::wstring hstr{ argv[idx] };
+            std::wstring hstr{argv[idx]};
             int bytesRequired = ::WideCharToMultiByte(CP_UTF8, 0, &hstr[0], static_cast<int>(hstr.size()), nullptr, 0, nullptr, nullptr);
             arguments.push_back(std::string(bytesRequired, 0));
             ::WideCharToMultiByte(CP_UTF8, 0, hstr.data(), static_cast<int>(hstr.size()), arguments.back().data(), bytesRequired, nullptr, nullptr);
@@ -85,63 +85,62 @@ namespace
             return;
         }
 
+        // Ensure this is properly disposed.
+        inputBuffer.reset();
+
         // Separately call reset and make_unique to ensure prior runtime is destroyed before new one is created.
         runtime.reset();
         runtime = std::make_unique<Babylon::AppRuntime>(scripts.empty() ? moduleRootUrl : GetUrlFromPath(std::filesystem::path{scripts.back()}.parent_path()));
 
         // Initialize console plugin.
-        runtime->Dispatch([](Napi::Env env)
-        {
-            Babylon::Console::CreateInstance(env, [](const char* message, auto)
-            {
+        runtime->Dispatch([rect, hWnd, moduleRootUrl = std::move(moduleRootUrl), scripts = std::move(scripts)](Napi::Env env) {
+            auto& jsRuntime = Babylon::JsRuntime::GetFromJavaScript(env);
+
+            Babylon::Console::CreateInstance(env, [](const char* message, auto) {
                 OutputDebugStringA(message);
             });
-        });
 
-        // Initialize NativeWindow plugin.
-        auto width = static_cast<float>(rect.right - rect.left);
-        auto height = static_cast<float>(rect.bottom - rect.top);
-        runtime->Dispatch([hWnd, width, height](Napi::Env env)
-        {
+            // Initialize NativeWindow plugin.
+            auto width = static_cast<float>(rect.right - rect.left);
+            auto height = static_cast<float>(rect.bottom - rect.top);
             Babylon::NativeWindow::Initialize(env, hWnd, width, height);
-        });
 
-        // Initialize NativeEngine plugin.
-        Babylon::InitializeNativeEngine(*runtime, hWnd, width, height);
+            // Initialize NativeEngine plugin.
+            Babylon::InitializeNativeEngine(jsRuntime, hWnd, width, height);
 
-        // Initialize XMLHttpRequest plugin.
-        Babylon::InitializeXMLHttpRequest(*runtime, runtime->RootUrl());
+            // Initialize XMLHttpRequest plugin.
+            Babylon::InitializeXMLHttpRequest(jsRuntime, runtime->RootUrl());
 
-        inputBuffer = std::make_unique<InputManager::InputBuffer>(*runtime);
-        InputManager::Initialize(*runtime, *inputBuffer);
+            inputBuffer = std::make_unique<InputManager::InputBuffer>(jsRuntime);
+            InputManager::Initialize(jsRuntime, *inputBuffer);
 
-        Babylon::ScriptLoader loader{ *runtime, runtime->RootUrl() };
-        loader.Eval("document = {}", "");
-        loader.LoadScript(moduleRootUrl + "/Scripts/ammo.js");
-        loader.LoadScript(moduleRootUrl + "/Scripts/recast.js");
-        loader.LoadScript(moduleRootUrl + "/Scripts/babylon.max.js");
-        loader.LoadScript(moduleRootUrl + "/Scripts/babylon.glTF2FileLoader.js");
-        loader.LoadScript(moduleRootUrl + "/Scripts/babylonjs.materials.js");
+            Babylon::ScriptLoader loader{jsRuntime, runtime->RootUrl()};
+            loader.Eval("document = {}", "");
+            loader.LoadScript(moduleRootUrl + "/Scripts/ammo.js");
+            loader.LoadScript(moduleRootUrl + "/Scripts/recast.js");
+            loader.LoadScript(moduleRootUrl + "/Scripts/babylon.max.js");
+            loader.LoadScript(moduleRootUrl + "/Scripts/babylon.glTF2FileLoader.js");
+            loader.LoadScript(moduleRootUrl + "/Scripts/babylonjs.materials.js");
 
-        if (scripts.empty())
-        {
-            loader.LoadScript("Scripts/experience.js");
-        }
-        else
-        {
-            for (const auto& script : scripts)
+            if (scripts.empty())
             {
-                loader.LoadScript(GetUrlFromPath(script));
+                loader.LoadScript("Scripts/experience.js");
             }
+            else
+            {
+                for (const auto& script : scripts)
+                {
+                    loader.LoadScript(GetUrlFromPath(script));
+                }
 
-            loader.LoadScript(moduleRootUrl + "/Scripts/playground_runner.js");
-        }
+                loader.LoadScript(moduleRootUrl + "/Scripts/playground_runner.js");
+            }
+        });
     }
 
     void UpdateWindowSize(float width, float height)
     {
-        runtime->Dispatch([width, height](Napi::Env env)
-        {
+        runtime->Dispatch([width, height](Napi::Env env) {
             auto& window = Babylon::NativeWindow::GetFromJavaScript(env);
             window.Resize(static_cast<size_t>(width), static_cast<size_t>(height));
         });
@@ -149,9 +148,9 @@ namespace
 }
 
 int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
-                     _In_opt_ HINSTANCE hPrevInstance,
-                     _In_ LPWSTR    lpCmdLine,
-                     _In_ int       nCmdShow)
+    _In_opt_ HINSTANCE hPrevInstance,
+    _In_ LPWSTR lpCmdLine,
+    _In_ int nCmdShow)
 {
     UNREFERENCED_PARAMETER(hPrevInstance);
     UNREFERENCED_PARAMETER(lpCmdLine);
@@ -164,7 +163,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     MyRegisterClass(hInstance);
 
     // Perform application initialization:
-    if (!InitInstance (hInstance, nCmdShow))
+    if (!InitInstance(hInstance, nCmdShow))
     {
         return FALSE;
     }
@@ -183,7 +182,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
         }
     }
 
-    return (int) msg.wParam;
+    return (int)msg.wParam;
 }
 
 //
@@ -197,17 +196,17 @@ ATOM MyRegisterClass(HINSTANCE hInstance)
 
     wcex.cbSize = sizeof(WNDCLASSEX);
 
-    wcex.style          = CS_HREDRAW | CS_VREDRAW;
-    wcex.lpfnWndProc    = WndProc;
-    wcex.cbClsExtra     = 0;
-    wcex.cbWndExtra     = 0;
-    wcex.hInstance      = hInstance;
-    wcex.hIcon          = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_PLAYGROUNDWIN32));
-    wcex.hCursor        = LoadCursor(nullptr, IDC_ARROW);
-    wcex.hbrBackground  = (HBRUSH)(COLOR_WINDOW+1);
-    wcex.lpszMenuName   = MAKEINTRESOURCEW(IDC_PLAYGROUNDWIN32);
-    wcex.lpszClassName  = szWindowClass;
-    wcex.hIconSm        = LoadIcon(wcex.hInstance, MAKEINTRESOURCE(IDI_SMALL));
+    wcex.style = CS_HREDRAW | CS_VREDRAW;
+    wcex.lpfnWndProc = WndProc;
+    wcex.cbClsExtra = 0;
+    wcex.cbWndExtra = 0;
+    wcex.hInstance = hInstance;
+    wcex.hIcon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_PLAYGROUNDWIN32));
+    wcex.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+    wcex.lpszMenuName = MAKEINTRESOURCEW(IDC_PLAYGROUNDWIN32);
+    wcex.lpszClassName = szWindowClass;
+    wcex.hIconSm = LoadIcon(wcex.hInstance, MAKEINTRESOURCE(IDI_SMALL));
 
     return RegisterClassExW(&wcex);
 }
@@ -224,22 +223,22 @@ ATOM MyRegisterClass(HINSTANCE hInstance)
 //
 BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
 {
-   hInst = hInstance; // Store instance handle in our global variable
+    hInst = hInstance; // Store instance handle in our global variable
 
-   HWND hWnd = CreateWindowW(szWindowClass, szTitle, WS_OVERLAPPEDWINDOW,
-      CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, nullptr, nullptr, hInstance, nullptr);
+    HWND hWnd = CreateWindowW(szWindowClass, szTitle, WS_OVERLAPPEDWINDOW,
+        CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, nullptr, nullptr, hInstance, nullptr);
 
-   if (!hWnd)
-   {
-      return FALSE;
-   }
+    if (!hWnd)
+    {
+        return FALSE;
+    }
 
-   ShowWindow(hWnd, nCmdShow);
-   UpdateWindow(hWnd);
+    ShowWindow(hWnd, nCmdShow);
+    UpdateWindow(hWnd);
 
-   RefreshBabylon(hWnd);
+    RefreshBabylon(hWnd);
 
-   return TRUE;
+    return TRUE;
 }
 
 //
@@ -258,7 +257,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     {
         case WM_SYSCOMMAND:
         {
-            if ((wParam & 0xFFF0) == SC_MINIMIZE) 
+            if ((wParam & 0xFFF0) == SC_MINIMIZE)
             {
                 runtime->Suspend();
             }
@@ -275,14 +274,14 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
             // Parse the menu selections:
             switch (wmId)
             {
-            case IDM_ABOUT:
-                DialogBox(hInst, MAKEINTRESOURCE(IDD_ABOUTBOX), hWnd, About);
-                break;
-            case IDM_EXIT:
-                DestroyWindow(hWnd);
-                break;
-            default:
-                return DefWindowProc(hWnd, message, wParam, lParam);
+                case IDM_ABOUT:
+                    DialogBox(hInst, MAKEINTRESOURCE(IDD_ABOUTBOX), hWnd, About);
+                    break;
+                case IDM_EXIT:
+                    DestroyWindow(hWnd);
+                    break;
+                default:
+                    return DefWindowProc(hWnd, message, wParam, lParam);
             }
             break;
         }
@@ -295,7 +294,8 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         }
         case WM_SIZE:
         {
-            if (runtime != nullptr) {
+            if (runtime != nullptr)
+            {
                 float width = static_cast<float>(LOWORD(lParam));
                 float height = static_cast<float>(HIWORD(lParam));
                 UpdateWindowSize(width, height);
@@ -319,18 +319,27 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         }
         case WM_MOUSEMOVE:
         {
-            inputBuffer->SetPointerPosition(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
+            if (inputBuffer != nullptr)
+            {
+                inputBuffer->SetPointerPosition(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
+            }
             break;
         }
         case WM_LBUTTONDOWN:
         {
             SetCapture(hWnd);
-            inputBuffer->SetPointerDown(true);
+            if (inputBuffer != nullptr)
+            {
+                inputBuffer->SetPointerDown(true);
+            }
             break;
         }
         case WM_LBUTTONUP:
         {
-            inputBuffer->SetPointerDown(false);
+            if (inputBuffer != nullptr)
+            {
+                inputBuffer->SetPointerDown(false);
+            }
             ReleaseCapture();
             break;
         }
@@ -348,16 +357,16 @@ INT_PTR CALLBACK About(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
     UNREFERENCED_PARAMETER(lParam);
     switch (message)
     {
-    case WM_INITDIALOG:
-        return (INT_PTR)TRUE;
-
-    case WM_COMMAND:
-        if (LOWORD(wParam) == IDOK || LOWORD(wParam) == IDCANCEL)
-        {
-            EndDialog(hDlg, LOWORD(wParam));
+        case WM_INITDIALOG:
             return (INT_PTR)TRUE;
-        }
-        break;
+
+        case WM_COMMAND:
+            if (LOWORD(wParam) == IDOK || LOWORD(wParam) == IDCANCEL)
+            {
+                EndDialog(hDlg, LOWORD(wParam));
+                return (INT_PTR)TRUE;
+            }
+            break;
     }
     return (INT_PTR)FALSE;
 }

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -109,13 +109,13 @@ namespace
             Babylon::InitializeNativeEngine(jsRuntime, hWnd, width, height);
 
             // Initialize XMLHttpRequest plugin.
-            Babylon::InitializeXMLHttpRequest(jsRuntime, runtime->RootUrl());
+            Babylon::InitializeXMLHttpRequest(env, runtime->RootUrl());
 
             inputBuffer = std::make_unique<InputManager::InputBuffer>(jsRuntime);
             InputManager::Initialize(jsRuntime, *inputBuffer);
         });
 
-        Babylon::ScriptLoader loader{[](auto func) { runtime->Dispatch(std::move(func)); }, runtime->RootUrl()};
+        Babylon::ScriptLoader loader{*runtime, runtime->RootUrl()};
         loader.Eval("document = {}", "");
         loader.LoadScript(moduleRootUrl + "/Scripts/ammo.js");
         loader.LoadScript(moduleRootUrl + "/Scripts/recast.js");

--- a/Apps/Playground/iOS/LibNativeBridge.mm
+++ b/Apps/Playground/iOS/LibNativeBridge.mm
@@ -47,7 +47,7 @@ std::unique_ptr<InputManager::InputBuffer> inputBuffer{};
     
         Babylon::InitializeNativeEngine(env);
         
-        InitializeXMLHttpRequest(env, runtime->RootUrl());
+        InitializeXMLHttpRequest(env);
 
         auto& jsRuntime = Babylon::JsRuntime::GetFromJavaScript(env);
 

--- a/Apps/Playground/iOS/LibNativeBridge.mm
+++ b/Apps/Playground/iOS/LibNativeBridge.mm
@@ -40,17 +40,20 @@ std::unique_ptr<InputManager::InputBuffer> inputBuffer{};
     float width = inWidth;
     float height = inHeight;
     void* windowPtr = CALayerPtr;
+    Babylon::InitializeGraphics(windowPtr, width, height);
     runtime->Dispatch([windowPtr, width, height](Napi::Env env)
     {
         Babylon::NativeWindow::Initialize(env, windowPtr, width, height);
-    });
     
-    Babylon::InitializeNativeEngine(*runtime, windowPtr, width, height);
-    
-    InitializeXMLHttpRequest(*runtime);
+        Babylon::InitializeNativeEngine(env);
+        
+        InitializeXMLHttpRequest(env, runtime->RootUrl());
 
-    inputBuffer = std::make_unique<InputManager::InputBuffer>(*runtime);
-    InputManager::Initialize(*runtime, *inputBuffer);
+        auto& jsRuntime = Babylon::JsRuntime::GetFromJavaScript(env);
+
+        inputBuffer = std::make_unique<InputManager::InputBuffer>(jsRuntime);
+        InputManager::Initialize(jsRuntime, *inputBuffer);
+    });
     
     Babylon::ScriptLoader loader{ *runtime, runtime->RootUrl() };
     loader.Eval("document = {}", "");

--- a/Apps/Playground/macOS/ViewController.mm
+++ b/Apps/Playground/macOS/ViewController.mm
@@ -44,7 +44,7 @@ std::unique_ptr<InputManager::InputBuffer> inputBuffer{};
     
         Babylon::InitializeNativeEngine(env);
         
-        InitializeXMLHttpRequest(env, runtime->RootUrl());
+        InitializeXMLHttpRequest(env);
 
         auto& jsRuntime = Babylon::JsRuntime::GetFromJavaScript(env);
 

--- a/Apps/Playground/macOS/ViewController.mm
+++ b/Apps/Playground/macOS/ViewController.mm
@@ -36,18 +36,21 @@ std::unique_ptr<InputManager::InputBuffer> inputBuffer{};
     float height = size.height;
     NSWindow* nativeWindow = [[self view] window];
     void* windowPtr = (__bridge void*)nativeWindow;
+    Babylon::InitializeGraphics(windowPtr, width, height);
+
     runtime->Dispatch([windowPtr, width, height](Napi::Env env)
     {
         Babylon::NativeWindow::Initialize(env, windowPtr, width, height);
-    });
     
-    Babylon::InitializeNativeEngine(*runtime, windowPtr, width, height);
-    
-    // Initialize XMLHttpRequest plugin.
-    InitializeXMLHttpRequest(*runtime);
+        Babylon::InitializeNativeEngine(env);
+        
+        InitializeXMLHttpRequest(env, runtime->RootUrl());
 
-    inputBuffer = std::make_unique<InputManager::InputBuffer>(*runtime);
-    InputManager::Initialize(*runtime, *inputBuffer);
+        auto& jsRuntime = Babylon::JsRuntime::GetFromJavaScript(env);
+
+        inputBuffer = std::make_unique<InputManager::InputBuffer>(jsRuntime);
+        InputManager::Initialize(jsRuntime, *inputBuffer);
+    });
     
     Babylon::ScriptLoader loader{ *runtime, runtime->RootUrl() };
     loader.Eval("document = {}", "");

--- a/Apps/ValidationTests/Win32/App.cpp
+++ b/Apps/ValidationTests/Win32/App.cpp
@@ -81,7 +81,8 @@ namespace
             auto& jsRuntime = Babylon::JsRuntime::GetFromJavaScript(env);
 
             // Initialize NativeEngine plugin.
-            Babylon::InitializeNativeEngine(jsRuntime, hWnd, width, height);
+            Babylon::InitializeGraphics(hWnd, width, height);
+            Babylon::InitializeNativeEngine(env);
 
             // Initialize XMLHttpRequest plugin.
             Babylon::InitializeXMLHttpRequest(env, runtime->RootUrl());

--- a/Apps/ValidationTests/Win32/App.cpp
+++ b/Apps/ValidationTests/Win32/App.cpp
@@ -66,34 +66,30 @@ namespace
         runtime = std::make_unique<Babylon::AppRuntime>(GetUrlFromPath(GetModulePath().parent_path().parent_path()));
 
         // Initialize console plugin.
-        runtime->Dispatch([](Napi::Env env)
+        runtime->Dispatch([rect, hWnd](Napi::Env env)
         {
             Babylon::Console::CreateInstance(env, [](const char* message, auto)
             {
                 OutputDebugStringA(message);
             });
-        });
 
-        // Initialize NativeWindow plugin.
-        auto width = static_cast<float>(rect.right - rect.left);
-        auto height = static_cast<float>(rect.bottom - rect.top);
-        runtime->Dispatch([hWnd, width, height](Napi::Env env)
-        {
+            // Initialize NativeWindow plugin.
+            auto width = static_cast<float>(rect.right - rect.left);
+            auto height = static_cast<float>(rect.bottom - rect.top);
             Babylon::NativeWindow::Initialize(env, hWnd, width, height);
-        });
 
-        // Initialize NativeEngine plugin.
-        Babylon::InitializeNativeEngine(*runtime, hWnd, width, height);
+            auto& jsRuntime = Babylon::JsRuntime::GetFromJavaScript(env);
 
-        // Initialize XMLHttpRequest plugin.
-        Babylon::InitializeXMLHttpRequest(*runtime, runtime->RootUrl());
+            // Initialize NativeEngine plugin.
+            Babylon::InitializeNativeEngine(jsRuntime, hWnd, width, height);
 
-        runtime->Dispatch([hWnd](Napi::Env env)
-        {
+            // Initialize XMLHttpRequest plugin.
+            Babylon::InitializeXMLHttpRequest(env, runtime->RootUrl());
+
             Babylon::TestUtils::CreateInstance(env, hWnd);
         });
 
-        Babylon::ScriptLoader loader{ *runtime, runtime->RootUrl() };
+        Babylon::ScriptLoader loader{*runtime, runtime->RootUrl()};
         loader.LoadScript("Scripts/babylon.max.js");
         loader.LoadScript("Scripts/babylon.glTF2FileLoader.js");
         loader.LoadScript("Scripts/babylonjs.materials.js");

--- a/Core/AppRuntime/Include/Babylon/AppRuntime.h
+++ b/Core/AppRuntime/Include/Babylon/AppRuntime.h
@@ -9,7 +9,7 @@ namespace Babylon
 {
     class WorkQueue;
 
-    class AppRuntime final : public JsRuntime
+    class AppRuntime final
     {
     public:
         AppRuntime(std::string rootUrl);
@@ -23,20 +23,6 @@ namespace Babylon
         void Dispatch(std::function<void(Napi::Env)> callback);
 
     private:
-        // This secondary constructor exists to resolve a timing issue with the construction
-        // of the JsRuntime. Because JsRuntime's contract requires that its dispatch function
-        // be valid and safe at the moment its constructor is called, the AppRuntime's work
-        // queue (which powers the dispatch function) must exist before the JsRuntime
-        // constructor is called. However, because AppRuntime inherits from JsRuntime, by
-        // by default the base class must be initialized before the members of the inheriting
-        // class -- relevantly m_workQueue. In short, the work queue must exist before
-        // m_workQueue can be initialized. The solution to this is to create the work queue
-        // separately within a forwarding constructor, then have the JsRuntime's dispatcher
-        // function simply capture a reference directly to the underlying work queue. The
-        // unique_ptr containing the work queue can then be moved so that it is owned by
-        // m_workQueue.
-        AppRuntime(std::string, std::unique_ptr<WorkQueue>);
-
         // These three methods are the mechanism by which platform- and JavaScript-specific
         // code can be "injected" into the execution of the JavaScript thread. These three
         // functions are implemented in separate files, thus allowing implementations to be

--- a/Core/JsRuntime/Include/Babylon/JsRuntime.h
+++ b/Core/JsRuntime/Include/Babylon/JsRuntime.h
@@ -13,23 +13,21 @@ namespace Babylon
         static constexpr auto JS_NATIVE_NAME = "_native";
         using DispatchFunctionT = std::function<void(std::function<void(Napi::Env)>)>;
 
-        static void Initialize(Napi::Env, DispatchFunctionT);
-        static JsRuntime& GetFromJavaScript(Napi::Env);
-        void Dispatch(std::function<void(Napi::Env)>);
-
-    protected:
         // Note: It is the contract of JsRuntime that its dispatch function must be usable
         // at the moment of construction. JsRuntime cannot be built with dispatch function
         // that captures a refence to a not-yet-completed object that will be completed
         // later -- an instance of an inheriting type, for example. The dispatch function
         // must be safely callable as soon as it is passed to the JsRuntime constructor.
-        JsRuntime(DispatchFunctionT);
+        static JsRuntime& CreateForJavaScript(Napi::Env, DispatchFunctionT);
+        static JsRuntime& GetFromJavaScript(Napi::Env);
+        void Dispatch(std::function<void(Napi::Env)>);
+
+    protected:
         JsRuntime(const JsRuntime&) = delete;
         JsRuntime(JsRuntime&&) = delete;
 
     private:
-        using DeleterT = std::function<void(Napi::Env, JsRuntime*)>;
-        JsRuntime(DispatchFunctionT, DeleterT);
+        JsRuntime(Napi::Env, DispatchFunctionT);
 
         DispatchFunctionT m_dispatchFunction{};
         std::mutex m_mutex{};

--- a/Plugins/NativeEngine/Include/Babylon/NativeEngine.h
+++ b/Plugins/NativeEngine/Include/Babylon/NativeEngine.h
@@ -4,7 +4,9 @@
 
 namespace Babylon
 {
-    void InitializeNativeEngine(JsRuntime& runtime, void* windowPtr, size_t width, size_t height);
+    void InitializeGraphics(void* windowPtr, size_t width, size_t height);
 
-    void ReinitializeNativeEngine(JsRuntime& runtime, void* windowPtr, size_t width, size_t height);
+    void InitializeNativeEngine(Napi::Env env);
+
+    void ReinitializeNativeEngine(Napi::Env env, void* windowPtr, size_t width, size_t height);
 }

--- a/Plugins/NativeEngine/Include/Babylon/NativeEngine.h
+++ b/Plugins/NativeEngine/Include/Babylon/NativeEngine.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Babylon/JsRuntime.h>
+#include <napi/env.h>
 
 namespace Babylon
 {

--- a/Plugins/NativeEngine/Source/InitializeNativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/InitializeNativeEngine.cpp
@@ -9,37 +9,31 @@
 
 namespace Babylon
 {
-    void InitializeNativeEngine(JsRuntime& runtime, void* windowPtr, size_t width, size_t height)
+    void InitializeGraphics(void* windowPtr, size_t width, size_t height)
     {
-#if (ANDROID)
-        runtime.Dispatch([windowPtr, width, height](Napi::Env env) {
-            NativeEngine::InitializeWindow(windowPtr, width, height);
-        });
-#else
         NativeEngine::InitializeWindow(windowPtr, width, height);
-#endif
-        runtime.Dispatch([](Napi::Env env) {
-            NativeEngine::Initialize(env);
-#ifdef NATIVE_ENGINE_XR
-            InitializeNativeXr(env);
-#endif
-        });
     }
 
-    void ReinitializeNativeEngine(JsRuntime& runtime, void* windowPtr, size_t width, size_t height)
+    void InitializeNativeEngine(Napi::Env env)
     {
-        runtime.Dispatch([windowPtr, width, height](Napi::Env env) {
-            bgfx::PlatformData pd;
-            pd.ndt = nullptr;
-            pd.nwh = windowPtr;
-            pd.context = nullptr;
-            pd.backBuffer = nullptr;
-            pd.backBufferDS = nullptr;
-            bgfx::setPlatformData(pd);
-            bgfx::reset(width, height);
+        NativeEngine::Initialize(env);
+#ifdef NATIVE_ENGINE_XR
+        InitializeNativeXr(env);
+#endif
+    }
 
-            auto& window = NativeWindow::GetFromJavaScript(env);
-            window.Resize(width, height);
-        });
+    void ReinitializeNativeEngine(Napi::Env env, void* windowPtr, size_t width, size_t height)
+    {
+        bgfx::PlatformData pd;
+        pd.ndt = nullptr;
+        pd.nwh = windowPtr;
+        pd.context = nullptr;
+        pd.backBuffer = nullptr;
+        pd.backBufferDS = nullptr;
+        bgfx::setPlatformData(pd);
+        bgfx::reset(width, height);
+
+        auto& window = NativeWindow::GetFromJavaScript(env);
+        window.Resize(width, height);
     }
 }

--- a/Plugins/ScriptLoader/CMakeLists.txt
+++ b/Plugins/ScriptLoader/CMakeLists.txt
@@ -8,7 +8,7 @@ target_include_directories(ScriptLoader PRIVATE "Include/Babylon")
 target_include_directories(ScriptLoader INTERFACE "Include")
 
 target_link_to_dependencies(ScriptLoader
-    PUBLIC JsRuntime
+    PUBLIC napi
     PRIVATE arcana
     PRIVATE BabylonNativeUtils)
 

--- a/Plugins/ScriptLoader/Include/Babylon/ScriptLoader.h
+++ b/Plugins/ScriptLoader/Include/Babylon/ScriptLoader.h
@@ -12,7 +12,15 @@ namespace Babylon
     {
     public:
         using DispatchFunctionT = std::function<void(std::function<void(Napi::Env)>)>;
+
         ScriptLoader(DispatchFunctionT dispatchFunction, std::string rootUrl);
+        
+        template<typename T>
+        ScriptLoader(T& dispatcher, std::string rootUrl)
+            : ScriptLoader([&dispatcher](auto func) { dispatcher.Dispatch(std::move(func)); }, std::move(rootUrl))
+        {
+        }
+
         ~ScriptLoader();
 
         void LoadScript(std::string url);

--- a/Plugins/ScriptLoader/Include/Babylon/ScriptLoader.h
+++ b/Plugins/ScriptLoader/Include/Babylon/ScriptLoader.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Napi/env.h>
+#include <napi/env.h>
 
 #include <functional>
 #include <memory>

--- a/Plugins/ScriptLoader/Include/Babylon/ScriptLoader.h
+++ b/Plugins/ScriptLoader/Include/Babylon/ScriptLoader.h
@@ -17,7 +17,8 @@ namespace Babylon
         
         template<typename T>
         ScriptLoader(T& dispatcher, std::string rootUrl)
-            : ScriptLoader([&dispatcher](auto func) { dispatcher.Dispatch(std::move(func)); }, std::move(rootUrl))
+            : ScriptLoader([&dispatcher](auto func) { dispatcher.Dispatch(std::move(func)); }
+            , std::move(rootUrl))
         {
         }
 

--- a/Plugins/ScriptLoader/Include/Babylon/ScriptLoader.h
+++ b/Plugins/ScriptLoader/Include/Babylon/ScriptLoader.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <Babylon/JsRuntime.h>
+#include <Napi/env.h>
 
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -10,7 +11,8 @@ namespace Babylon
     class ScriptLoader
     {
     public:
-        ScriptLoader(JsRuntime&, std::string rootUrl);
+        using DispatchFunctionT = std::function<void(std::function<void(Napi::Env)>)>;
+        ScriptLoader(DispatchFunctionT dispatchFunction, std::string rootUrl);
         ~ScriptLoader();
 
         void LoadScript(std::string url);

--- a/Plugins/XMLHttpRequest/Include/Babylon/XMLHttpRequest.h
+++ b/Plugins/XMLHttpRequest/Include/Babylon/XMLHttpRequest.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <Babylon/JsRuntime.h>
+#include <Napi/env.h>
 
 #include <string>
 
 namespace Babylon
 {
-    void InitializeXMLHttpRequest(JsRuntime& runtime, std::string rootUrl);
+    void InitializeXMLHttpRequest(Napi::Env env, std::string rootUrl);
 }

--- a/Plugins/XMLHttpRequest/Include/Babylon/XMLHttpRequestApple.h
+++ b/Plugins/XMLHttpRequest/Include/Babylon/XMLHttpRequestApple.h
@@ -9,7 +9,7 @@
 typedef void (^ CompletionHandlerFunction)();
 typedef void (^ CompletionHandler)(CompletionHandlerFunction);
 
-void InitializeXMLHttpRequest(Babylon::JsRuntime& runtime);
+void InitializeXMLHttpRequest(Napi::Env);
 
 typedef NS_ENUM(NSUInteger , ReadyState) {
     XMLHttpRequestUNSENT =0,	// open()has not been called yet.

--- a/Plugins/XMLHttpRequest/Source/XMLHttpRequest.cpp
+++ b/Plugins/XMLHttpRequest/Source/XMLHttpRequest.cpp
@@ -12,11 +12,9 @@ namespace Babylon
         constexpr auto JS_ROOT_URL_NAME = "RootUrl";
     }
 
-    void InitializeXMLHttpRequest(JsRuntime& runtime, std::string rootUrl)
+    void InitializeXMLHttpRequest(Napi::Env env, std::string rootUrl)
     {
-        runtime.Dispatch([rootUrl = std::move(rootUrl)](Napi::Env env) {
-            XMLHttpRequest::Initialize(env, rootUrl.data());
-        });
+        XMLHttpRequest::Initialize(env, rootUrl.data());
     }
 
     void XMLHttpRequest::Initialize(Napi::Env env, const char* rootUrl)

--- a/Plugins/XMLHttpRequest/Source/XMLHttpRequestApple.mm
+++ b/Plugins/XMLHttpRequest/Source/XMLHttpRequestApple.mm
@@ -9,13 +9,11 @@ void bytesDeallocator(void* ptr, void* context)
     free(ptr);
 }
 
-void InitializeXMLHttpRequest(Babylon::JsRuntime& runtime)
+void InitializeXMLHttpRequest(Napi::Env env)
 {
-    runtime.Dispatch([&runtime](Napi::Env env)
-    {
-        JSGlobalContextRef globalContext = Napi::GetContext<JSGlobalContextRef>(env);
-        [[XMLHttpRequest new] extend:globalContext:&runtime];
-    });
+    auto& runtime = Babylon::JsRuntime::GetFromJavaScript(env);
+    JSGlobalContextRef globalContext = Napi::GetContext<JSGlobalContextRef>(env);
+    [[XMLHttpRequest new] extend:globalContext:&runtime];
 }
 
 @implementation XMLHttpRequest {


### PR DESCRIPTION
Following up on initialization paradigm conversation, removed inheritance relationship from between AppRuntime and JsRuntime and adapted several plugins to (at least loosely) follow the new paradigm of requiring initialization on the correct thread.