### PR TITLE
Move DeviceInputSystem from global scope to _native

### DIFF
--- a/Plugins/NativeInput/Source/DeviceInputSystem.cpp
+++ b/Plugins/NativeInput/Source/DeviceInputSystem.cpp
@@ -6,6 +6,8 @@ namespace Babylon::Plugins
     {
         Napi::HandleScope scope{env};
 
+        static constexpr auto JS_CONSTRUCTOR_NAME = "DeviceInputSystem";
+
         Napi::Function func
         {
             DefineClass(
@@ -19,7 +21,7 @@ namespace Babylon::Plugins
                 })
         };
 
-        env.Global().Set(JS_CONSTRUCTOR_NAME, func);
+        env.Global().Get(JsRuntime::JS_NATIVE_NAME).As<Napi::Object>().Set(JS_CONSTRUCTOR_NAME, func);
     }
 
     // TODO: The JavaScript contract is such that the constructor takes an Engine, but really it should take some kind of view id, which should be passed through to NativeInput::GetFromJavaScript.

--- a/Plugins/NativeInput/Source/DeviceInputSystem.h
+++ b/Plugins/NativeInput/Source/DeviceInputSystem.h
@@ -6,8 +6,6 @@ namespace Babylon::Plugins
 {
     class NativeInput::Impl::DeviceInputSystem final : public Napi::ObjectWrap<DeviceInputSystem>
     {
-        static constexpr auto JS_CONSTRUCTOR_NAME = "DeviceInputSystem";
-
     public:
         static void Initialize(Napi::Env env);
 


### PR DESCRIPTION
We can't override classes with ES6+modules, so moving this into the `_native` object, and adding explicit code to the JS `DeviceInputSystem` to check for this (see https://github.com/BabylonJS/Babylon.js/pull/8225).