### PR TITLE
fix rotation crash with XR and 0 sized texture (when locking the phone)

### DIFF
--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -147,7 +147,7 @@ namespace xr
             // Move to private when changing to unique_ptr.
             Session(System& system, void* graphicsDevice);
 
-            std::unique_ptr<Frame> GetNextFrame(bool& shouldEndSession, bool& shouldRestartSession);
+            std::unique_ptr<Frame> GetNextFrame(bool& shouldEndSession, bool& shouldRestartSession, std::function<void(void* texturePointer)> deletedTextureCallback = [](void*){});
             void RequestEndSession();
             Size GetWidthAndHeightForViewIndex(size_t viewIndex) const;
             void SetDepthsNearFar(float depthNear, float depthFar);

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -409,7 +409,7 @@ namespace xr
             isInitialized = true;
         }
 
-        std::unique_ptr<Session::Frame> GetNextFrame(bool& shouldEndSession, bool& shouldRestartSession)
+        std::unique_ptr<Session::Frame> GetNextFrame(bool& shouldEndSession, bool& shouldRestartSession, std::function<void(void* texturePointer)> deletedTextureCallback)
         {
             if (!isInitialized)
             {
@@ -453,7 +453,7 @@ namespace xr
             // Check whether the dimensions have changed
             if ((ActiveFrameViews[0].ColorTextureSize.Width != width || ActiveFrameViews[0].ColorTextureSize.Height != height) && width && height)
             {
-                DestroyDisplayResources();
+                DestroyDisplayResources(deletedTextureCallback);
 
                 int rotation = GetAppContext().getSystemService<android::view::WindowManager>().getDefaultDisplay().getRotation();
 
@@ -731,12 +731,13 @@ namespace xr
             }
         }
 
-        void DestroyDisplayResources()
+        void DestroyDisplayResources(std::function<void(void* texturePointer)> deletedTextureCallback = [](void*){})
         {
             if (ActiveFrameViews[0].ColorTexturePointer)
             {
                 auto colorTextureId = static_cast<GLuint>(reinterpret_cast<uintptr_t>(ActiveFrameViews[0].ColorTexturePointer));
                 glDeleteTextures(1, &colorTextureId);
+                deletedTextureCallback(ActiveFrameViews[0].ColorTexturePointer);
             }
 
             if (ActiveFrameViews[0].DepthTexturePointer)
@@ -863,9 +864,9 @@ namespace xr
     {
     }
 
-    std::unique_ptr<System::Session::Frame> System::Session::GetNextFrame(bool& shouldEndSession, bool& shouldRestartSession)
+    std::unique_ptr<System::Session::Frame> System::Session::GetNextFrame(bool& shouldEndSession, bool& shouldRestartSession, std::function<void(void* texturePointer)> deletedTextureCallback)
     {
-        return m_impl->GetNextFrame(shouldEndSession, shouldRestartSession);
+        return m_impl->GetNextFrame(shouldEndSession, shouldRestartSession, deletedTextureCallback);
     }
 
     void System::Session::RequestEndSession()

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -451,7 +451,7 @@ namespace xr
             }
 
             // Check whether the dimensions have changed
-            if (ActiveFrameViews[0].ColorTextureSize.Width != width || ActiveFrameViews[0].ColorTextureSize.Height != height)
+            if ((ActiveFrameViews[0].ColorTextureSize.Width != width || ActiveFrameViews[0].ColorTextureSize.Height != height) && width && height)
             {
                 DestroyDisplayResources();
 

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -831,7 +831,7 @@ namespace xr
 
     System::Session::~Session() {}
 
-    std::unique_ptr<System::Session::Frame> System::Session::GetNextFrame(bool& shouldEndSession, bool& shouldRestartSession)
+    std::unique_ptr<System::Session::Frame> System::Session::GetNextFrame(bool& shouldEndSession, bool& shouldRestartSession, std::function<void(void* /*texturePointer*/)> /*deletedTextureCallback*/)
     {
         return m_impl->GetNextFrame(shouldEndSession, shouldRestartSession);
     }

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -289,8 +289,8 @@ namespace Babylon
         for (size_t viewIndex = 0; viewIndex < viewCount; viewIndex++)
         {
             const auto& view = m_frame->Views[viewIndex];
-            auto* frameBuffer = m_viewFrameBuffers[viewIndex].get();
-            if (frameBuffer == nullptr || frameBuffer->Width != view.ColorTextureSize.Width || frameBuffer->Height != view.ColorTextureSize.Height)
+            auto* viewFrameBuffer = m_viewFrameBuffers[viewIndex].get();
+            if (viewFrameBuffer == nullptr || viewFrameBuffer->Width != view.ColorTextureSize.Width || viewFrameBuffer->Height != view.ColorTextureSize.Height)
             {
                 // if a texture width or height is 0, bgfx will assert (can't create 0 sized texture). Asserting here instead of deeper in bgfx rendering
                 assert(view.ColorTextureSize.Width); 
@@ -332,7 +332,7 @@ namespace Babylon
             }
             else
             {
-                m_activeFrameBuffers.push_back(frameBuffer);
+                m_activeFrameBuffers.push_back(viewFrameBuffer);
             }
         }
     }


### PR DESCRIPTION
# 1st bug:
- bgfx keeps a list of framebuffers and update them when a resize happens
- in xr, when a resize happens, we delete the color/depth textures and create new ones : https://github.com/BabylonJS/BabylonNative/blob/a6384a810919697dd1f5186ef1d51cdd76e89266/Dependencies/xr/Source/ARCore/XR.cpp#L736
- bgfx frame buffer list contains an entry with a deleted texture. when trying to associate the deleted texture and the framebuffer object, there is an GL_INVALID_OPERATION error, trapped by bgfx as a fatal error
- the framebuffer with invalid texture exists because we never delete any framebuffer. we create a new one.
- the FB is added to a std::map here : https://github.com/BabylonJS/BabylonNative/blob/a6384a810919697dd1f5186ef1d51cdd76e89266/Plugins/NativeXr/Source/NativeXr.cpp#L325 but it's never removed. leading to those invalid FB

So, I replaced that std::map with a std::vector, resize it to the number of views and simply replace a new std::unique once the view size changed. @syntheticmagus Maybe I missed something here on why a std::map is used in the first place and why the association is done on the texture handle (and not the view index like I did here). 

# 2nd bug:

when the phone gets locked, the size of the surface reported here : https://github.com/BabylonJS/BabylonNative/blob/a6384a810919697dd1f5186ef1d51cdd76e89266/Dependencies/xr/Source/ARCore/XR.cpp#L447 is (0,0). That size is then used for creating the temp textures for the framebuffer : https://github.com/BabylonJS/BabylonNative/blob/a6384a810919697dd1f5186ef1d51cdd76e89266/Plugins/NativeXr/Source/NativeXr.cpp#L301
but bgfx does a check with the creation command are performed (bgfx::frame) and fatal asserts.
I've added a check to not update views texture when the size is 0.