### PR TITLE
Removed Window polyfills added ref

### DIFF
--- a/Polyfills/Window/Source/Window.cpp
+++ b/Polyfills/Window/Source/Window.cpp
@@ -26,11 +26,6 @@ namespace Babylon::Polyfills::Internal
         auto jsNative = global.Get(JsRuntime::JS_NATIVE_NAME).As<Napi::Object>();
         auto jsWindow = constructor.New({});
 
-        // Need a reference or It's destroyed when loading babylon.material.js
-        // TODO: Find why
-        napi_ref result;
-        napi_create_reference(env, jsWindow, 1, &result);
-
         jsNative.Set(JS_WINDOW_NAME, jsWindow);
 
         if (global.Get(JS_SET_TIMEOUT_NAME).IsUndefined())


### PR DESCRIPTION
The ref issue with Window Polyfills is still present for 32bits ValidationTests on the CI.
I tried locally and it works. Can it be a bug with Chakra in 32bits mode?
