### PR TITLE
script loader

### DIFF
--- a/Apps/Playground/CMakeLists.txt
+++ b/Apps/Playground/CMakeLists.txt
@@ -110,6 +110,7 @@ target_link_to_dependencies(Playground
     PRIVATE NativeWindow
     PRIVATE NativeEngine
     PRIVATE Console
+    PRIVATE Script
     PRIVATE Window
     PRIVATE ScriptLoader
     PRIVATE XMLHttpRequest

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -15,6 +15,7 @@
 #include <Babylon/Plugins/NativeWindow.h>
 #include <Babylon/Plugins/NativeXr.h>
 #include <Babylon/Polyfills/Console.h>
+#include <Babylon/Polyfills/Script.h>
 #include <Babylon/Polyfills/Window.h>
 #include <Babylon/Polyfills/XMLHttpRequest.h>
 
@@ -107,6 +108,7 @@ namespace
 
             Babylon::Polyfills::Window::Initialize(env);
             Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+            Babylon::Polyfills::Script::Initialize(env, [](auto func) { runtime->Dispatch(std::move(func)); });
 
             // Initialize NativeWindow plugin.
             auto width = static_cast<float>(rect.right - rect.left);

--- a/Apps/ValidationTests/CMakeLists.txt
+++ b/Apps/ValidationTests/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_to_dependencies(ValidationTests
     PRIVATE NativeEngine
     PRIVATE NativeWindow
     PRIVATE Console
+    PRIVATE Script
     PRIVATE Window
     PRIVATE ScriptLoader
     PRIVATE XMLHttpRequest)

--- a/Apps/ValidationTests/Win32/App.cpp
+++ b/Apps/ValidationTests/Win32/App.cpp
@@ -18,6 +18,7 @@
 #include <Babylon/Plugins/NativeEngine.h>
 #include <Babylon/Plugins/NativeWindow.h>
 #include <Babylon/Polyfills/Console.h>
+#include <Babylon/Polyfills/Script.h>
 #include <Babylon/Polyfills/Window.h>
 #include <Babylon/Polyfills/XMLHttpRequest.h>
 #include <iostream>
@@ -107,6 +108,7 @@ namespace
 
                 Babylon::Polyfills::Window::Initialize(env);
                 Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+                Babylon::Polyfills::Script::Initialize(env, [](auto func) { runtime->Dispatch(std::move(func)); });
 
                 Babylon::Polyfills::Window::Initialize(env);
                 // Initialize NativeWindow plugin to the test size.

--- a/Core/ScriptLoader/Include/Babylon/ScriptLoader.h
+++ b/Core/ScriptLoader/Include/Babylon/ScriptLoader.h
@@ -23,7 +23,7 @@ namespace Babylon
 
         ~ScriptLoader();
 
-        void LoadScript(std::string url);
+        void LoadScript(std::string url, Napi::FunctionReference* onSuccess = nullptr, Napi::FunctionReference* onError = nullptr);
         void Eval(std::string source, std::string url);
 
     private:

--- a/Polyfills/CMakeLists.txt
+++ b/Polyfills/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Console)
 add_subdirectory(Window)
 add_subdirectory(XMLHttpRequest)
+add_subdirectory(Script)

--- a/Polyfills/Script/CMakeLists.txt
+++ b/Polyfills/Script/CMakeLists.txt
@@ -1,0 +1,21 @@
+set(SOURCES
+    "Include/Babylon/Polyfills/Script.h"
+    "Source/Script.cpp"
+    "Source/Script.h")
+
+add_library(Script ${SOURCES})
+
+target_include_directories(Script PUBLIC "Include")
+
+target_link_to_dependencies(Script 
+    PUBLIC napi 
+    PRIVATE arcana)
+
+target_link_to_dependencies(Script 
+    PUBLIC napi
+    PRIVATE ScriptLoader
+    PRIVATE JsRuntime
+    INTERFACE arcana)
+    
+set_property(TARGET Script PROPERTY FOLDER Polyfills)
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Polyfills/Script/Include/Babylon/Polyfills/Script.h
+++ b/Polyfills/Script/Include/Babylon/Polyfills/Script.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <napi/env.h>
+
+namespace Babylon::Polyfills::Script
+{
+    using DispatchFunctionT = std::function<void(std::function<void(Napi::Env)>)>;
+
+    void Initialize(Napi::Env env, DispatchFunctionT dispathFunction);
+}

--- a/Polyfills/Script/Source/Script.cpp
+++ b/Polyfills/Script/Source/Script.cpp
@@ -1,0 +1,56 @@
+#include "Script.h"
+#include <Babylon/JsRuntime.h>
+#include <functional>
+#include <sstream>
+
+#include <arcana/threading/task.h>
+#include <arcana/threading/task_schedulers.h>
+
+
+namespace Babylon::Polyfills::Internal
+{
+    void Script::CreateInstance(Napi::Env env, DispatchFunctionT dispatchFunction)
+    {
+        Napi::HandleScope scope{env};
+
+        Napi::Function func = ParentT::DefineClass(
+            env,
+            "Script",
+            {
+                ParentT::InstanceMethod("loadScript", &Script::LoadScript),
+            });
+
+        Napi::Object script = func.New({ Napi::External<Babylon::Polyfills::Script::DispatchFunctionT>::New(env, new Babylon::Polyfills::Script::DispatchFunctionT(std::move(dispatchFunction))) });
+        env.Global().Set(JS_INSTANCE_NAME, script);
+    }
+
+    Script::Script(const Napi::CallbackInfo& info)
+        : ParentT{info}
+        , m_dispatchFunction{ *info[0].As<Napi::External<Babylon::Polyfills::Script::DispatchFunctionT>>().Data() }
+        , m_loader{ m_dispatchFunction }
+        , m_runtimeScheduler{ JsRuntime::GetFromJavaScript(info.Env()) }
+    {
+    }
+
+    void Script::LoadScript(const Napi::CallbackInfo& info)
+    {
+        const auto url = info[0].As<Napi::String>();
+        const auto onSuccess = info[1].As<Napi::Function>();
+        const auto onError = info[2].As<Napi::Function>();
+        //const auto scriptId = info[3].As<Napi::String>();
+
+        m_loader.LoadScript(url, new Napi::FunctionReference(Napi::Persistent(onSuccess)), new Napi::FunctionReference(Napi::Persistent(onError)));
+        /*
+            std::make_shared<std::function<void()>>( [onSuccessRef = Napi::Persistent(onSuccess)]()  {
+                onSuccessRef.Call({});
+            }));*/
+    }
+}
+
+namespace Babylon::Polyfills::Script
+{
+    void Initialize(Napi::Env env, DispatchFunctionT dispatchFunction)
+    {
+        Internal::Script::CreateInstance(env, dispatchFunction);
+    }
+}

--- a/Polyfills/Script/Source/Script.h
+++ b/Polyfills/Script/Source/Script.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Babylon/Polyfills/Script.h>
+#include <Babylon/ScriptLoader.h>
+#include <arcana/threading/cancellation.h>
+#include <Babylon/JsRuntimeScheduler.h>
+
+namespace Babylon::Polyfills::Internal
+{
+    class Script final : public Napi::ObjectWrap<Script>
+    {
+    public:
+        static inline constexpr const char* JS_INSTANCE_NAME{ "NativeScript" };
+        using DispatchFunctionT = std::function<void(std::function<void(Napi::Env)>)>;
+
+        using ParentT = Napi::ObjectWrap<Script>;
+
+        static void CreateInstance(Napi::Env env, DispatchFunctionT dispatchFunction);
+
+        explicit Script(const Napi::CallbackInfo& info);
+
+    private:
+        void LoadScript(const Napi::CallbackInfo& info);
+        DispatchFunctionT m_dispatchFunction;
+        Babylon::ScriptLoader m_loader;
+
+        arcana::cancellation_source m_cancelSource{};
+        JsRuntimeScheduler m_runtimeScheduler;
+    };
+}


### PR DESCRIPTION
This is WIP for https://github.com/BabylonJS/BabylonNative/issues/219 and https://github.com/BabylonJS/BabylonNative/issues/214 because PG needs a way to load .js

Using polyfills as loading JS use DOM.
Once this PR is ine, I'll do a PR in bjs to override ```BABYLON.Tools.GetAbsoluteUrl``` and ```BABYLON.Tools.LoadScript``` from nativeengine init as it seems the best way to do it after talking to @sebavan .

the NativeScript polyfill uses the ScriptLoader. I'm running into 1 c++ issue:
I need to call onSuccess and onError JS function to loadScript. I tried many things with lamba, std::move, std::unique,... to push to Napi::FunctionReference to that function without success. I used a new/delete.  https://github.com/BabylonJS/BabylonNative/pull/274/files#diff-827872a1f803d4a7fc75b6c63e938a2cR42