### PR TITLE
Added missing headers to js_native_api_chakra.cc

### DIFF
--- a/Dependencies/napi/source/js_native_api_chakra.cc
+++ b/Dependencies/napi/source/js_native_api_chakra.cc
@@ -2,7 +2,10 @@
 #include <napi/js_native_api.h>
 #include <array>
 #include <cassert>
+#include <cmath>
 #include <vector>
+#include <string>
+#include <stdexcept>
 
 namespace {
 constexpr UINT CP_LATIN1 = 28591;


### PR DESCRIPTION
Added missing headers to js_native_api_chakra.cc to build properly in VS 16.6.0.