### PR TITLE
Integration + iOS.Framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,3 +38,6 @@ if(hasParent)
 else()
     add_subdirectory(Apps)
 endif()
+
+# integration
+add_subdirectory(Integration)

--- a/Integration/CMakeLists.txt
+++ b/Integration/CMakeLists.txt
@@ -1,0 +1,5 @@
+if(APPLE)
+    if(IOS)
+        add_subdirectory(iOS.Framework)
+    endif()
+endif()

--- a/Integration/iOS.Framework/CMakeLists.txt
+++ b/Integration/iOS.Framework/CMakeLists.txt
@@ -1,0 +1,145 @@
+set(BABYLONSCRIPTS
+    "../../Apps/BabylonScripts/babylon.glTF2FileLoader.js"
+    "../../Apps/BabylonScripts/babylon.max.js"
+    "../../Apps/BabylonScripts/babylonjs.materials.js"
+    "../../Apps/BabylonScripts/ammo.js"
+    "../../Apps/BabylonScripts/meshwriter.min.js"
+    "../../Apps/BabylonScripts/recast.js")
+
+set(SCRIPTS
+    "../../Apps/Playground/Scripts/experience.js"
+    "../../Apps/Playground/Scripts/playground_runner.js")
+
+set(SOURCES
+    "Source/Framework.cpp"
+    "Include/napi.h")
+
+set(RESOURCE_FILES ${STORYBOARD} ${BABYLONSCRIPTS} ${SCRIPTS})
+
+add_library(BabylonNative ${SOURCES} ${RESOURCE_FILES})
+warnings_as_errors(BabylonNative)
+
+target_compile_definitions(BabylonNative PRIVATE UNICODE)
+target_compile_definitions(BabylonNative PRIVATE _UNICODE)
+
+target_include_directories(BabylonNative PUBLIC "Source" ".")
+file(GLOB_RECURSE appruntime_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Core/AppRuntime/Include/Babylon/*.h)
+file(GLOB_RECURSE jsruntime_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Core/JsRuntime/Include/Babylon/*.h)
+file(GLOB_RECURSE scriptloader_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Core/ScriptLoader/Include/Babylon/*.h)
+
+file(GLOB_RECURSE nativewindow_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Plugins/NativeWindow/Include/Babylon/*.h)
+file(GLOB_RECURSE nativeengine_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Plugins/NativeEngine/Include/Babylon/*.h)
+file(GLOB_RECURSE nativeinput_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Plugins/NativeInput/Include/Babylon/*.h)
+#file(GLOB_RECURSE nativexr_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Plugins/NativeXr/Include/Babylon/*.h)
+
+file(GLOB_RECURSE console_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Polyfills/Console/Include/Babylon/*.h)
+file(GLOB_RECURSE window_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Polyfills/Window/Include/Babylon/*.h)
+file(GLOB_RECURSE xmlhttprequest_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Polyfills/XMLHttpRequest/Include/Babylon/*.h)
+
+file(GLOB_RECURSE napi_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Dependencies/napi/Include/napi/*.h)
+
+# copy headers
+foreach(header ${appruntime_headers} 
+        ${jsruntime_headers}
+        ${scriptloader_headers}
+        ${nativewindow_headers}
+        ${nativeengine_headers}
+        ${nativeinput_headers}
+        #${nativexr_headers}
+        ${console_headers}
+        ${window_headers}
+        ${xmlhttprequest_headers} )
+    get_filename_component(HEADER_NAME "${header}" NAME)
+    add_custom_command(TARGET BabylonNative PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy
+        ${header}
+        $<TARGET_FILE_DIR:BabylonNative>/Headers/${HEADER_NAME})
+endforeach()
+
+foreach(header ${napi_headers})
+    get_filename_component(HEADER_NAME "${header}" NAME)
+    if(NOT "${HEADER_NAME}" STREQUAL "napi.h")
+        add_custom_command(TARGET BabylonNative PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy
+            ${header}
+            $<TARGET_FILE_DIR:BabylonNative>/Headers/${HEADER_NAME})
+    endif()
+endforeach()
+
+# concatenate static libs
+add_custom_command(TARGET BabylonNative POST_BUILD
+        COMMAND libtool -static -o $<TARGET_FILE:BabylonNative> 
+            $<TARGET_FILE:AppRuntime> 
+            $<TARGET_FILE:JsRuntime> 
+            $<TARGET_FILE:NativeWindow>
+            $<TARGET_FILE:NativeEngine> 
+            $<TARGET_FILE:Console> 
+            $<TARGET_FILE:Window> 
+            $<TARGET_FILE:ScriptLoader> 
+            $<TARGET_FILE:XMLHttpRequest> 
+            $<TARGET_FILE:NativeInput> 
+            $<TARGET_FILE:napi> 
+            $<TARGET_FILE:UrlLib> 
+            $<TARGET_FILE:bgfx> 
+            $<TARGET_FILE:bimg> 
+            $<TARGET_FILE:bx> 
+            $<TARGET_FILE:glslang> 
+            $<TARGET_FILE:SPIRV> 
+            $<TARGET_FILE:spirv-cross-core> 
+            $<TARGET_FILE:spirv-cross-hlsl>
+            $<TARGET_FILE:spirv-cross-msl>
+            $<TARGET_FILE:spirv-cross-glsl>
+            $<TARGET_FILE:OGLCompiler>
+            $<TARGET_FILE:OSDependent>
+            $<TARGET_FILE:astc>
+            $<TARGET_FILE:astc-codec>
+            #$<TARGET_FILE:NativeXr>
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        DEPENDS AppRuntime 
+            NativeWindow 
+            NativeEngine 
+            #NativeXr
+            Console 
+            ScriptLoader 
+            XMLHttpRequest 
+            NativeInput 
+            Window 
+            JsRuntime
+            napi
+            UrlLib
+            bgfx
+            bimg
+            bx
+            glslang
+            SPIRV
+            spirv-cross-core
+            spirv-cross-hlsl
+            spirv-cross-msl
+            spirv-cross-glsl
+            OGLCompiler
+            OSDependent
+            astc
+            astc-codec)
+
+set_target_properties(BabylonNative PROPERTIES
+    FRAMEWORK TRUE
+    FRAMEWORK_VERSION C
+    PUBLIC_HEADER "Include/napi.h"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES
+    RESOURCE "${RESOURCE_FILES}"
+
+    XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET 12.0
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.BabylonNative.iOS"
+    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer"
+    XCODE_ATTRIBUTE_ENABLE_BITCODE NO
+
+    XCODE_ATTRIBUTE_SWIFT_VERSION "4.0"
+    XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/Frameworks"
+    XCODE_ATTRIBUTE_ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES YES
+
+    # CMake seems to add a custom flag "-Wno-unknown-pragmas" to the Swift compiler. That flag is used for Clang,
+    # So we need to make sure we override it with nothing here in order to compile Swift.
+    XCODE_ATTRIBUTE_OTHER_SWIFT_FLAGS "")
+
+    # Swift support
+    set(CMAKE_Swift_COMPILER_FORCED TRUE)
+    set(CMAKE_Swift_LANGUAGE_VERSION 4.0)
+    enable_language(Swift) )

--- a/Integration/iOS.Framework/CMakeLists.txt
+++ b/Integration/iOS.Framework/CMakeLists.txt
@@ -23,20 +23,20 @@ target_compile_definitions(BabylonNative PRIVATE UNICODE)
 target_compile_definitions(BabylonNative PRIVATE _UNICODE)
 
 target_include_directories(BabylonNative PUBLIC "Source" ".")
-file(GLOB_RECURSE appruntime_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Core/AppRuntime/Include/Babylon/*.h)
-file(GLOB_RECURSE jsruntime_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Core/JsRuntime/Include/Babylon/*.h)
-file(GLOB_RECURSE scriptloader_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Core/ScriptLoader/Include/Babylon/*.h)
+file(GLOB_RECURSE appruntime_headers ${CMAKE_CURRENT_SOURCE_DIR}/../../Core/AppRuntime/Include/Babylon/*.h)
+file(GLOB_RECURSE jsruntime_headers ${CMAKE_CURRENT_SOURCE_DIR}/../../Core/JsRuntime/Include/Babylon/*.h)
+file(GLOB_RECURSE scriptloader_headers ${CMAKE_CURRENT_SOURCE_DIR}/../../Core/ScriptLoader/Include/Babylon/*.h)
 
-file(GLOB_RECURSE nativewindow_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Plugins/NativeWindow/Include/Babylon/*.h)
-file(GLOB_RECURSE nativeengine_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Plugins/NativeEngine/Include/Babylon/*.h)
-file(GLOB_RECURSE nativeinput_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Plugins/NativeInput/Include/Babylon/*.h)
+file(GLOB_RECURSE nativewindow_headers ${CMAKE_CURRENT_SOURCE_DIR}/../../Plugins/NativeWindow/Include/Babylon/*.h)
+file(GLOB_RECURSE nativeengine_headers ${CMAKE_CURRENT_SOURCE_DIR}/../../Plugins/NativeEngine/Include/Babylon/*.h)
+file(GLOB_RECURSE nativeinput_headers ${CMAKE_CURRENT_SOURCE_DIR}/../../Plugins/NativeInput/Include/Babylon/*.h)
 #file(GLOB_RECURSE nativexr_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Plugins/NativeXr/Include/Babylon/*.h)
 
-file(GLOB_RECURSE console_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Polyfills/Console/Include/Babylon/*.h)
-file(GLOB_RECURSE window_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Polyfills/Window/Include/Babylon/*.h)
-file(GLOB_RECURSE xmlhttprequest_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Polyfills/XMLHttpRequest/Include/Babylon/*.h)
+file(GLOB_RECURSE console_headers ${CMAKE_CURRENT_SOURCE_DIR}/../../Polyfills/Console/Include/Babylon/*.h)
+file(GLOB_RECURSE window_headers ${CMAKE_CURRENT_SOURCE_DIR}/../../Polyfills/Window/Include/Babylon/*.h)
+file(GLOB_RECURSE xmlhttprequest_headers ${CMAKE_CURRENT_SOURCE_DIR}/../../Polyfills/XMLHttpRequest/Include/Babylon/*.h)
 
-file(GLOB_RECURSE napi_headers ${CMAKE_CURRENT_SOURCE_DIR}/../Dependencies/napi/Include/napi/*.h)
+file(GLOB_RECURSE napi_headers ${CMAKE_CURRENT_SOURCE_DIR}/../../Dependencies/napi/Include/napi/*.h)
 
 # copy headers
 foreach(header ${appruntime_headers} 
@@ -44,8 +44,8 @@ foreach(header ${appruntime_headers}
         ${scriptloader_headers}
         ${nativewindow_headers}
         ${nativeengine_headers}
-        ${nativeinput_headers}
         #${nativexr_headers}
+        ${nativeinput_headers}
         ${console_headers}
         ${window_headers}
         ${xmlhttprequest_headers} )
@@ -67,23 +67,24 @@ endforeach()
 # concatenate static libs
 add_custom_command(TARGET BabylonNative POST_BUILD
         COMMAND libtool -static -o $<TARGET_FILE:BabylonNative> 
-            $<TARGET_FILE:AppRuntime> 
-            $<TARGET_FILE:JsRuntime> 
+            $<TARGET_FILE:AppRuntime>
+            $<TARGET_FILE:JsRuntime>
             $<TARGET_FILE:NativeWindow>
-            $<TARGET_FILE:NativeEngine> 
-            $<TARGET_FILE:Console> 
-            $<TARGET_FILE:Window> 
-            $<TARGET_FILE:ScriptLoader> 
-            $<TARGET_FILE:XMLHttpRequest> 
-            $<TARGET_FILE:NativeInput> 
-            $<TARGET_FILE:napi> 
-            $<TARGET_FILE:UrlLib> 
-            $<TARGET_FILE:bgfx> 
-            $<TARGET_FILE:bimg> 
-            $<TARGET_FILE:bx> 
-            $<TARGET_FILE:glslang> 
-            $<TARGET_FILE:SPIRV> 
-            $<TARGET_FILE:spirv-cross-core> 
+            $<TARGET_FILE:NativeEngine>
+            #$<TARGET_FILE:NativeXr>
+            $<TARGET_FILE:Console>
+            $<TARGET_FILE:Window>
+            $<TARGET_FILE:ScriptLoader>
+            $<TARGET_FILE:XMLHttpRequest>
+            $<TARGET_FILE:NativeInput>
+            $<TARGET_FILE:napi>
+            $<TARGET_FILE:UrlLib>
+            $<TARGET_FILE:bgfx>
+            $<TARGET_FILE:bimg>
+            $<TARGET_FILE:bx>
+            $<TARGET_FILE:glslang>
+            $<TARGET_FILE:SPIRV>
+            $<TARGET_FILE:spirv-cross-core>
             $<TARGET_FILE:spirv-cross-hlsl>
             $<TARGET_FILE:spirv-cross-msl>
             $<TARGET_FILE:spirv-cross-glsl>
@@ -91,18 +92,18 @@ add_custom_command(TARGET BabylonNative POST_BUILD
             $<TARGET_FILE:OSDependent>
             $<TARGET_FILE:astc>
             $<TARGET_FILE:astc-codec>
-            #$<TARGET_FILE:NativeXr>
+            
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         DEPENDS AppRuntime 
-            NativeWindow 
-            NativeEngine 
-            #NativeXr
-            Console 
-            ScriptLoader 
-            XMLHttpRequest 
-            NativeInput 
-            Window 
             JsRuntime
+            NativeWindow
+            NativeEngine
+            #NativeXr
+            Console
+            Window
+            ScriptLoader
+            XMLHttpRequest
+            NativeInput
             napi
             UrlLib
             bgfx

--- a/Integration/iOS.Framework/CMakeLists.txt
+++ b/Integration/iOS.Framework/CMakeLists.txt
@@ -139,7 +139,7 @@ set_target_properties(BabylonNative PROPERTIES
     # So we need to make sure we override it with nothing here in order to compile Swift.
     XCODE_ATTRIBUTE_OTHER_SWIFT_FLAGS "")
 
-    # Swift support
-    set(CMAKE_Swift_COMPILER_FORCED TRUE)
-    set(CMAKE_Swift_LANGUAGE_VERSION 4.0)
-    enable_language(Swift) )
+# Swift support
+set(CMAKE_Swift_COMPILER_FORCED TRUE)
+set(CMAKE_Swift_LANGUAGE_VERSION 4.0)
+enable_language(Swift)

--- a/Integration/iOS.Framework/Include/napi.h
+++ b/Integration/iOS.Framework/Include/napi.h
@@ -1,0 +1,15 @@
+#ifndef NAPI_H__
+#define NAPI_H__
+
+#define NODE_ADDON_API_DISABLE_NODE_SPECIFIC
+#define NODE_ADDON_API_DISABLE_DEPRECATED
+
+#include <BabylonNative/js_native_api_types.h>
+#include <BabylonNative/js_native_api.h>
+
+#include <BabylonNative/js_napi.h>
+#include <BabylonNative/napi-inl.h>
+
+#include <BabylonNative/env.h>
+
+#endif

--- a/Integration/iOS.Framework/Source/framework.cpp
+++ b/Integration/iOS.Framework/Source/framework.cpp
@@ -1,0 +1,1 @@
+// blank .cpp to bootstrap library creation

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,20 @@ jobs:
       useXcpretty: false
     displayName: 'Build iOS'
     
+  - task: Xcode@5
+    inputs:
+      xcWorkspacePath: 'buildiOS/BabylonNative.xcodeproj'
+      scheme: 'BabylonNative'
+      sdk: 'iphoneos'
+      useXcpretty: false
+    displayName: 'Build iOS Framework'
+    
+  - task: PublishBuildArtifacts@1
+    inputs:
+      artifactName: 'iOS Framework'
+      pathtoPublish: 'buildiOS/Integration/Debug-iphoneos/BabylonNative.framework'
+    displayName: 'Publish iOS Framework'
+    
 - job: win32_x64
   timeoutInMinutes: 20
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
   - task: PublishBuildArtifacts@1
     inputs:
       artifactName: 'iOS Framework'
-      pathtoPublish: 'buildiOS/Integration/Debug-iphoneos/BabylonNative.framework'
+      pathtoPublish: 'buildiOS/Integration/iOS.Framework/Debug-iphoneos/BabylonNative.framework'
     displayName: 'Publish iOS Framework'
     
 - job: win32_x64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,7 +77,7 @@ jobs:
     
   - task: PublishBuildArtifacts@1
     inputs:
-      artifactName: 'iOS Framework'
+      artifactName: 'BabylonNative.framework'
       pathtoPublish: 'buildiOS/Integration/iOS.Framework/Debug-iphoneos/BabylonNative.framework'
     displayName: 'Publish iOS Framework'
     


### PR DESCRIPTION
This is part 2 of ios packaging. Part 1 is here https://github.com/BabylonJS/BabylonNative/pull/291
The goal of this PR is to add a new target that builds a Framework usable for Xcode directly (drag and drop .framework in the source tree) or with a cocoapod.

The artifact contains this:
![image](https://user-images.githubusercontent.com/1312968/84491209-78d41380-aca4-11ea-85c8-9f8a34e27c2c.png)
- Headers from the Include directories of plugins, core, polyfills, and napi
- .js resources
- a big BabylonNative static library that is the concatenation of all .a (plugins, dependencies, ...)
Xcode automaticaly recognise the format of this archive so end user doesn't have to set path for includes, name of lib,...

When building the framework, napi.h is replaced with a special napi.h with relative to framework path. See Part1.

The archive is published as a build artifact. Part3 will be cocoapods and binary feed.
It's not possible to use this framework before the Part1 is merged.

Once you have downloaded/installed the framework in the Xcode project, just add some includes.
![image](https://user-images.githubusercontent.com/1312968/84492031-cd2bc300-aca5-11ea-98a8-1ff586de5f24.png)

Some words on cocoapods, I'll elaborate more in the next PR. A pod, basically, needs to files :  a podspec and a pod. The podspec specifies what the pod is composed of. It's used for publishing, and consuming the pod. a pod file contains the list and path to podspec that will be integrated in a named project.

BabylonNative.podspec:
```
Pod::Spec.new do |s|  
    s.name              = 'BabylonNative'
    s.version           = '0.0.4'
    s.summary           = 'Babylon Native.'
    s.homepage          = 'https://github.com/CedricGuillemet'

    s.author            = { 'ceguille' => 'ceguille@microsoft.com' }
    s.license           = { :type => 'MIT' }

    s.platform          = :ios
    s.source            = { :http => 'file:///Users/cedricguillemet/dev/podtest/BabylonNative/buildios/Integration/Debug-iphonesimulator/BabylonNative.framework.zip'}
    s.resource = '**/*.js'
    s.ios.deployment_target = '12.0'
    s.ios.vendored_frameworks = 'BabylonNative.framework'
end  
```
Two most important things here:
the s.source and s.resource. s.resource is needed so xcode can merge the resource in the app bundle.
s.source here points to a local directory that I'm using for my tests.  This path can points to a GitHub release (so we need to update it when we do a GitHub). My task now is to see if it can point to a CI Feed: when merging into master, a build is triggered and it's the artifact from that master version that I'd like to put in the feed. User would have to do a 'pod update' to update to the latest good version of BabylonNative.
It also possible to point to the GitHub and trigger a local build when installing pod.
This file will be at the root of the repo.

End user will only have to update its own pod file like this:
```
target 'name_of_app' do
   pod 'BabylonNative', :git => "https://github.com/BabylonJS/BabylonNative.git"
end
```
Once the pod is installed, load the workspace that cocoapods has generated.

For reactnative integration, it's possible to write its own podspec that will not use the resources from the framework (and use npm instead for Babylonjs).

It's possible to release the framework as an npm package. You then need a podspec to points to that framework (s.source = ".... /node_modules/BabylonNative/). You pod would point to your local podspec.

user would do :
```
npm install
pod install
```