### PR TITLE
Handle display orientation changes in XR (ARCore specifically)

### DIFF
--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
@@ -163,6 +163,11 @@ namespace android::content
         Context(jobject object);
 
         res::AssetManager getAssets() const;
+
+        template<typename ServiceT>
+        ServiceT getSystemService();
+
+        jobject getSystemService(const char* serviceName);
     };
 }
 
@@ -174,6 +179,26 @@ namespace android::content::res
         AssetManager(jobject object);
 
         operator AAssetManager*() const;
+    };
+}
+
+namespace android::view
+{
+    class Display : public java::lang::Object
+    {
+    public:
+        Display(jobject object);
+
+        int getRotation();
+    };
+
+    class WindowManager : public java::lang::Object
+    {
+    public:
+        static constexpr const char* ServiceName{"window"};
+        WindowManager(jobject object);
+
+        Display getDefaultDisplay();
     };
 }
 

--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
@@ -165,7 +165,10 @@ namespace android::content
         res::AssetManager getAssets() const;
 
         template<typename ServiceT>
-        ServiceT getSystemService();
+        ServiceT getSystemService()
+        {
+            return {getSystemService(ServiceT::ServiceName)};
+        };
 
         jobject getSystemService(const char* serviceName);
     };

--- a/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
+++ b/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
@@ -176,12 +176,6 @@ namespace android::content
         return {m_env->CallObjectMethod(m_object, m_env->GetMethodID(m_class, "getAssets", "()Landroid/content/res/AssetManager;"))};
     }
 
-    template<typename ServiceT>
-    ServiceT Context::getSystemService()
-    {
-        return {getSystemService(ServiceT::ServiceName)};
-    }
-
     jobject Context::getSystemService(const char* serviceName)
     {
         return m_env->CallObjectMethod(m_object, m_env->GetMethodID(m_class, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;"), m_env->NewStringUTF(serviceName));

--- a/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
+++ b/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
@@ -175,6 +175,17 @@ namespace android::content
     {
         return {m_env->CallObjectMethod(m_object, m_env->GetMethodID(m_class, "getAssets", "()Landroid/content/res/AssetManager;"))};
     }
+
+    template<typename ServiceT>
+    ServiceT Context::getSystemService()
+    {
+        return {getSystemService(ServiceT::ServiceName)};
+    }
+
+    jobject Context::getSystemService(const char* serviceName)
+    {
+        return m_env->CallObjectMethod(m_object, m_env->GetMethodID(m_class, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;"), m_env->NewStringUTF(serviceName));
+    }
 }
 
 namespace android::content::res
@@ -187,6 +198,29 @@ namespace android::content::res
     AssetManager::operator AAssetManager*() const
     {
         return AAssetManager_fromJava(m_env, m_object);
+    }
+}
+
+namespace android::view
+{
+    Display::Display(jobject object)
+            : Object("android/view/Display", object)
+    {
+    }
+
+    int Display::getRotation()
+    {
+        return m_env->CallIntMethod(m_object, m_env->GetMethodID(m_class, "getRotation", "()I"));
+    }
+
+    WindowManager::WindowManager(jobject object)
+        : Object("android/view/WindowManager", object)
+    {
+    }
+
+    Display WindowManager::getDefaultDisplay()
+    {
+        return {m_env->CallObjectMethod(m_object, m_env->GetMethodID(m_class, "getDefaultDisplay", "()Landroid/view/Display;"))};
     }
 }
 

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -43,41 +43,12 @@ namespace xr
 
         bool TryInitialize()
         {
-            // Perhaps call eglGetCurrentSurface to get the render surface *before* XR render loop starts and changes to rendering to an FBO?
             return true;
         }
     };
 
     namespace
     {
-        void log(const char* message)
-        {
-            __android_log_print(ANDROID_LOG_VERBOSE, __FILE__, "%s", message);
-        }
-
-        template<typename TTimeUnit>
-        class DiagnosticTimer final
-        {
-        public:
-            DiagnosticTimer()
-                : m_lastCheckpoint{std::chrono::high_resolution_clock::now()}
-            {
-            }
-
-            void LogCheckpoint(const char* message)
-            {
-                auto now = std::chrono::high_resolution_clock::now();
-                std::chrono::duration<double> duration = now - m_lastCheckpoint;
-                m_lastCheckpoint = now;
-                std::ostringstream fullMessage;
-                fullMessage << message << ": " << std::chrono::duration_cast<TTimeUnit>(duration).count();
-                log(fullMessage.str().c_str());
-            }
-
-        private:
-            std::chrono::high_resolution_clock::time_point m_lastCheckpoint;
-        };
-
         constexpr GLfloat VERTEX_POSITIONS[]{ -1.0f, -1.0f, +1.0f, -1.0f, -1.0f, +1.0f, +1.0f, +1.0f };
         constexpr size_t VERTEX_COUNT{ std::size(VERTEX_POSITIONS) / 2 };
 

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -314,11 +314,6 @@ namespace xr
             // Update the ArSession to get a new frame
             ArSession_update(session, frame);
 
-            // TODO: Probably move most of the logic from Session::Impl constructor and Frame constructor here, and then reduce access to most of the members of Session::Impl
-            // TODO: 4) Add a DrawFrame function that is called from ~Frame
-            //       5) Make a bunch of public stuff in Session::Impl private
-            // Update the display resources as needed (e.g. changes to render surface)
-
             ArCamera* camera{};
             ArFrame_acquireCamera(session, frame, &camera);
 
@@ -417,8 +412,8 @@ namespace xr
             {
                 // Transform the UVs for the vertex positions given the current display size
                 ArFrame_transformCoordinates2d(
-                        session, frame, AR_COORDINATES_2D_OPENGL_NORMALIZED_DEVICE_COORDINATES,
-                        VERTEX_COUNT, VERTEX_POSITIONS, AR_COORDINATES_2D_TEXTURE_NORMALIZED, CameraFrameUVs);
+                    session, frame, AR_COORDINATES_2D_OPENGL_NORMALIZED_DEVICE_COORDINATES,
+                    VERTEX_COUNT, VERTEX_POSITIONS, AR_COORDINATES_2D_TEXTURE_NORMALIZED, CameraFrameUVs);
             }
 
             ArCamera_release(camera);

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -347,9 +347,7 @@ namespace xr
             {
                 DestroyDisplayResources();
 
-                //auto windowManager_ = GetAppContext().getSystemService<android::view::WindowManager>();
-                android::view::WindowManager windowManager(GetAppContext().getSystemService(android::view::WindowManager::ServiceName));
-                int rotation = windowManager.getDefaultDisplay().getRotation();
+                int rotation = GetAppContext().getSystemService<android::view::WindowManager>().getDefaultDisplay().getRotation();
 
                 // Update the width and height of the display with ARCore (this is used to adjust the UVs for the camera texture so we can draw a portion of the camera frame that matches the size of the UI element displaying it)
                 ArSession_setDisplayGeometry(session, rotation, static_cast<int32_t>(width), static_cast<int32_t>(height));

--- a/Plugins/NativeEngine/Source/NativeXr.cpp
+++ b/Plugins/NativeEngine/Source/NativeXr.cpp
@@ -280,7 +280,7 @@ namespace Babylon
             auto colorTexPtr = reinterpret_cast<uintptr_t>(view.ColorTexturePointer);
 
             auto it = m_texturesToFrameBuffers.find(colorTexPtr);
-            if (it == m_texturesToFrameBuffers.end())
+            if (it == m_texturesToFrameBuffers.end() || it->second.get()->Width != view.ColorTextureSize.Width || it->second.get()->Height != view.ColorTextureSize.Height)
             {
                 assert(view.ColorTextureSize.Width == view.DepthTextureSize.Width);
                 assert(view.ColorTextureSize.Height == view.DepthTextureSize.Height);


### PR DESCRIPTION
This change is to handle display orientation changes for the ARCore-based XR support (as noted in #230). The primary changes are:
1. Creation of the textures moved from the constructor to GetNextFrame (it is done whenever the surface dimensions have changed (querying the surface dimensions is a ~12 microsecond operation, so I think it's ok to just check it every frame)).
1. Adding cleanup code to free the various resources (textures, shaders, etc.) that are allocated especially since some of these are now allocated every time the display orientation changes.
1. Exposing Android APIs to get the current display rotation through the JavaWrappers interfaces.
1. Moving around some more code to consolidate much of it to Session::Impl::GetNextFrame, and also moving the drawing code out of Frame::Impl::~Frame and into Session::Impl::DrawFrame for better encapsulation (Frame::Impl::~Frame still calls Session::Impl::DrawFrame).
1. Recreating frame buffers in NativeXR.cpp when the texture resolution changes.