### PR TITLE
Add a NativeEngine function to get current API (#211 groundwork)

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -397,6 +397,7 @@ namespace Babylon
                 InstanceMethod("getRenderHeight", &NativeEngine::GetRenderHeight),
                 InstanceMethod("setViewPort", &NativeEngine::SetViewPort),
                 InstanceMethod("getFramebufferData", &NativeEngine::GetFramebufferData),
+                InstanceMethod("getRenderAPI", &NativeEngine::GetRenderAPI),
             });
 
         env.Global().Get(JsRuntime::JS_NATIVE_NAME).As<Napi::Object>().Set(JS_ENGINE_CONSTRUCTOR_NAME, func);
@@ -1399,6 +1400,11 @@ namespace Babylon
         s_bgfxCallback.m_screenShotBitmap.clear();
 
         return Napi::External<ImageData>::New(info.Env(), imageData);
+    }
+
+    Napi::Value NativeEngine::GetRenderAPI(const Napi::CallbackInfo& info)
+    {
+        return Napi::Value::From(info.Env(), static_cast<int>(bgfx::getRendererType()));
     }
 
     void NativeEngine::EndFrame()

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -388,6 +388,7 @@ namespace Babylon
         Napi::Value GetRenderHeight(const Napi::CallbackInfo& info);
         void SetViewPort(const Napi::CallbackInfo& info);
         Napi::Value GetFramebufferData(const Napi::CallbackInfo& info);
+        Napi::Value GetRenderAPI(const Napi::CallbackInfo& info);
 
         void UpdateSize(size_t width, size_t height);
 


### PR DESCRIPTION
Prerequisite to move any GL shader work out of C++ and into Typescript as discussed with @CedricGuillemet for issue #211. Returns the bgfx RenderType enum as an int: returning a string would also be possible if that's more idiomatic!