### PR TITLE
Update device input system to match the latest contract on the Babylon.js side

### DIFF
--- a/Plugins/NativeInput/Source/DeviceInputSystem.cpp
+++ b/Plugins/NativeInput/Source/DeviceInputSystem.cpp
@@ -26,18 +26,16 @@ namespace Babylon::Plugins
     NativeInput::Impl::DeviceInputSystem::DeviceInputSystem(const Napi::CallbackInfo& info)
         : Napi::ObjectWrap<DeviceInputSystem>{info}
         , m_nativeInput{*NativeInput::GetFromJavaScript(info.Env()).m_impl}
-        , m_deviceConnectedTicket{m_nativeInput.AddDeviceConnectedCallback([this](const std::string& deviceId) {
+        , m_deviceConnectedTicket{m_nativeInput.AddDeviceConnectedCallback([this](DeviceType deviceType, int32_t deviceSlot) {
             if (!m_onDeviceConnected.IsEmpty())
             {
-                Napi::Value napiDeviceId = Napi::String::New(Env(), deviceId);
-                m_onDeviceConnected({napiDeviceId});
+                m_onDeviceConnected({Napi::Value::From(Env(), static_cast<uint32_t>(deviceType)), Napi::Value::From(Env(), deviceSlot)});
             }
         })}
-        , m_deviceDisconnectedTicket{m_nativeInput.AddDeviceDisconnectedCallback([this](const std::string& deviceId) {
+        , m_deviceDisconnectedTicket{m_nativeInput.AddDeviceDisconnectedCallback([this](DeviceType deviceType, int32_t deviceSlot) {
             if (!m_onDeviceDisconnected.IsEmpty())
             {
-                Napi::Value napiDeviceId = Napi::String::New(Env(), deviceId);
-                m_onDeviceDisconnected({napiDeviceId});
+                m_onDeviceDisconnected({Napi::Value::From(Env(), static_cast<uint32_t>(deviceType)), Napi::Value::From(Env(), deviceSlot)});
             }
         })}
     {
@@ -65,11 +63,12 @@ namespace Babylon::Plugins
 
     Napi::Value NativeInput::Impl::DeviceInputSystem::PollInput(const Napi::CallbackInfo& info)
     {
-        std::string deviceName = info[0].As<Napi::String>().Utf8Value();
-        uint32_t inputIndex = info[1].As<Napi::Number>().Uint32Value();
+        uint32_t deviceType = info[0].As<Napi::Number>().Uint32Value();
+        uint32_t deviceSlot = info[1].As<Napi::Number>().Uint32Value();
+        uint32_t inputIndex = info[2].As<Napi::Number>().Uint32Value();
         try
         {
-            std::optional<int32_t> inputValue = m_nativeInput.PollInput(deviceName, inputIndex);
+            std::optional<int32_t> inputValue = m_nativeInput.PollInput(static_cast<DeviceType>(deviceType), deviceSlot, inputIndex);
             return inputValue ? Napi::Value::From(Env(), *inputValue) : Env().Null();
         }
         catch (const std::runtime_error& exception)

--- a/Plugins/NativeInput/Source/DeviceInputSystem.cpp
+++ b/Plugins/NativeInput/Source/DeviceInputSystem.cpp
@@ -102,9 +102,7 @@ namespace Babylon::Plugins
         }
         catch (const std::runtime_error& exception)
         {
-            return Napi::Value::From(Env(), -1);
-            // TODO: Re-enable this when exceptions are supported in Napi JSC
-            //throw Napi::Error::New(Env(), exception.what());
+            throw Napi::Error::New(Env(), exception.what());
         }
     }
 }

--- a/Plugins/NativeInput/Source/DeviceInputSystem.h
+++ b/Plugins/NativeInput/Source/DeviceInputSystem.h
@@ -18,12 +18,16 @@ namespace Babylon::Plugins
         void SetOnDeviceConnected(const Napi::CallbackInfo& info, const Napi::Value& value);
         Napi::Value GetOnDeviceDisconnected(const Napi::CallbackInfo& info);
         void SetOnDeviceDisconnected(const Napi::CallbackInfo& info, const Napi::Value& value);
+        Napi::Value GetOnInputChanged(const Napi::CallbackInfo& info);
+        void SetOnInputChanged(const Napi::CallbackInfo& info, const Napi::Value& value);
         Napi::Value PollInput(const Napi::CallbackInfo& info);
 
         NativeInput::Impl& m_nativeInput;
         Napi::FunctionReference m_onDeviceConnected;
         Napi::FunctionReference m_onDeviceDisconnected;
+        Napi::FunctionReference m_onInputChanged;
         NativeInput::Impl::DeviceStatusChangedCallbackTicket m_deviceConnectedTicket;
         NativeInput::Impl::DeviceStatusChangedCallbackTicket m_deviceDisconnectedTicket;
+        NativeInput::Impl::InputStateChangedCallbackTicket m_InputChangedTicket;
     };
 }

--- a/Plugins/NativeInput/Source/NativeInput.cpp
+++ b/Plugins/NativeInput/Source/NativeInput.cpp
@@ -17,13 +17,6 @@ namespace Babylon::Plugins
         constexpr uint32_t POINTER_Y_INPUT_INDEX{1};
         constexpr uint32_t POINTER_BUTTON_BASE_INDEX{2};
 
-        std::string GetPointerDeviceId(uint32_t pointerId)
-        {
-            std::ostringstream deviceId;
-            deviceId << POINTER_BASE_DEVICE_ID << "-" << pointerId;
-            return deviceId.str();
-        }
-
         constexpr uint32_t GetPointerButtonInputIndex(uint32_t buttonIndex)
         {
             return POINTER_BUTTON_BASE_INDEX + buttonIndex;
@@ -72,9 +65,8 @@ namespace Babylon::Plugins
     void NativeInput::Impl::PointerDown(uint32_t pointerId, uint32_t buttonIndex, uint32_t x, uint32_t y)
     {
         m_runtimeScheduler([pointerId, buttonIndex, x, y, this]() {
-            const std::string deviceId{GetPointerDeviceId(pointerId)};
             const uint32_t inputIndex{GetPointerButtonInputIndex(buttonIndex)};
-            std::vector<int>& deviceInputs{GetOrCreateInputMap(deviceId, { inputIndex, POINTER_X_INPUT_INDEX, POINTER_Y_INPUT_INDEX })};
+            std::vector<int>& deviceInputs{GetOrCreateInputMap(DeviceType::Touch, pointerId, { inputIndex, POINTER_X_INPUT_INDEX, POINTER_Y_INPUT_INDEX })};
             deviceInputs[inputIndex] = 1;
             deviceInputs[POINTER_X_INPUT_INDEX] = x;
             deviceInputs[POINTER_Y_INPUT_INDEX] = y;
@@ -84,9 +76,8 @@ namespace Babylon::Plugins
     void NativeInput::Impl::PointerUp(uint32_t pointerId, uint32_t buttonIndex, uint32_t x, uint32_t y)
     {
         m_runtimeScheduler([pointerId, buttonIndex, x, y, this]() {
-            const std::string deviceId{GetPointerDeviceId(pointerId)};
             const uint32_t inputIndex{GetPointerButtonInputIndex(buttonIndex)};
-            std::vector<int>& deviceInputs{GetOrCreateInputMap(deviceId, { inputIndex, POINTER_X_INPUT_INDEX, POINTER_Y_INPUT_INDEX })};
+            std::vector<int>& deviceInputs{GetOrCreateInputMap(DeviceType::Touch, pointerId, { inputIndex, POINTER_X_INPUT_INDEX, POINTER_Y_INPUT_INDEX })};
             deviceInputs[inputIndex] = 0;
             deviceInputs[POINTER_X_INPUT_INDEX] = x;
             deviceInputs[POINTER_Y_INPUT_INDEX] = y;
@@ -99,15 +90,14 @@ namespace Babylon::Plugins
                 }
             }
 
-            RemoveInputMap(deviceId);
+            RemoveInputMap(DeviceType::Touch, pointerId);
         });
     }
 
     void NativeInput::Impl::PointerMove(uint32_t pointerId, uint32_t x, uint32_t y)
     {
         m_runtimeScheduler([pointerId, x, y, this]() {
-            const std::string deviceId{GetPointerDeviceId(pointerId)};
-            std::vector<int>& deviceInputs{GetOrCreateInputMap(deviceId, { POINTER_X_INPUT_INDEX, POINTER_Y_INPUT_INDEX })};
+            std::vector<int>& deviceInputs{GetOrCreateInputMap(DeviceType::Touch, pointerId, { POINTER_X_INPUT_INDEX, POINTER_Y_INPUT_INDEX })};
             deviceInputs[POINTER_X_INPUT_INDEX] = x;
             deviceInputs[POINTER_Y_INPUT_INDEX] = y;
         });
@@ -123,13 +113,13 @@ namespace Babylon::Plugins
         return m_deviceDisconnectedCallbacks.insert(std::move(callback));
     }
 
-    std::optional<int32_t> NativeInput::Impl::PollInput(const std::string& deviceName, uint32_t inputIndex)
+    std::optional<int32_t> NativeInput::Impl::PollInput(DeviceType deviceType, int32_t deviceSlot, uint32_t inputIndex)
     {
-        auto it = m_inputs.find(deviceName);
+        auto it = m_inputs.find({deviceType, deviceSlot});
         if (it == m_inputs.end())
         {
             std::ostringstream message;
-            message << "Unable to find device " + deviceName;
+            message << "Unable to find device of type " << static_cast<uint32_t>(deviceType) << " with slot " << deviceSlot;
             throw std::runtime_error{ message.str() };
         }
 
@@ -137,7 +127,7 @@ namespace Babylon::Plugins
         if (inputIndex >= device.size())
         {
             std::ostringstream message;
-            message << "Unable to find " << inputIndex << " on device " << deviceName;
+            message << "Unable to find " << inputIndex << " on device of type " << static_cast<uint32_t>(deviceType) << " with slot " << deviceSlot;
             throw std::runtime_error{ message.str() };
         }
 
@@ -152,18 +142,18 @@ namespace Babylon::Plugins
         }
     }
 
-    std::vector<int32_t>& NativeInput::Impl::GetOrCreateInputMap(const std::string& deviceId, const std::vector<uint32_t>& inputIndices)
+    std::vector<int32_t>& NativeInput::Impl::GetOrCreateInputMap(DeviceType deviceType, int32_t deviceSlot, const std::vector<uint32_t>& inputIndices)
     {
         uint32_t inputIndex = *std::max_element(inputIndices.begin(), inputIndices.end());
 
         auto previousSize = m_inputs.size();
-        std::vector<int32_t>& deviceInputs{m_inputs[deviceId]};
+        std::vector<int32_t>& deviceInputs{m_inputs[{deviceType, deviceSlot}]};
         auto newSize = m_inputs.size();
 
         if (newSize != previousSize)
         {
-            m_deviceConnectedCallbacks.apply_to_all([deviceId](auto& callback) {
-                callback(deviceId);
+            m_deviceConnectedCallbacks.apply_to_all([deviceType, deviceSlot](auto& callback) {
+                callback(deviceType, deviceSlot);
             });
         }
 
@@ -172,12 +162,12 @@ namespace Babylon::Plugins
         return deviceInputs;
     }
 
-    void NativeInput::Impl::RemoveInputMap(const std::string& deviceId)
+    void NativeInput::Impl::RemoveInputMap(DeviceType deviceType, int32_t deviceSlot)
     {
-        if (m_inputs.erase(deviceId))
+        if (m_inputs.erase({deviceType, deviceSlot}))
         {
-            m_deviceDisconnectedCallbacks.apply_to_all([deviceId](auto& callback){
-               callback(deviceId);
+            m_deviceDisconnectedCallbacks.apply_to_all([deviceType, deviceSlot](auto& callback){
+                callback(deviceType, deviceSlot);
             });
         }
     }

--- a/Plugins/NativeInput/Source/NativeInput.h
+++ b/Plugins/NativeInput/Source/NativeInput.h
@@ -9,10 +9,21 @@
 
 namespace Babylon::Plugins
 {
-    class NativeInput::Impl
+    class NativeInput::Impl final
     {
     public:
-        using DeviceStatusChangedCallback = std::function<void(const std::string&)>;
+        enum class DeviceType
+        {
+            Generic = 0,
+            Keyboard = 1,
+            Mouse = 2,
+            Touch = 3,
+            DualShock = 4,
+            Xbox = 5,
+            Switch = 6,
+        };
+
+        using DeviceStatusChangedCallback = std::function<void(DeviceType deviceType, int32_t deviceSlot)>;
         using DeviceStatusChangedCallbackTicket = arcana::weak_table<DeviceStatusChangedCallback>::ticket;
 
         Impl(Napi::Env);
@@ -23,14 +34,24 @@ namespace Babylon::Plugins
 
         DeviceStatusChangedCallbackTicket AddDeviceConnectedCallback(DeviceStatusChangedCallback&& callback);
         DeviceStatusChangedCallbackTicket AddDeviceDisconnectedCallback(DeviceStatusChangedCallback&& callback);
-        std::optional<int32_t> PollInput(const std::string& deviceName, uint32_t inputIndex);
+        std::optional<int32_t> PollInput(DeviceType deviceType, int32_t deviceSlot, uint32_t inputIndex);
 
     private:
-        std::vector<int32_t>& GetOrCreateInputMap(const std::string& deviceId, const std::vector<uint32_t>& inputIndices);
-        void RemoveInputMap(const std::string& deviceId);
+        using InputMapKey = std::pair<DeviceType, int32_t>;
+
+        struct InputMapKeyHash
+        {
+            size_t operator()(const InputMapKey& inputMapKey) const
+            {
+                return std::hash<uint64_t>{}((static_cast<uint64_t>(inputMapKey.first) << (sizeof(uint32_t) * 8)) + static_cast<uint32_t>(inputMapKey.second));
+            }
+        };
+
+        std::vector<int32_t>& GetOrCreateInputMap(DeviceType deviceType, int32_t deviceSlot, const std::vector<uint32_t>& inputIndices);
+        void RemoveInputMap(DeviceType deviceType, int32_t deviceSlot);
 
         JsRuntimeScheduler m_runtimeScheduler;
-        std::unordered_map<std::string, std::vector<int32_t>> m_inputs{};
+        std::unordered_map<InputMapKey, std::vector<int32_t>, InputMapKeyHash> m_inputs{};
         arcana::weak_table<DeviceStatusChangedCallback> m_deviceConnectedCallbacks{};
         arcana::weak_table<DeviceStatusChangedCallback> m_deviceDisconnectedCallbacks{};
 


### PR DESCRIPTION
With this change the native contract for `DeviceInputSystem` matches the latest JS contract for `DeviceInputSystem`. The notable changes are:
- Devices are now identified by the DeviceType/DeviceSlot pair (rather than a string, e.g. "Pointer-0").
- There is now an event that fires whenever any input state changes.

Note that this still doesn't work in the sense of "overriding" the JS class. It seems it is not enough to just define a class with the same name and try to put it in the global scope. So as is, this class can be used/tested in the React Native repo by just not importing the JS `DeviceInputSystem` (in which case the native provides the implementation), but as soon as you import the JS version, then the native one does not replace the JS one. I need to think more about how to handle this, and I'll address it in a different change.

FYI @polygonalsun.