### PR TITLE
Add back NativeXR to Android Playground

### DIFF
--- a/Apps/Playground/Android/app/CMakeLists.txt
+++ b/Apps/Playground/Android/app/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(BabylonNativeJNI
         AndroidExtensions
         AppRuntime
         NativeEngine
+        NativeXr
         NativeWindow
         Console
         Window

--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -13,6 +13,7 @@
 #include <Babylon/ScriptLoader.h>
 #include <Babylon/Plugins/NativeEngine.h>
 #include <Babylon/Plugins/NativeWindow.h>
+#include <Babylon/Plugins/NativeXr.h>
 #include <Babylon/Polyfills/Console.h>
 #include <Babylon/Polyfills/Window.h>
 #include <Babylon/Polyfills/XMLHttpRequest.h>
@@ -85,6 +86,8 @@ extern "C"
 
                 Babylon::Plugins::NativeEngine::InitializeGraphics(window, width, height);
                 Babylon::Plugins::NativeEngine::Initialize(env);
+
+                Babylon::Plugins::NativeXr::Initialize(env);
 
                 Babylon::Polyfills::Window::Initialize(env);
                 Babylon::Polyfills::XMLHttpRequest::Initialize(env);


### PR DESCRIPTION
When NativeXR got factored out to its own plugin, it didn't get added to the Android Playground app. With this change I'm adding it back.