### PR TITLE
Enable validation tests on CI for Win32

### DIFF
--- a/Apps/ValidationTests/Scripts/validation_native.js
+++ b/Apps/ValidationTests/Scripts/validation_native.js
@@ -3,7 +3,7 @@ var currentScene;
 var config;
 var justOnce;
 var threshold = 25;
-var errorRatio = 0;
+var errorRatio = 2.5;
 var saveResult = true;
 var testWidth = 600;
 var testHeight = 400;

--- a/Apps/ValidationTests/Scripts/validation_native.js
+++ b/Apps/ValidationTests/Scripts/validation_native.js
@@ -3,7 +3,7 @@ var currentScene;
 var config;
 var justOnce;
 var threshold = 25;
-var errorRatio = 2.5;
+var errorRatio = 0;
 var saveResult = true;
 var testWidth = 600;
 var testHeight = 400;

--- a/Apps/ValidationTests/Shared/TestUtils.h
+++ b/Apps/ValidationTests/Shared/TestUtils.h
@@ -15,10 +15,13 @@
 #include <functional>
 #include <sstream>
 #include <Babylon/JsRuntime.h>
+#include <atomic>
 
 namespace
 {
     std::filesystem::path GetModulePath();
+    std::atomic<bool> doExit{};
+    int errorCode{};
 }
 
 namespace Babylon

--- a/Apps/ValidationTests/Shared/TestUtils.h
+++ b/Apps/ValidationTests/Shared/TestUtils.h
@@ -64,14 +64,12 @@ namespace Babylon
         void Exit(const Napi::CallbackInfo& info)
         {
             const int32_t exitCode = info[0].As<Napi::Number>().Int32Value();
-#ifdef WIN32
             doExit = true;
             errorCode = exitCode;
+#ifdef WIN32
             PostMessageW((HWND)_nativeWindowPtr, WM_CLOSE, exitCode, 0);
 #elif __linux__
             Display* display = XOpenDisplay(NULL);
-            exitPending = true;
-            exitErrorCode = exitCode;
             XClientMessageEvent dummyEvent;
             memset(&dummyEvent, 0, sizeof(XClientMessageEvent));
             dummyEvent.type = ClientMessage;

--- a/Apps/ValidationTests/Win32/App.cpp
+++ b/Apps/ValidationTests/Win32/App.cpp
@@ -11,8 +11,6 @@
 #include <filesystem>
 #include <algorithm>
 
-volatile bool doExit = false;
-int errorCode{};
 #include <Shared/TestUtils.h>
 
 #include <Babylon/AppRuntime.h>

--- a/Apps/ValidationTests/Win32/App.cpp
+++ b/Apps/ValidationTests/Win32/App.cpp
@@ -29,7 +29,6 @@ HINSTANCE hInst;                                // current instance
 WCHAR szTitle[MAX_LOADSTRING];                  // The title bar text
 WCHAR szWindowClass[MAX_LOADSTRING];            // the main window class name
 std::unique_ptr<Babylon::AppRuntime> runtime{};
-bool _NoWindow{};                               // No window for CI
 
 // 600, 400 mandatory size for CI tests
 static const int TEST_WIDTH = 600;
@@ -142,17 +141,6 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 {
     UNREFERENCED_PARAMETER(hPrevInstance);
     UNREFERENCED_PARAMETER(lpCmdLine);
-
-    std::vector<std::string> args = GetCommandLineArguments();
-    if (std::find(args.begin(), args.end(), "-NoWindow") != args.end())
-    {
-        Initialize((HWND)1);
-        while (!doExit)
-        {
-        };
-        Uninitialize();
-        return errorCode;
-    }
 
     // Initialize global strings
     LoadStringW(hInstance, IDS_APP_TITLE, szTitle, MAX_LOADSTRING);

--- a/Apps/ValidationTests/Win32/App.cpp
+++ b/Apps/ValidationTests/Win32/App.cpp
@@ -11,7 +11,7 @@
 #include <filesystem>
 #include <algorithm>
 
-bool doExit = false;
+volatile bool doExit = false;
 int errorCode{};
 #include <Shared/TestUtils.h>
 

--- a/Apps/ValidationTests/X11/App.cpp
+++ b/Apps/ValidationTests/X11/App.cpp
@@ -169,7 +169,7 @@ int main(int _argc, const char* const* _argv)
             case ClientMessage:
                 if ( (Atom)event.xclient.data.l[0] == wmDeleteWindow)
                 {
-                    exitPending = true;
+                    doExit = true;
                 }
                 break;
             case ConfigureNotify:

--- a/Apps/ValidationTests/X11/App.cpp
+++ b/Apps/ValidationTests/X11/App.cpp
@@ -7,9 +7,6 @@
 #undef None
 #include <filesystem>
 
-bool exitPending{};
-int exitErrorCode{};
-
 #include <Shared/TestUtils.h>
 
 #include <Babylon/AppRuntime.h>
@@ -161,7 +158,7 @@ int main(int _argc, const char* const* _argv)
     UpdateWindowSize(width, height);
 
     
-    while (!exitPending)
+    while (!doExit)
     {
         XEvent event;
         XNextEvent(display, &event);
@@ -188,5 +185,5 @@ int main(int _argc, const char* const* _argv)
 
     XUnmapWindow(display, window);
     XDestroyWindow(display, window);
-    return exitErrorCode;
+    return errorCode;
 }

--- a/Polyfills/Window/Source/Window.cpp
+++ b/Polyfills/Window/Source/Window.cpp
@@ -26,11 +26,6 @@ namespace Babylon::Polyfills::Internal
         auto jsNative = global.Get(JsRuntime::JS_NATIVE_NAME).As<Napi::Object>();
         auto jsWindow = constructor.New({});
 
-        // Need a reference or It's destroyed when loading babylon.material.js
-        // TODO: Find why
-        napi_ref result;
-        napi_create_reference(env, jsWindow, 1, &result);
-        
         jsNative.Set(JS_WINDOW_NAME, jsWindow);
 
         if (global.Get(JS_SET_TIMEOUT_NAME).IsUndefined())

--- a/Polyfills/Window/Source/Window.cpp
+++ b/Polyfills/Window/Source/Window.cpp
@@ -26,6 +26,11 @@ namespace Babylon::Polyfills::Internal
         auto jsNative = global.Get(JsRuntime::JS_NATIVE_NAME).As<Napi::Object>();
         auto jsWindow = constructor.New({});
 
+        // Need a reference or It's destroyed when loading babylon.material.js
+        // TODO: Find why
+        napi_ref result;
+        napi_create_reference(env, jsWindow, 1, &result);
+
         jsNative.Set(JS_WINDOW_NAME, jsWindow);
 
         if (global.Get(JS_SET_TIMEOUT_NAME).IsUndefined())

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,6 +88,23 @@ jobs:
       maximumCpuCount: true
       configuration: 'Release'
     displayName: 'Build WIN32_x64'
+  - script: |
+      cd buildWin32_x64\Apps\ValidationTests
+      mkdir Results
+      mkdir Errors
+      cd Release
+      ValidationTests -NoWindow
+    displayName: 'Test on CI'
+  - task: PublishBuildArtifacts@1
+    inputs:
+      artifactName: 'Win32_x64 Rendered Pictures'
+      pathtoPublish: 'buildWin32_x64/Apps/ValidationTests/Results'
+    displayName: 'Publish Tests Win32_x64 Results'
+  - task: PublishBuildArtifacts@1
+    inputs:
+      artifactName: 'Win32_x64 Rendered Pictures with errors'
+      pathtoPublish: 'buildWin32_x64/Apps/ValidationTests/Errors'
+    displayName: 'Publish Error Win32_x64 Results'
     
 - job: win32_x86    
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ jobs:
       mkdir Results
       mkdir Errors
       cd Release
-      ValidationTests -NoWindow
+      ValidationTests
     displayName: 'Validation Tests'
   - task: PublishBuildArtifacts@1
     inputs:
@@ -129,7 +129,7 @@ jobs:
       mkdir Results
       mkdir Errors
       cd Release
-      ValidationTests -NoWindow
+      ValidationTests
     displayName: 'Validation Tests'
   - task: PublishBuildArtifacts@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,13 +86,13 @@ jobs:
     inputs:
       solution: 'buildWin32_x64/BabylonNative.sln'
       maximumCpuCount: true
-      configuration: 'Release'
+      configuration: 'Debug'
     displayName: 'Build WIN32_x64'
   - script: |
       cd buildWin32_x64\Apps\ValidationTests
       mkdir Results
       mkdir Errors
-      cd Release
+      cd Debug
       ValidationTests -NoWindow
     displayName: 'Test on CI'
   - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,13 +86,13 @@ jobs:
     inputs:
       solution: 'buildWin32_x64/BabylonNative.sln'
       maximumCpuCount: true
-      configuration: 'Debug'
+      configuration: 'Release'
     displayName: 'Build WIN32_x64'
   - script: |
       cd buildWin32_x64\Apps\ValidationTests
       mkdir Results
       mkdir Errors
-      cd Debug
+      cd Release
       ValidationTests -NoWindow
     displayName: 'Test on CI'
   - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,7 +102,8 @@ jobs:
       pathtoPublish: 'buildWin32_x64/Apps/ValidationTests/Results'
     displayName: 'Publish Tests Win32_x64 Results'
     
-- job: win32_x86    
+- job: win32_x86
+  timeoutInMinutes: 20 
   pool:
     vmImage: 'windows-latest'
 
@@ -123,6 +124,18 @@ jobs:
       maximumCpuCount: true
       configuration: 'Release'
     displayName: 'Build WIN32_x86'
+  - script: |
+      cd buildWin32_x86\Apps\ValidationTests
+      mkdir Results
+      mkdir Errors
+      cd Release
+      ValidationTests -NoWindow
+    displayName: 'Validation Tests'
+  - task: PublishBuildArtifacts@1
+    inputs:
+      artifactName: 'Win32_x86 Rendered Pictures'
+      pathtoPublish: 'buildWin32_x86/Apps/ValidationTests/Results'
+    displayName: 'Publish Tests Win32_x86 Results'
     
 - job: uwp_x64    
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,8 @@ jobs:
       useXcpretty: false
     displayName: 'Build iOS'
     
-- job: win32_x64    
+- job: win32_x64
+  timeoutInMinutes: 20
   pool:
     vmImage: 'windows-latest'
 
@@ -94,17 +95,12 @@ jobs:
       mkdir Errors
       cd Release
       ValidationTests -NoWindow
-    displayName: 'Test on CI'
+    displayName: 'Validation Tests'
   - task: PublishBuildArtifacts@1
     inputs:
       artifactName: 'Win32_x64 Rendered Pictures'
       pathtoPublish: 'buildWin32_x64/Apps/ValidationTests/Results'
     displayName: 'Publish Tests Win32_x64 Results'
-  - task: PublishBuildArtifacts@1
-    inputs:
-      artifactName: 'Win32_x64 Rendered Pictures with errors'
-      pathtoPublish: 'buildWin32_x64/Apps/ValidationTests/Errors'
-    displayName: 'Publish Error Win32_x64 Results'
     
 - job: win32_x86    
   pool:


### PR DESCRIPTION
Run the tests provided in config.json and fails the build when image difference threshold is reached.
I successfully failed it by setting threshold to 0.
