### PR TITLE
Refresh and commandline support macos

### DIFF
--- a/Apps/Playground/macOS/Base.lproj/Main.storyboard
+++ b/Apps/Playground/macOS/Base.lproj/Main.storyboard
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14868"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -99,9 +98,9 @@
                                                 <action selector="saveDocumentAs:" target="Ady-hI-5gd" id="mDf-zr-I0C"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Revert to Saved" keyEquivalent="r" id="KaW-ft-85H">
+                                        <menuItem title="Refresh" keyEquivalent="r" id="KaW-ft-85H">
                                             <connections>
-                                                <action selector="revertDocumentToSaved:" target="Ady-hI-5gd" id="iJ3-Pv-kwq"/>
+                                                <action selector="refresh:" target="Ady-hI-5gd" id="26J-XE-53g"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>

--- a/Apps/Playground/macOS/ViewController.h
+++ b/Apps/Playground/macOS/ViewController.h
@@ -2,6 +2,6 @@
 
 @interface ViewController : NSViewController
 
-
+-(IBAction) refresh:(id)sender;
 @end
 

--- a/Apps/Playground/macOS/ViewController.mm
+++ b/Apps/Playground/macOS/ViewController.mm
@@ -18,8 +18,19 @@ std::unique_ptr<InputManager::InputBuffer> inputBuffer{};
     [super viewDidLoad];
 }
 
-- (void)viewDidAppear {
-    [super viewDidAppear];
+- (void)refreshBabylon {
+    // reset
+    runtime.reset();
+    inputBuffer.reset();
+
+    // parse command line arguments
+    NSArray *arguments = [[NSProcessInfo processInfo] arguments];
+    arguments = [arguments subarrayWithRange:NSMakeRange(1, arguments.count - 1)];
+    __block std::vector<std::string> scripts;
+    scripts.reserve([arguments count]);
+    [arguments enumerateObjectsUsingBlock:^(NSString * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        scripts.push_back([obj UTF8String]);
+    }];
 
     // Create the AppRuntime
     {
@@ -58,7 +69,26 @@ std::unique_ptr<InputManager::InputBuffer> inputBuffer{};
     loader.LoadScript("babylon.max.js");
     loader.LoadScript("babylon.glTF2FileLoader.js");
     loader.LoadScript("babylonjs.materials.js");
-    loader.LoadScript("experience.js");
+    
+    if (scripts.empty())
+    {
+        loader.LoadScript("experience.js");
+    }
+    else
+    {
+        for (const auto& script : scripts)
+        {
+            loader.LoadScript(script);
+        }
+
+        loader.LoadScript("playground_runner.js");
+    }
+}
+
+- (void)viewDidAppear {
+    [super viewDidAppear];
+    
+    [self refreshBabylon];
 }
 
 - (void)viewDidDisappear {
@@ -110,6 +140,11 @@ std::unique_ptr<InputManager::InputBuffer> inputBuffer{};
     {
         inputBuffer->SetPointerDown(false);
     }
+}
+
+-(IBAction) refresh:(id)sender
+{
+    [self refreshBabylon];
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ project. Build and run this app by pressing the green "Play" button or by pressi
 **Required Tools:** [Xcode 11](https://developer.apple.com/xcode/) or newer, 
 [Python 3.0](https://www.python.org/) or newer (required by dependencies)
 
+This has been tested on MacOS Catalina (10.15)
 For macOS development, CMake by default will generate a Makefile. It may be possible
 to build Babylon Native for macOS using this approach, but at present only the Xcode
 method is supported. To generate an Xcode project using CMake, you must specify the
@@ -202,6 +203,7 @@ the selected Babylon Native demo app.
 **Required Tools:** [Xcode 11](https://developer.apple.com/xcode/) or newer, 
 [Python 3.0](https://www.python.org/) or newer (required by dependencies)
 
+This has been tested on MacOS Catalina (10.15) and iOS 13.
 For macOS development, CMake by default will generate a Makefile. It may be possible
 to build Babylon Native for macOS using this approach, but at present only the Xcode
 method is supported. To generate an Xcode project using CMake, you must specify the
@@ -213,7 +215,7 @@ these capabilities are set to their correct state by the additional CMake variab
 the following command:
 
 ```
-cmake -G Xcode -DCMAKE_TOOLCHAIN_FILE=../Dependencies/ios-cmake/ios.toolchain.cmake -DPLATFORM=OS64COMBINED -DENABLE_ARC=0 -DDEPLOYMENT_TARGET=12 -DENABLE_GLSLANG_BINARIES=OFF -DSPIRV_CROSS_CLI=OFF
+cmake .. -G Xcode -DCMAKE_TOOLCHAIN_FILE=../Dependencies/ios-cmake/ios.toolchain.cmake -DPLATFORM=OS64COMBINED -DENABLE_ARC=0 -DDEPLOYMENT_TARGET=12 -DENABLE_GLSLANG_BINARIES=OFF -DSPIRV_CROSS_CLI=OFF
 ```
 
 CMake will generate a new `BabylonNative.xcodeproj` file in your working directory.
@@ -237,6 +239,7 @@ the selected Babylon Native demo app.
 **Required Tools:** 
 [Android Studio](https://developer.android.com/studio), [Nodejs](https://nodejs.org/en/download/)
 
+The minimal requirement target is Android 5.0 with an OpenGL ES 3.0 compatible GPU.
 Only building with AndroidStudio is supported. CMake is not used directly. Instead, 
 Gradle is used for building and CMake is automatically invocated for building the native part.
 An .apk that can be executed on your device or simulator is the output.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ project. Build and run this app by pressing the green "Play" button or by pressi
 **Required Tools:** [Xcode 11](https://developer.apple.com/xcode/) or newer, 
 [Python 3.0](https://www.python.org/) or newer (required by dependencies)
 
-This has been tested on MacOS Catalina (10.15)
+This has been tested on MacOS Catalina (10.15).
+
 For macOS development, CMake by default will generate a Makefile. It may be possible
 to build Babylon Native for macOS using this approach, but at present only the Xcode
 method is supported. To generate an Xcode project using CMake, you must specify the

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ the selected Babylon Native demo app.
 [Python 3.0](https://www.python.org/) or newer (required by dependencies)
 
 This has been tested on MacOS Catalina (10.15) and iOS 13.
+
 For macOS development, CMake by default will generate a Makefile. It may be possible
 to build Babylon Native for macOS using this approach, but at present only the Xcode
 method is supported. To generate an Xcode project using CMake, you must specify the

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ the selected Babylon Native demo app.
 [Android Studio](https://developer.android.com/studio), [Nodejs](https://nodejs.org/en/download/)
 
 The minimal requirement target is Android 5.0 with an OpenGL ES 3.0 compatible GPU.
+
 Only building with AndroidStudio is supported. CMake is not used directly. Instead, 
 Gradle is used for building and CMake is automatically invocated for building the native part.
 An .apk that can be executed on your device or simulator is the output.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ these capabilities are set to their correct state by the additional CMake variab
 the following command:
 
 ```
-cmake .. -G Xcode -DCMAKE_TOOLCHAIN_FILE=../Dependencies/ios-cmake/ios.toolchain.cmake -DPLATFORM=OS64COMBINED -DENABLE_ARC=0 -DDEPLOYMENT_TARGET=12 -DENABLE_GLSLANG_BINARIES=OFF -DSPIRV_CROSS_CLI=OFF
+cmake -G Xcode -DCMAKE_TOOLCHAIN_FILE=../Dependencies/ios-cmake/ios.toolchain.cmake -DPLATFORM=OS64COMBINED -DENABLE_ARC=0 -DDEPLOYMENT_TARGET=12 -DENABLE_GLSLANG_BINARIES=OFF -DSPIRV_CROSS_CLI=OFF ..
 ```
 
 CMake will generate a new `BabylonNative.xcodeproj` file in your working directory.


### PR DESCRIPTION
- CMD + R to refresh view (or via the File->refresh menu)
- command line arguments support (Product->scheme->edit scheme to edit command line arguments in Xcode)
- min requirements for ios/macos/android in readme

NB: .js files passed as command line arguments must point to files in content/resources of the application.

Tested with marbletower and default experience.js