### PR TITLE
Move app context jobject lifetime management to Globals

### DIFF
--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -43,7 +43,7 @@ extern "C"
     }
 
     JNIEXPORT void JNICALL
-    Java_BabylonNative_Wrapper_surfaceCreated(JNIEnv* env, jclass clazz, jobject surface, jobject appContext)
+    Java_BabylonNative_Wrapper_surfaceCreated(JNIEnv* env, jclass clazz, jobject surface, jobject context)
     {
         if (!g_runtime)
         {
@@ -55,16 +55,13 @@ extern "C"
                 throw std::runtime_error("Failed to get Java VM");
             }
 
-            // TODO: This should be cleaned up via env->DeleteGlobalRef
-            auto globalAppContext = env->NewGlobalRef(appContext);
-
-            android::global::Initialize(javaVM, globalAppContext);
+            android::global::Initialize(javaVM, context);
 
             ANativeWindow* window = ANativeWindow_fromSurface(env, surface);
             int32_t width  = ANativeWindow_getWidth(window);
             int32_t height = ANativeWindow_getHeight(window);
 
-            g_runtime->Dispatch([javaVM, globalAppContext, window, width, height](Napi::Env env)
+            g_runtime->Dispatch([javaVM, window, width, height](Napi::Env env)
             {
                 Babylon::Polyfills::Console::Initialize(env, [](const char* message, Babylon::Polyfills::Console::LogLevel level)
                 {

--- a/Apps/Playground/Android/app/src/main/java/BabylonNative/Wrapper.java
+++ b/Apps/Playground/Android/app/src/main/java/BabylonNative/Wrapper.java
@@ -13,7 +13,7 @@ public class Wrapper {
 
     public static native void finishEngine();
 
-    public static native void surfaceCreated(Surface surface, Context appContext);
+    public static native void surfaceCreated(Surface surface, Context context);
 
     public static native void surfaceChanged(int width, int height, Surface surface);
 

--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
@@ -162,6 +162,8 @@ namespace android::content
     public:
         Context(jobject object);
 
+        Context getApplicationContext();
+
         res::AssetManager getAssets() const;
 
         template<typename ServiceT>

--- a/Dependencies/AndroidExtensions/Source/Globals.cpp
+++ b/Dependencies/AndroidExtensions/Source/Globals.cpp
@@ -55,10 +55,10 @@ namespace android::global
         RequestPermissionsResultEvent g_requestPermissionsResultEvent{};
     }
 
-    void Initialize(JavaVM* javaVM, jobject appContext)
+    void Initialize(JavaVM* javaVM, jobject context)
     {
         g_javaVM = javaVM;
-        g_appContext = appContext;
+        g_appContext = GetEnvForCurrentThread()->NewGlobalRef(android::content::Context{context}.getApplicationContext());
     }
 
     JNIEnv* GetEnvForCurrentThread()

--- a/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
+++ b/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
@@ -171,6 +171,11 @@ namespace android::content
     {
     }
 
+    Context Context::getApplicationContext()
+    {
+        return {m_env->CallObjectMethod(m_object, m_env->GetMethodID(m_class, "getApplicationContext", "()Landroid/content/Context;"))};
+    }
+
     res::AssetManager Context::getAssets() const
     {
         return {m_env->CallObjectMethod(m_object, m_env->GetMethodID(m_class, "getAssets", "()Landroid/content/res/AssetManager;"))};


### PR DESCRIPTION
This change makes it the responsibility of `Globals` to manage the lifetime of the `jobject` referring to the app context. With the current implementation, it does this by first getting the application context from an arbitrary context, and creating a global ref from this jobject. The application context itself has the lifetime of the application, so in this case Globals just never cleans up this jobject (it will always exist, and reference an always existing application context). 