### PR TITLE
fix bound samplers arcore

### DIFF
--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -220,6 +220,14 @@ namespace xr
                 glClearColor(red, green, blue, alpha);
                 return gsl::finally([red = previousClearColor[0], green = previousClearColor[1], blue = previousClearColor[2], alpha = previousClearColor[3]]() { glClearColor(red, green, blue, alpha); });
             }
+
+            auto Sampler(int unit)
+            {
+                glActiveTexture(GL_TEXTURE0 + unit);
+                GLint previousSampler;
+                glGetIntegerv(GL_SAMPLER_BINDING, &previousSampler);
+                return gsl::finally([unit, sampler = previousSampler]() { glActiveTexture(GL_TEXTURE0 + unit); glBindSampler(unit, sampler); });
+            }
         }
 
         bool CheckARCoreInstallStatus(bool requestInstall)
@@ -559,6 +567,8 @@ namespace xr
                 auto blendTransaction = GLTransactions::SetCapability(GL_BLEND, false);
                 auto depthMaskTransaction = GLTransactions::DepthMask(GL_FALSE);
                 auto blendFuncTransaction = GLTransactions::BlendFunc(GL_BLEND_SRC_ALPHA, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+                auto sampler0Transation = GLTransactions::Sampler(0);
+                auto sampler1Transation = GLTransactions::Sampler(1);
 
                 glViewport(0, 0, ActiveFrameViews[0].ColorTextureSize.Width, ActiveFrameViews[0].ColorTextureSize.Height);
                 glUseProgram(shaderProgramId);
@@ -572,6 +582,7 @@ namespace xr
                 glUniform1i(cameraTextureUniformLocation, GetTextureUnit(GL_TEXTURE0));
                 glActiveTexture(GL_TEXTURE0);
                 glBindTexture(GL_TEXTURE_EXTERNAL_OES, cameraTextureId);
+                glBindSampler(0, 0);
 
                 // Configure the camera frame UVs
                 auto cameraFrameUVsUniformLocation = glGetUniformLocation(shaderProgramId, "cameraFrameUVs");
@@ -583,6 +594,7 @@ namespace xr
                 glActiveTexture(GL_TEXTURE1);
                 auto babylonTextureId = (GLuint)(size_t)ActiveFrameViews[0].ColorTexturePointer;
                 glBindTexture(GL_TEXTURE_2D, babylonTextureId);
+                glBindSampler(1, 0);
 
                 // Draw the quad
                 glDrawArrays(GL_TRIANGLE_STRIP, 0, VERTEX_COUNT);


### PR DESCRIPTION
samplers were still the bgfx ones with mipmap enabled. but as we don't have MM for camera and Babylon texture, we ended up with a black rendering.

fixes #279 