### PR TITLE
[ARCore] Clear color/depth texture each frame, and explicitly present to the display

### DIFF
--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -483,6 +483,8 @@ namespace xr
                 glDrawArrays(GL_TRIANGLE_STRIP, 0, VERTEX_COUNT);
 
                 // Present to the screen
+                // NOTE: For a yet to be determined reason, bgfx is also doing an eglSwapBuffers when running in the regular Android Babylon Native Playground playground app.
+                //       The "double" eglSwapBuffers causes rendering issues, so until we figure out this issue, comment out this line while testing in the regular playground app.
                 eglSwapBuffers(eglGetCurrentDisplay(), eglGetCurrentSurface(EGL_DRAW));
 
                 glUseProgram(0);

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -204,6 +204,14 @@ namespace xr
                 glBlendFunc(blendFuncSFactor, blendFuncTFactor);
                 return gsl::finally([blendFuncSFactor, previousBlendFuncTFactor]() { glBlendFunc(blendFuncSFactor, static_cast<GLenum>(previousBlendFuncTFactor)); });
             }
+
+            auto ClearColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)
+            {
+                GLfloat previousClearColor[4];
+                glGetFloatv(GL_COLOR_CLEAR_VALUE, previousClearColor);
+                glClearColor(red, green, blue, alpha);
+                return gsl::finally([red = previousClearColor[0], green = previousClearColor[1], blue = previousClearColor[2], alpha = previousClearColor[3]]() { glClearColor(red, green, blue, alpha); });
+            }
         }
     }
 
@@ -246,6 +254,9 @@ namespace xr
                 }
             }
 
+            // Create a frame buffer used for clearing the color texture
+            glGenFramebuffers(1, &clearFrameBufferId);
+
             // Create the ARCore ArFrame (this gets reused each time we query for the latest frame)
             ArFrame_create(session, &frame);
 
@@ -285,6 +296,7 @@ namespace xr
 
             glDeleteTextures(1, &cameraTextureId);
             glDeleteProgram(shaderProgramId);
+            glDeleteFramebuffers(1, &clearFrameBufferId);
 
             DestroyDisplayResources();
         }
@@ -362,6 +374,19 @@ namespace xr
                     ActiveFrameViews[0].DepthTextureFormat = TextureFormat::D24S8;
                     ActiveFrameViews[0].DepthTextureSize = {width, height};
                 }
+
+                // Bind the color and depth texture to the clear color frame buffer
+                auto bindFrameBufferTransaction = GLTransactions::BindFrameBuffer(clearFrameBufferId);
+                glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, static_cast<GLuint>(reinterpret_cast<uintptr_t>(ActiveFrameViews[0].ColorTexturePointer)), 0);
+                glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, static_cast<GLuint>(reinterpret_cast<uintptr_t>(ActiveFrameViews[0].DepthTexturePointer)), 0);
+            }
+            else
+            {
+                // Clear the color and depth texture
+                // Whether or not to clear is an implementation detail - OpenXR (for example) provides a color texture that is already filled with the camera texture, so the common XR layer should not assume a clear is required
+                auto bindFrameBufferTransaction = GLTransactions::BindFrameBuffer(clearFrameBufferId);
+                auto clearColorTransaction = GLTransactions::ClearColor(0, 0, 0, 0);
+                glClear(GL_COLOR_BUFFER_BIT);
             }
 
             int32_t geometryChanged{0};
@@ -456,6 +481,10 @@ namespace xr
 
                 // Draw the quad
                 glDrawArrays(GL_TRIANGLE_STRIP, 0, VERTEX_COUNT);
+
+                // Present to the screen
+                eglSwapBuffers(eglGetCurrentDisplay(), eglGetCurrentSurface(EGL_DRAW));
+
                 glUseProgram(0);
             }
         }
@@ -552,6 +581,7 @@ namespace xr
 
         GLuint shaderProgramId{};
         GLuint cameraTextureId{};
+        GLuint clearFrameBufferId{};
 
         ArSession* session{};
         ArFrame* frame{};


### PR DESCRIPTION
While adding XR support into the React Native integration layer, I found that the ARCore XR implementation did not work in this context. After some debugging, I found a couple issues:
1. Babylon intentionally does not clear the color texture each frame because whether or not it should be cleared is a detail of a specific XR implementation. For example, OpenXR provides a color texture that already contains the current camera frame, so you just draw your scene on top of it without clearing. In the case of ARCore, we use two separate textures - one for the camera frame, and one for the Babylon scene. So in this case, the ARCore XR implementation should clear the color texture each frame before Babylon draws the scene onto it.
1. When Babylon is rendering to an offscreen frame buffer (the color render texture mentioned above), it is not presenting to the display, and so there is no call to `eglSwapBuffers`. This seems expected (since `eglSwapBuffers` basically means present to the display), so the ARCore XR implementation now explicitly calls `eglSwapBuffers` since it is an implementation detail that it presents to the current surface.

When running in the regular Babylon Native Playground app, the above two are not needed because bgfx is internally clearing and presenting, but this behavior should not be different between the regular playground and the react native playground. We need to figure out why this is happening and fix it, but I want to do this separately from this change. What that means is that if I leave the added call to `eglSwapBuffers`, it breaks the regular playground app but fixes the react native playground app. If I remove it, then it works in the regular playground app, but breaks the react native playground app. I don't really care which of the two are temporarily broken until we figure out the underlying issue, so if you care, speak up.

For clearing the texture, there is an OpenGL function to clear a texture directly, but it is not available on Android (as far as I can tell). So instead, I create another frame buffer that the color texture can be bound to specifically for the purpose of clearing it (by binding the frame buffer and calling `glClear`). According to "the internet" this is a cheap operation. 😁