### PR TITLE
Use bounds instead of safe area

### DIFF
--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -357,16 +357,15 @@ namespace xr {
             // Create the XR View to stay within the safe area of the main view.
             // TODO: Should re-use the view passed into the engine rather than creating a sub-view.
             dispatch_sync(dispatch_get_main_queue(), ^{
-                auto guide = MainView.safeAreaLayoutGuide;
-                xrView = [[MTKView alloc] initWithFrame:guide.layoutFrame device:metalDevice];
+                xrView = [[MTKView alloc] initWithFrame:MainView.bounds device:metalDevice];
                 [MainView addSubview:xrView];
                 xrView.colorPixelFormat = MTLPixelFormatBGRA8Unorm;
                 xrView.depthStencilPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
                 metalLayer = (CAMetalLayer *)xrView.layer;
                 metalLayer.device = metalDevice;
                 auto scale = UIScreen.mainScreen.scale;
-                viewportSize.x = guide.layoutFrame.size.width * scale;
-                viewportSize.y = guide.layoutFrame.size.height * scale;
+                viewportSize.x = MainView.bounds.size.width * scale;
+                viewportSize.y = MainView.bounds.size.height * scale;
             });
 
             // Create and configure the ARKit session.


### PR DESCRIPTION
I'm not sure why, but `MainView.safeAreaLayoutGuide.layoutFrame` is zero in the context of React Native. However, we shouldn't try to accommodate the notch at this layer anyway. The owning view should do that, and we should make the subview match so that it just looks like we are drawing to the same view. For this, we can just use the `bounds`.

This change is related to #278 