### PR TITLE
Add Activity related events and support pause/resume in ARCore XR

### DIFF
--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -142,6 +142,25 @@ extern "C"
     }
 
     JNIEXPORT void JNICALL
+    Java_BabylonNative_Wrapper_activityOnRequestPermissionsResult(JNIEnv* env, jclass clazz, jint requestCode, jobjectArray permissions, jintArray grantResults)
+    {
+        std::vector<std::string> nativePermissions{};
+        for (int i = 0; i < env->GetArrayLength(permissions); i++)
+        {
+            jstring permission = (jstring)env->GetObjectArrayElement(permissions, i);
+            nativePermissions.push_back({env->GetStringUTFChars(permission, nullptr)});
+            env->ReleaseStringUTFChars(permission, nullptr);
+        }
+
+        auto grantResultElements{env->GetIntArrayElements(grantResults, nullptr)};
+        auto grantResultElementCount = env->GetArrayLength(grantResults);
+        std::vector<int32_t> nativeGrantResults{grantResultElements, grantResultElements + grantResultElementCount};
+        env->ReleaseIntArrayElements(grantResults, grantResultElements, 0);
+
+        android::global::RequestPermissionsResult(requestCode, nativePermissions, nativeGrantResults);
+    }
+
+    JNIEXPORT void JNICALL
     Java_BabylonNative_Wrapper_loadScript(JNIEnv* env, jclass clazz, jstring path)
     {
         if (g_scriptLoader)

--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -124,6 +124,7 @@ extern "C"
     JNIEXPORT void JNICALL
     Java_BabylonNative_Wrapper_activityOnPause(JNIEnv* env, jclass clazz)
     {
+        android::global::Pause();
         if (g_runtime)
         {
             g_runtime->Suspend();
@@ -137,6 +138,7 @@ extern "C"
         {
             g_runtime->Resume();
         }
+        android::global::Resume();
     }
 
     JNIEXPORT void JNICALL

--- a/Apps/Playground/Android/app/src/main/java/BabylonNative/BabylonView.java
+++ b/Apps/Playground/Android/app/src/main/java/BabylonNative/BabylonView.java
@@ -39,6 +39,10 @@ public class BabylonView extends SurfaceView implements SurfaceHolder.Callback2,
         BabylonNative.Wrapper.activityOnResume();
     }
 
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] results) {
+        BabylonNative.Wrapper.activityOnRequestPermissionsResult(requestCode, permissions, results);
+    }
+
     /**
      * This method is part of the SurfaceHolder.Callback interface, and is
      * not normally called or subclassed by clients of BabylonView.

--- a/Apps/Playground/Android/app/src/main/java/BabylonNative/Wrapper.java
+++ b/Apps/Playground/Android/app/src/main/java/BabylonNative/Wrapper.java
@@ -21,6 +21,8 @@ public class Wrapper {
 
     public static native void activityOnResume();
 
+    public static native void activityOnRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults);
+
     public static native void setTouchInfo(float dx, float dy, boolean down);
 
     public static native void loadScript(String path);

--- a/Apps/Playground/Android/app/src/main/java/com/android/babylonnative/playground/PlaygroundActivity.java
+++ b/Apps/Playground/Android/app/src/main/java/com/android/babylonnative/playground/PlaygroundActivity.java
@@ -40,6 +40,11 @@ public class PlaygroundActivity extends Activity implements BabylonView.ViewDele
     }
 
     @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] results) {
+        mView.onRequestPermissionsResult(requestCode, permissions, results);
+    }
+
+    @Override
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
         if (hasFocus && mView.getVisibility() == View.GONE) {

--- a/Dependencies/AndroidExtensions/CMakeLists.txt
+++ b/Dependencies/AndroidExtensions/CMakeLists.txt
@@ -6,4 +6,7 @@ set(SOURCES
 
 add_library(AndroidExtensions ${SOURCES})
 
+target_link_to_dependencies(AndroidExtensions 
+    PUBLIC arcana)
+
 target_include_directories(AndroidExtensions PUBLIC "Include")

--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/Globals.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/Globals.h
@@ -12,7 +12,6 @@ namespace android::global
 
     android::content::Context GetAppContext();
 
-
     using AppStateChangedCallbackTicket = arcana::ticketed_collection<std::function<void()>>::ticket;
 
     void Pause();
@@ -20,4 +19,9 @@ namespace android::global
 
     void Resume();
     AppStateChangedCallbackTicket AddResumedCallback(std::function<void()>&&);
+
+    using RequestPermissionsResultCallbackTicket = arcana::ticketed_collection<std::function<void(int32_t, const std::vector<std::string>&, const std::vector<int32_t>&)>>::ticket;
+
+    void RequestPermissionsResult(int32_t, const std::vector<std::string>&, const std::vector<int32_t>&);
+    RequestPermissionsResultCallbackTicket AddRequestPermissionsResultCallback(std::function<void(int32_t, const std::vector<std::string>&, const std::vector<int32_t>&)>&&);
 }

--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/Globals.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/Globals.h
@@ -15,10 +15,10 @@ namespace android::global
     using AppStateChangedCallbackTicket = arcana::ticketed_collection<std::function<void()>>::ticket;
 
     void Pause();
-    AppStateChangedCallbackTicket AddPausedCallback(std::function<void()>&&);
+    AppStateChangedCallbackTicket AddPauseCallback(std::function<void()>&&);
 
     void Resume();
-    AppStateChangedCallbackTicket AddResumedCallback(std::function<void()>&&);
+    AppStateChangedCallbackTicket AddResumeCallback(std::function<void()>&&);
 
     using RequestPermissionsResultCallbackTicket = arcana::ticketed_collection<std::function<void(int32_t, const std::vector<std::string>&, const std::vector<int32_t>&)>>::ticket;
 

--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/Globals.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/Globals.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <jni.h>
+#include <arcana/containers/ticketed_collection.h>
 #include "JavaWrappers.h"
 
 namespace android::global
@@ -10,4 +11,13 @@ namespace android::global
     JNIEnv* GetEnvForCurrentThread();
 
     android::content::Context GetAppContext();
+
+
+    using AppStateChangedCallbackTicket = arcana::ticketed_collection<std::function<void()>>::ticket;
+
+    void Pause();
+    AppStateChangedCallbackTicket AddPausedCallback(std::function<void()>&&);
+
+    void Resume();
+    AppStateChangedCallbackTicket AddResumedCallback(std::function<void()>&&);
 }

--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/Globals.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/Globals.h
@@ -12,7 +12,8 @@ namespace android::global
 
     android::content::Context GetAppContext();
 
-    using AppStateChangedCallbackTicket = arcana::ticketed_collection<std::function<void()>>::ticket;
+    using AppStateChangedCallback = std::function<void()>;
+    using AppStateChangedCallbackTicket = arcana::ticketed_collection<AppStateChangedCallback>::ticket;
 
     void Pause();
     AppStateChangedCallbackTicket AddPauseCallback(std::function<void()>&&);
@@ -20,8 +21,9 @@ namespace android::global
     void Resume();
     AppStateChangedCallbackTicket AddResumeCallback(std::function<void()>&&);
 
-    using RequestPermissionsResultCallbackTicket = arcana::ticketed_collection<std::function<void(int32_t, const std::vector<std::string>&, const std::vector<int32_t>&)>>::ticket;
+    using RequestPermissionsResultCallback = std::function<void(int32_t, const std::vector<std::string>&, const std::vector<int32_t>&)>;
+    using RequestPermissionsResultCallbackTicket = arcana::ticketed_collection<RequestPermissionsResultCallback>::ticket;
 
     void RequestPermissionsResult(int32_t, const std::vector<std::string>&, const std::vector<int32_t>&);
-    RequestPermissionsResultCallbackTicket AddRequestPermissionsResultCallback(std::function<void(int32_t, const std::vector<std::string>&, const std::vector<int32_t>&)>&&);
+    RequestPermissionsResultCallbackTicket AddRequestPermissionsResultCallback(RequestPermissionsResultCallback&&);
 }

--- a/Dependencies/AndroidExtensions/Source/Globals.cpp
+++ b/Dependencies/AndroidExtensions/Source/Globals.cpp
@@ -47,8 +47,8 @@ namespace android::global
             arcana::ticketed_collection<Handler> m_handlers{};
         };
 
-        Event g_pausedEvent{};
-        Event g_resumedEvent{};
+        Event g_pauseEvent{};
+        Event g_resumeEvent{};
 
         Event<int32_t, const std::vector<std::string>&, const std::vector<int32_t>&> g_requestPermissionsResultEvent{};
     }
@@ -82,22 +82,22 @@ namespace android::global
 
     void Pause()
     {
-        g_pausedEvent.Fire();
+        g_pauseEvent.Fire();
     }
 
-    AppStateChangedCallbackTicket AddPausedCallback(std::function<void()>&& onPaused)
+    AppStateChangedCallbackTicket AddPauseCallback(std::function<void()>&& onPause)
     {
-        return g_pausedEvent.AddHandler(std::move(onPaused));
+        return g_pauseEvent.AddHandler(std::move(onPause));
     }
 
     void Resume()
     {
-        g_resumedEvent.Fire();
+        g_resumeEvent.Fire();
     }
 
-    AppStateChangedCallbackTicket AddResumedCallback(std::function<void()>&& onResumed)
+    AppStateChangedCallbackTicket AddResumeCallback(std::function<void()>&& onResume)
     {
-        return g_resumedEvent.AddHandler(std::move(onResumed));
+        return g_resumeEvent.AddHandler(std::move(onResume));
     }
 
     void RequestPermissionsResult(int32_t requestCode, const std::vector<std::string>& permissions, const std::vector<int32_t>& grantResults)

--- a/Dependencies/AndroidExtensions/Source/Globals.cpp
+++ b/Dependencies/AndroidExtensions/Source/Globals.cpp
@@ -8,7 +8,7 @@ namespace android::global
         JavaVM* g_javaVM{};
         jobject g_appContext{};
 
-        thread_local struct Env
+        thread_local struct Env final
         {
             ~Env()
             {
@@ -22,7 +22,7 @@ namespace android::global
         } g_env{};
 
         template<typename ... Args>
-        class Event
+        class Event final
         {
         public:
             using Handler = std::function<void(Args ...)>;

--- a/Dependencies/AndroidExtensions/Source/Globals.cpp
+++ b/Dependencies/AndroidExtensions/Source/Globals.cpp
@@ -43,12 +43,14 @@ namespace android::global
             }
 
         private:
-            std::mutex m_mutex;
+            std::mutex m_mutex{};
             arcana::ticketed_collection<Handler> m_handlers{};
         };
 
         Event g_pausedEvent{};
         Event g_resumedEvent{};
+
+        Event<int32_t, const std::vector<std::string>&, const std::vector<int32_t>&> g_requestPermissionsResultEvent{};
     }
 
     void Initialize(JavaVM* javaVM, jobject appContext)
@@ -96,5 +98,15 @@ namespace android::global
     AppStateChangedCallbackTicket AddResumedCallback(std::function<void()>&& onResumed)
     {
         return g_resumedEvent.AddHandler(std::move(onResumed));
+    }
+
+    void RequestPermissionsResult(int32_t requestCode, const std::vector<std::string>& permissions, const std::vector<int32_t>& grantResults)
+    {
+        g_requestPermissionsResultEvent.Fire(requestCode, permissions, grantResults);
+    }
+
+    RequestPermissionsResultCallbackTicket AddRequestPermissionsResultCallback(std::function<void(int32_t, const std::vector<std::string>&, const std::vector<int32_t>&)>&& onAddRequestPermissionsResult)
+    {
+        return g_requestPermissionsResultEvent.AddHandler(std::move(onAddRequestPermissionsResult));
     }
 }

--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -118,8 +118,6 @@ namespace xr
             Size GetWidthAndHeightForViewIndex(size_t viewIndex) const;
             void SetDepthsNearFar(float depthNear, float depthFar);
 
-            // TODO: Probably need pause/resume functionality for ARCore
-
         private:
             std::unique_ptr<Impl> m_impl{};
         };

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -218,6 +218,8 @@ namespace xr
 
         Impl(System::Impl& systemImpl, void* graphicsContext)
             : SystemImpl{ systemImpl }
+            , pausedTicket{AddPausedCallback([this]() { this->PauseSession(); }) }
+            , resumedTicket{ AddResumedCallback([this]() { this->ResumeSession(); }) }
         {
             // Note: graphicsContext is an EGLContext
 
@@ -458,7 +460,26 @@ namespace xr
         ArFrame* frame{};
         ArPose* pose{};
 
-        float CameraFrameUVs[VERTEX_COUNT * 2];
+        float CameraFrameUVs[VERTEX_COUNT * 2]{};
+
+        AppStateChangedCallbackTicket pausedTicket;
+        AppStateChangedCallbackTicket resumedTicket;
+
+        void PauseSession()
+        {
+            if (session)
+            {
+                ArSession_pause(session);
+            }
+        }
+
+        void ResumeSession()
+        {
+            if (session)
+            {
+                ArSession_resume(session);
+            }
+        }
 
         void DestroyDisplayResources()
         {

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -218,8 +218,8 @@ namespace xr
 
         Impl(System::Impl& systemImpl, void* graphicsContext)
             : SystemImpl{ systemImpl }
-            , pausedTicket{AddPausedCallback([this]() { this->PauseSession(); }) }
-            , resumedTicket{ AddResumedCallback([this]() { this->ResumeSession(); }) }
+            , pauseTicket{AddPauseCallback([this]() { this->PauseSession(); }) }
+            , resumeTicket{AddResumeCallback([this]() { this->ResumeSession(); }) }
         {
             // Note: graphicsContext is an EGLContext
 
@@ -462,8 +462,8 @@ namespace xr
 
         float CameraFrameUVs[VERTEX_COUNT * 2]{};
 
-        AppStateChangedCallbackTicket pausedTicket;
-        AppStateChangedCallbackTicket resumedTicket;
+        AppStateChangedCallbackTicket pauseTicket;
+        AppStateChangedCallbackTicket resumeTicket;
 
         void PauseSession()
         {


### PR DESCRIPTION
This change adds three "events" to the Android `globals`: Pause, Resume, and RequestPermissionsResult. The first two are currently being used to pause/resume the ARCore session, and address one of the items in #230. I added the third because it was very similar to code I was already writing and @Alex-MSFT will need it for the permissions request stuff he is working on. I added a helper `Event` class, which could be moved to arcana, but I'm not sure if it will be used in the long term or not based on the AppLifecycle Core component we've discussed potentially adding, so I could go either way (leave it or move it to arcana).