### PR TITLE
bgfx Encoder POC

### DIFF
--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -81,7 +81,7 @@ extern "C"
 
                 Babylon::Plugins::NativeWindow::Initialize(env, window, width, height);
 
-                Babylon::Plugins::NativeEngine::InitializeGraphics(window, width, height);
+                Babylon::Plugins::NativeEngine::InitializeGraphics(window, width, height, true);
                 Babylon::Plugins::NativeEngine::Initialize(env);
 
                 Babylon::Plugins::NativeXr::Initialize(env);

--- a/Apps/Playground/CMakeLists.txt
+++ b/Apps/Playground/CMakeLists.txt
@@ -163,6 +163,7 @@ if(APPLE)
             XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES
             RESOURCE "${RESOURCE_FILES}"
             FOLDER "Playground")
+        target_link_libraries(Playground PRIVATE "-framework MetalKit")
     endif()
 endif()
 

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -103,10 +103,6 @@ void App::Run()
 {
     while (!m_windowClosed)
     {
-        if (m_runtime)
-        {
-            Babylon::Plugins::NativeEngine::Render();
-        }
         CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessOneAndAllPending);
     }
 }
@@ -157,7 +153,7 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
     size_t width = static_cast<size_t>(bounds.Width * m_displayScale);
     size_t height = static_cast<size_t>(bounds.Height * m_displayScale);
     auto* windowPtr = reinterpret_cast<ABI::Windows::UI::Core::ICoreWindow*>(CoreWindow::GetForCurrentThread());
-    Babylon::Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height);
+    Babylon::Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height, true);
     m_runtime->Dispatch([&runtime = m_runtime, &inputBuffer = m_inputBuffer, windowPtr, width, height](Napi::Env env)
     {
         Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto)

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -103,6 +103,10 @@ void App::Run()
 {
     while (!m_windowClosed)
     {
+        if (m_runtime)
+        {
+            Babylon::Plugins::NativeEngine::Render();
+        }
         CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessOneAndAllPending);
     }
 }
@@ -153,6 +157,7 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
     size_t width = static_cast<size_t>(bounds.Width * m_displayScale);
     size_t height = static_cast<size_t>(bounds.Height * m_displayScale);
     auto* windowPtr = reinterpret_cast<ABI::Windows::UI::Core::ICoreWindow*>(CoreWindow::GetForCurrentThread());
+    Babylon::Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height);
     m_runtime->Dispatch([&runtime = m_runtime, &inputBuffer = m_inputBuffer, windowPtr, width, height](Napi::Env env)
     {
         Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto)
@@ -166,7 +171,6 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
         Babylon::Plugins::NativeWindow::Initialize(env, windowPtr, width, height);
 
         // Initialize NativeEngine plugin.
-        Babylon::Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height);
         Babylon::Plugins::NativeEngine::Initialize(env);
 
         // Initialize NativeXr plugin.
@@ -230,6 +234,7 @@ void App::OnWindowSizeChanged(CoreWindow^ /*sender*/, WindowSizeChangedEventArgs
 {
     size_t width = static_cast<size_t>(args->Size.Width * m_displayScale);
     size_t height = static_cast<size_t>(args->Size.Height * m_displayScale);
+    Babylon::Plugins::NativeEngine::Resize(width, height);
     m_runtime->Dispatch([width, height](Napi::Env env)
     {
         Babylon::Plugins::NativeWindow::UpdateSize(env, width, height);

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -153,7 +153,6 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
     size_t width = static_cast<size_t>(bounds.Width * m_displayScale);
     size_t height = static_cast<size_t>(bounds.Height * m_displayScale);
     auto* windowPtr = reinterpret_cast<ABI::Windows::UI::Core::ICoreWindow*>(CoreWindow::GetForCurrentThread());
-    Babylon::Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height, true);
     m_runtime->Dispatch([&runtime = m_runtime, &inputBuffer = m_inputBuffer, windowPtr, width, height](Napi::Env env)
     {
         Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto)
@@ -167,6 +166,7 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
         Babylon::Plugins::NativeWindow::Initialize(env, windowPtr, width, height);
 
         // Initialize NativeEngine plugin.
+        Babylon::Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height, true);
         Babylon::Plugins::NativeEngine::Initialize(env);
 
         // Initialize NativeXr plugin.

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -101,7 +101,7 @@ namespace
 
         auto width = static_cast<size_t>(rect.right - rect.left);
         auto height = static_cast<size_t>(rect.bottom - rect.top);
-        Babylon::Plugins::NativeEngine::InitializeGraphics(hWnd, width, height);
+        Babylon::Plugins::NativeEngine::InitializeGraphics(hWnd, width, height, true);
 
         // Initialize console plugin.
         runtime->Dispatch([rect, hWnd](Napi::Env env) {
@@ -192,21 +192,13 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     MSG msg;
 
     // Main message loop:
-    while (true) // 
+    while (GetMessage(&msg, nullptr, 0, 0))
     {
-        while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
+        if (!TranslateAccelerator(msg.hwnd, hAccelTable, &msg))
         {
-            if (!TranslateAccelerator(msg.hwnd, hAccelTable, &msg))
-            {
-                TranslateMessage(&msg);
-                DispatchMessage(&msg);
-            }
+            TranslateMessage(&msg);
+            DispatchMessage(&msg);
         }
-        if (msg.message == WM_QUIT)
-        {
-            break;
-        }
-        Babylon::Plugins::NativeEngine::Render();
     }
 
     return (int)msg.wParam;

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -99,6 +99,10 @@ namespace
             return;
         }
 
+        auto width = static_cast<size_t>(rect.right - rect.left);
+        auto height = static_cast<size_t>(rect.bottom - rect.top);
+        Babylon::Plugins::NativeEngine::InitializeGraphics(hWnd, width, height);
+
         // Initialize console plugin.
         runtime->Dispatch([rect, hWnd](Napi::Env env) {
             Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
@@ -114,7 +118,7 @@ namespace
             Babylon::Plugins::NativeWindow::Initialize(env, hWnd, width, height);
 
             // Initialize NativeEngine plugin.
-            Babylon::Plugins::NativeEngine::InitializeGraphics(hWnd, width, height);
+            
             Babylon::Plugins::NativeEngine::Initialize(env);
 
             // Initialize NativeXr plugin.
@@ -156,6 +160,7 @@ namespace
 
     void UpdateWindowSize(size_t width, size_t height)
     {
+        Babylon::Plugins::NativeEngine::Resize(width, height);
         runtime->Dispatch([width, height](Napi::Env env) {
             Babylon::Plugins::NativeWindow::UpdateSize(env, width, height);
         });
@@ -188,13 +193,21 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     MSG msg;
 
     // Main message loop:
-    while (GetMessage(&msg, nullptr, 0, 0))
+    while (true) // 
     {
-        if (!TranslateAccelerator(msg.hwnd, hAccelTable, &msg))
+        while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
         {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
+            if (!TranslateAccelerator(msg.hwnd, hAccelTable, &msg))
+            {
+                TranslateMessage(&msg);
+                DispatchMessage(&msg);
+            }
         }
+        if (msg.message == WM_QUIT)
+        {
+            break;
+        }
+        Babylon::Plugins::NativeEngine::Render();
     }
 
     return (int)msg.wParam;

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -99,10 +99,6 @@ namespace
             return;
         }
 
-        auto width = static_cast<size_t>(rect.right - rect.left);
-        auto height = static_cast<size_t>(rect.bottom - rect.top);
-        Babylon::Plugins::NativeEngine::InitializeGraphics(hWnd, width, height, true);
-
         // Initialize console plugin.
         runtime->Dispatch([rect, hWnd](Napi::Env env) {
             Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
@@ -118,6 +114,7 @@ namespace
             Babylon::Plugins::NativeWindow::Initialize(env, hWnd, width, height);
 
             // Initialize NativeEngine plugin.
+            Babylon::Plugins::NativeEngine::InitializeGraphics(hWnd, width, height, true);
             Babylon::Plugins::NativeEngine::Initialize(env);
 
             // Initialize NativeXr plugin.

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -118,7 +118,6 @@ namespace
             Babylon::Plugins::NativeWindow::Initialize(env, hWnd, width, height);
 
             // Initialize NativeEngine plugin.
-            
             Babylon::Plugins::NativeEngine::Initialize(env);
 
             // Initialize NativeXr plugin.
@@ -261,10 +260,10 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
         return FALSE;
     }
 
+    RefreshBabylon(hWnd);
+
     ShowWindow(hWnd, nCmdShow);
     UpdateWindow(hWnd);
-
-    RefreshBabylon(hWnd);
 
     return TRUE;
 }

--- a/Apps/Playground/X11/App.cpp
+++ b/Apps/Playground/X11/App.cpp
@@ -68,7 +68,7 @@ namespace
             Babylon::Plugins::NativeWindow::Initialize(env, (void*)(uintptr_t)window, width, height);
 
             // Initialize NativeEngine plugin.
-            Babylon::Plugins::NativeEngine::InitializeGraphics((void*)(uintptr_t)window, width, height);
+            Babylon::Plugins::NativeEngine::InitializeGraphics((void*)(uintptr_t)window, width, height, true);
             Babylon::Plugins::NativeEngine::Initialize(env);
 
             auto& jsRuntime = Babylon::JsRuntime::GetFromJavaScript(env);

--- a/Apps/Playground/iOS/LibNativeBridge.mm
+++ b/Apps/Playground/iOS/LibNativeBridge.mm
@@ -36,7 +36,7 @@ std::unique_ptr<InputManager::InputBuffer> inputBuffer{};
     float width = inWidth;
     float height = inHeight;
     void* windowPtr = view;
-    Babylon::Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height);
+    Babylon::Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height, false);
 
     runtime->Dispatch([windowPtr, width, height](Napi::Env env)
     {

--- a/Apps/Playground/macOS/ViewController.h
+++ b/Apps/Playground/macOS/ViewController.h
@@ -1,6 +1,7 @@
 #import <Cocoa/Cocoa.h>
+#import <MetalKit/MetalKit.h>
 
-@interface ViewController : NSViewController
+@interface ViewController : NSViewController <MTKViewDelegate>
 
 -(IBAction) refresh:(id)sender;
 @end

--- a/Apps/Playground/macOS/ViewController.mm
+++ b/Apps/Playground/macOS/ViewController.mm
@@ -40,7 +40,7 @@ std::unique_ptr<InputManager::InputBuffer> inputBuffer{};
     float height = size.height;
     NSWindow* nativeWindow = [[self view] window];
     void* windowPtr = (__bridge void*)nativeWindow;
-    Babylon::Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height);
+    Babylon::Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height, false);
 
     runtime->Dispatch([windowPtr, width, height](Napi::Env env)
     {

--- a/Apps/ValidationTests/Win32/App.cpp
+++ b/Apps/ValidationTests/Win32/App.cpp
@@ -115,7 +115,7 @@ namespace
                 Babylon::Plugins::NativeWindow::Initialize(env, hWnd, width, height);
 
                 // Initialize NativeEngine plugin.
-                Babylon::Plugins::NativeEngine::InitializeGraphics(hWnd, width, height);
+                Babylon::Plugins::NativeEngine::InitializeGraphics(hWnd, width, height, true);
                 Babylon::Plugins::NativeEngine::Initialize(env);
 
                 Babylon::TestUtils::CreateInstance(env, hWnd);

--- a/Apps/ValidationTests/X11/App.cpp
+++ b/Apps/ValidationTests/X11/App.cpp
@@ -68,7 +68,7 @@ namespace
             Babylon::Plugins::NativeWindow::Initialize(env, (void*)(uintptr_t)window, width, height);
 
             // Initialize NativeEngine plugin.
-            Babylon::Plugins::NativeEngine::InitializeGraphics((void*)(uintptr_t)window, width, height);
+            Babylon::Plugins::NativeEngine::InitializeGraphics((void*)(uintptr_t)window, width, height, true);
             Babylon::Plugins::NativeEngine::Initialize(env);
         });
 

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(base-n INTERFACE "base-n/include")
 # -------------------------------- bgfx.cmake --------------------------------
 # Dependencies: none
 add_compile_definitions(BGFX_CONFIG_DEBUG_UNIFORM=0)
-add_compile_definitions(BGFX_CONFIG_MULTITHREADED=1)
+add_compile_definitions(BGFX_CONFIG_MULTITHREADED=0)
 add_compile_definitions(BGFX_CONFIG_MAX_VERTEX_STREAMS=32)
 add_compile_definitions(BGFX_CONFIG_MAX_COMMAND_BUFFER_SIZE=12582912)
 if(APPLE)

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(base-n INTERFACE "base-n/include")
 # -------------------------------- bgfx.cmake --------------------------------
 # Dependencies: none
 add_compile_definitions(BGFX_CONFIG_DEBUG_UNIFORM=0)
-add_compile_definitions(BGFX_CONFIG_MULTITHREADED=0)
+add_compile_definitions(BGFX_CONFIG_MULTITHREADED=1)
 add_compile_definitions(BGFX_CONFIG_MAX_VERTEX_STREAMS=32)
 add_compile_definitions(BGFX_CONFIG_MAX_COMMAND_BUFFER_SIZE=12582912)
 if(APPLE)

--- a/Plugins/NativeEngine/Include/Babylon/Plugins/NativeEngine.h
+++ b/Plugins/NativeEngine/Include/Babylon/Plugins/NativeEngine.h
@@ -12,8 +12,7 @@ namespace Babylon::Plugins::NativeEngine
 
     void DeinitializeGraphics();
 
-
     void Resize(size_t width, size_t height);
-    void Render();
 
+    void Render();
 }

--- a/Plugins/NativeEngine/Include/Babylon/Plugins/NativeEngine.h
+++ b/Plugins/NativeEngine/Include/Babylon/Plugins/NativeEngine.h
@@ -4,7 +4,7 @@
 
 namespace Babylon::Plugins::NativeEngine
 {
-    void InitializeGraphics(void* windowPtr, size_t width, size_t height);
+    void InitializeGraphics(void* windowPtr, size_t width, size_t height, bool theadedRendering);
 
     void Initialize(Napi::Env env);
 
@@ -13,6 +13,6 @@ namespace Babylon::Plugins::NativeEngine
     void DeinitializeGraphics();
 
     void Resize(size_t width, size_t height);
-
+    // when theadedRendering is false, user is responsible for calling Render
     void Render();
 }

--- a/Plugins/NativeEngine/Include/Babylon/Plugins/NativeEngine.h
+++ b/Plugins/NativeEngine/Include/Babylon/Plugins/NativeEngine.h
@@ -11,4 +11,9 @@ namespace Babylon::Plugins::NativeEngine
     void Reinitialize(Napi::Env env, void* windowPtr, size_t width, size_t height);
 
     void DeinitializeGraphics();
+
+
+    void Resize(size_t width, size_t height);
+    void Render();
+
 }

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -578,6 +578,8 @@ namespace Babylon
 #else
         init.type = bgfx::RendererType::Direct3D11;
 #endif
+        _displayWidth = width;
+        _displayHeight = height;
         init.resolution.width = width;
         init.resolution.height = height;
         init.resolution.reset = BGFX_RESET_FLAGS;

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -373,7 +373,6 @@ namespace Babylon
 
     public:
         NativeEngine(const Napi::CallbackInfo& info);
-        NativeEngine(const Napi::CallbackInfo& info, Plugins::Internal::NativeWindow& nativeWindow);
         ~NativeEngine();
 
         static void InitializeWindow(void* nativeWindowPtr, uint32_t width, uint32_t height);
@@ -389,6 +388,8 @@ namespace Babylon
         static inline bgfx::Encoder* m_encoder{ nullptr };
         static inline bx::Semaphore m_syncEncoder;
         static inline bx::Semaphore m_syncRenderer;
+        static inline size_t _displayWidth{ 1 };
+        static inline size_t _displayHeight{ 1 };
     private:
         
         void Dispose();
@@ -480,8 +481,6 @@ namespace Babylon
 
         static inline BgfxCallback s_bgfxCallback{};
         FrameBufferManager m_frameBufferManager{};
-
-        Plugins::Internal::NativeWindow::NativeWindow::OnResizeCallbackTicket m_resizeCallbackTicket;
 
         template<int size, typename arrayType>
         void SetTypeArrayN(const Napi::CallbackInfo& info);

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -375,7 +375,7 @@ namespace Babylon
         NativeEngine(const Napi::CallbackInfo& info);
         ~NativeEngine();
 
-        static void InitializeWindow(void* nativeWindowPtr, uint32_t width, uint32_t height);
+        static void InitializeWindow(void* nativeWindowPtr, uint32_t width, uint32_t height, bool theadedRendering);
         static void DeinitializeWindow();
         static void Initialize(Napi::Env);
 
@@ -390,6 +390,7 @@ namespace Babylon
         static inline bx::Semaphore m_syncRenderer;
         static inline size_t _displayWidth{ 1 };
         static inline size_t _displayHeight{ 1 };
+        static inline bool _theadedRendering{ false };
     private:
         
         void Dispose();

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -2,7 +2,7 @@
 
 #include "ShaderCompiler.h"
 #include "BgfxCallback.h"
-
+#include <bx/semaphore.h>
 #include <Babylon/JsRuntime.h>
 #include <Babylon/JsRuntimeScheduler.h>
 
@@ -154,13 +154,7 @@ namespace Babylon
 
     private:
 
-        void Update() const
-        {
-            bgfx::setViewClear(m_viewId, m_clearState.Flags, m_clearState.Color(), m_clearState.Depth, m_clearState.Stencil);
-            // discard any previous set state
-            bgfx::discard();
-            bgfx::touch(m_viewId);
-        }
+        void Update() const;
 
         uint16_t m_viewId{};
         ClearState& m_clearState;
@@ -390,7 +384,13 @@ namespace Babylon
         void Dispatch(std::function<void()>);
         void EndFrame();
 
+        static void UpdateSize(size_t width, size_t height);
+        static void Render();
+        static inline bgfx::Encoder* m_encoder{ nullptr };
+        static inline bx::Semaphore m_syncEncoder;
+        static inline bx::Semaphore m_syncRenderer;
     private:
+        
         void Dispose();
 
         void Dispose(const Napi::CallbackInfo& info);
@@ -463,7 +463,7 @@ namespace Babylon
         void GetFramebufferData(const Napi::CallbackInfo& info);
         Napi::Value GetRenderAPI(const Napi::CallbackInfo& info);
 
-        void UpdateSize(size_t width, size_t height);
+        
 
         arcana::cancellation_source m_cancelSource{};
 
@@ -496,5 +496,7 @@ namespace Babylon
         std::vector<float> m_scratch{};
         
         Napi::FunctionReference m_requestAnimationFrameCalback{};
+
+        
     };
 }

--- a/Plugins/NativeEngine/Source/NativeEngineAPI.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngineAPI.cpp
@@ -5,9 +5,9 @@
 
 namespace Babylon::Plugins::NativeEngine
 {
-    void InitializeGraphics(void* windowPtr, size_t width, size_t height)
+    void InitializeGraphics(void* windowPtr, size_t width, size_t height, bool theadedRendering)
     {
-        Babylon::NativeEngine::InitializeWindow(windowPtr, static_cast<uint32_t>(width), static_cast<uint32_t>(height));
+        Babylon::NativeEngine::InitializeWindow(windowPtr, static_cast<uint32_t>(width), static_cast<uint32_t>(height), theadedRendering);
     }
 
     void Initialize(Napi::Env env)

--- a/Plugins/NativeEngine/Source/NativeEngineAPI.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngineAPI.cpp
@@ -34,4 +34,14 @@ namespace Babylon::Plugins::NativeEngine
     {
         Babylon::NativeEngine::DeinitializeWindow();
     }
+
+    void Resize(size_t width, size_t height)
+    {
+        Babylon::NativeEngine::UpdateSize(width, height);
+    }
+
+    void Render()
+    {
+        Babylon::NativeEngine::Render();
+    }
 }


### PR DESCRIPTION
Unlike Android and Windows, on iOS bgfx init and resize must happen on main thread.
And because of that, rendering must also happen on the main thread (resizing when doing rendering on another thread crashes the app)
I tried with locks here and there without getting 100% reliable behavior. That's why I ended up doing this bgfx encoder Proof of concept.

You can record rendering commands on an encoder. All encoding streams will be effectively send to the graphics driver when calling bgfx::frame.

There are 2 semaphores involved here. The bgfx good practice is to create an encoder, record commands, and repeat. If there is no more encode available, then skip rendering until bgfx is called and flushes the encoders. With 1 semaphore I usually get all encoders (8) used before getting to bgfx::frame. So I had to sync in both ways.

I also had to change the win32 loop. I don't know yet how to do the same with Android. 

The good part of this for some integration is you get your rendering when you call ```Babylon::Plugins::NativeEngine::Render();```
POC, not meant to be merged in this state. Only tested with the cube.