### PR TITLE
Update Babylon.js, roll back XR workaround

### DIFF
--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -530,19 +530,17 @@ namespace Babylon
 
             void Update(const xr::System::Session::Frame::Space& space, bool isViewSpace)
             {
-                // The names of these properties should be reverted to x, y, z, w to match the WebXR spec
-                // once the regression in BabylonJS is fixed see: https://github.com/BabylonJS/BabylonNative/issues/304
                 auto position = m_position.Value();
-                position.Set("_x", space.Pose.Position.X);
-                position.Set("_y", space.Pose.Position.Y);
-                position.Set("_z", space.Pose.Position.Z);
-                position.Set("_w", 1.f);
+                position.Set("x", space.Pose.Position.X);
+                position.Set("y", space.Pose.Position.Y);
+                position.Set("z", space.Pose.Position.Z);
+                position.Set("w", 1.f);
 
                 auto orientation = m_orientation.Value();
-                orientation.Set("_x", space.Pose.Orientation.X);
-                orientation.Set("_y", space.Pose.Orientation.Y);
-                orientation.Set("_z", space.Pose.Orientation.Z);
-                orientation.Set("_w", space.Pose.Orientation.W);
+                orientation.Set("x", space.Pose.Orientation.X);
+                orientation.Set("y", space.Pose.Orientation.Y);
+                orientation.Set("z", space.Pose.Orientation.Z);
+                orientation.Set("w", space.Pose.Orientation.W);
 
                 std::memcpy(m_matrix.Value().Data(), CreateTransformMatrix(space, isViewSpace).data(), m_matrix.Value().ByteLength());
             }


### PR DESCRIPTION
Updating to the latest release (4.2.0-alpha.21) of `babylon.max.js` (pulled from https://github.com/BabylonJS/Babylon.js/blob/9ddcddf942189345dc47190fe8a22fc7451b654f/dist/preview%20release/babylon.max.js). With this change, we can roll back the XR workaround for vector related changes.