### PR TITLE
Adding calls to DeinitializeGraphics to Playground apps

### DIFF
--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -51,6 +51,7 @@ Java_BabylonNative_Wrapper_finishEngine(JNIEnv* env, jobject obj)
     loader.reset();
     inputBuffer.reset();
     runtime.reset();
+    Babylon::DeinitializeGraphics();
 }
 
 JNIEXPORT void JNICALL

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -162,9 +162,6 @@ concurrency::task<void> App::RestartRuntimeAsync(Windows::Foundation::Rect bound
         m_runtime = std::make_unique<Babylon::AppRuntime>(std::move(rootUrl));
     }
 
-    // Ensure this is properly uninitialized since it depends on state of the runtime.
-    m_inputBuffer.reset();
-
     // Create the console plugin.
     m_runtime->Dispatch([](Napi::Env env)
     {

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -112,6 +112,9 @@ void App::Run()
 // class is torn down while the app is in the foreground.
 void App::Uninitialize()
 {
+    m_inputBuffer.reset();
+    m_runtime.reset();
+    Babylon::DeinitializeGraphics();
 }
 
 // Application lifecycle event handlers.
@@ -135,8 +138,16 @@ void App::OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^
 
 concurrency::task<void> App::RestartRuntimeAsync(Windows::Foundation::Rect bounds)
 {
-    m_inputBuffer.reset();
-    m_runtime.reset();
+    if (m_inputBuffer)
+    {
+        m_inputBuffer.reset();
+    }
+
+    if (m_runtime)
+    {
+        m_runtime.reset();
+        Babylon::DeinitializeGraphics();
+    }
 
     std::string appUrl{ "file:///" + std::filesystem::current_path().generic_string() };
 

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -112,9 +112,16 @@ void App::Run()
 // class is torn down while the app is in the foreground.
 void App::Uninitialize()
 {
-    m_inputBuffer.reset();
-    m_runtime.reset();
-    Babylon::DeinitializeGraphics();
+    if (m_inputBuffer)
+    {
+        m_inputBuffer.reset();
+    }
+
+    if (m_runtime)
+    {
+        m_runtime.reset();
+        Babylon::DeinitializeGraphics();
+    }
 }
 
 // Application lifecycle event handlers.
@@ -138,16 +145,7 @@ void App::OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^
 
 concurrency::task<void> App::RestartRuntimeAsync(Windows::Foundation::Rect bounds)
 {
-    if (m_inputBuffer)
-    {
-        m_inputBuffer.reset();
-    }
-
-    if (m_runtime)
-    {
-        m_runtime.reset();
-        Babylon::DeinitializeGraphics();
-    }
+    Uninitialize();
 
     std::string appUrl{ "file:///" + std::filesystem::current_path().generic_string() };
 

--- a/Apps/Playground/macOS/ViewController.mm
+++ b/Apps/Playground/macOS/ViewController.mm
@@ -22,7 +22,6 @@ std::unique_ptr<InputManager::InputBuffer> inputBuffer{};
     [super viewDidAppear];
 
     // Create the AppRuntime
-    runtime.reset();
     {
         NSBundle *main = [NSBundle mainBundle];
         NSURL * resourceUrl = [main resourceURL];
@@ -60,6 +59,14 @@ std::unique_ptr<InputManager::InputBuffer> inputBuffer{};
     loader.LoadScript("babylon.glTF2FileLoader.js");
     loader.LoadScript("babylonjs.materials.js");
     loader.LoadScript("experience.js");
+}
+
+- (void)viewDidDisappear {
+    [super viewDidDisappear];
+
+    inputBuffer.reset();
+    runtime.reset();
+    Babylon::DeinitializeGraphics();
 }
 
 - (void)setRepresentedObject:(id)representedObject {

--- a/Apps/ValidationTests/Win32/App.cpp
+++ b/Apps/ValidationTests/Win32/App.cpp
@@ -63,6 +63,7 @@ namespace
         }
 
         runtime.reset();
+        Babylon::DeinitializeGraphics();
         runtime = std::make_unique<Babylon::AppRuntime>(GetUrlFromPath(GetModulePath().parent_path().parent_path()));
 
         // Initialize console plugin.
@@ -242,6 +243,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         case WM_DESTROY:
         {
             runtime.reset();
+            Babylon::DeinitializeGraphics();
             PostQuitMessage(0);
             break;
         }


### PR DESCRIPTION
I tried to add these calls in the right places, but it also seems like the existing deinitialization code was only partially done, so I tried to flesh it out where it seemed like it was missing as part of this change as well. I tested on Android, MacOS, Win32, and UWP. I haven't been able to get the iOS playground app to build or run yet.