### PR TITLE
Anchors for ARKit

### DIFF
--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -75,8 +75,6 @@ namespace xr
     {
         Pose Pose{};
         NativeAnchorPtr NativeAnchor{};
-        struct Pose Offset{};
-        bool isAnchorOwned{true};
         bool IsValid{true};
     };
 

--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -75,6 +75,8 @@ namespace xr
     {
         Pose Pose{};
         NativeAnchorPtr NativeAnchor{};
+        struct Pose Offset{};
+        bool isAnchorOwned{true};
         bool IsValid{true};
     };
 

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -31,7 +31,6 @@ namespace {
      Helper function to convert a transform into an xr::pose.
      */
     static xr::Pose TransformToPose(simd_float4x4 transform){
-        
         // Set orientation.
         xr::Pose pose{};
         auto orientation = simd_quaternion(transform);
@@ -733,7 +732,7 @@ namespace xr {
         }
         
         /**
-         Create an ARKit anchor for the given pose and/or hit test result.
+         Create an ARKit anchor for the given pose.
          */
         xr::Anchor CreateAnchor(Pose pose){
             // Pull out the pose into a float 4x4 transform that is usable by ARKit.
@@ -771,7 +770,6 @@ namespace xr {
                 auto arAnchor = reinterpret_cast<ARAnchor*>(anchor.NativeAnchor);
                 anchor.NativeAnchor = nil;
 
-                [session removeAnchor:arAnchor];
                 CleanupAnchor(arAnchor);
             }
         }

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -31,11 +31,10 @@ namespace {
      Helper function to convert a transform into an xr::pose.
      */
     static xr::Pose TransformToPose(simd_float4x4 transform){
-        //Pull out the rotation.
-        auto orientation = simd_quaternion(transform);
         
-        // set the orientation;
+        // Set orientation.
         xr::Pose pose{};
+        auto orientation = simd_quaternion(transform);
         pose.Orientation = { orientation.vector.x
             , orientation.vector.y
             , orientation.vector.z
@@ -720,17 +719,13 @@ namespace xr {
                         
                         // Process the results and push them into the results list.
                         for (ARRaycastResult* result in rayCastResults) {
-                            auto hitResult = transformToHitResult(result.worldTransform);
-                            hitResult.NativeTrackable = result.anchor;
-                            filteredResults.push_back(hitResult);
+                            filteredResults.push_back(transformToHitResult(result.worldTransform));
                         }
                     } else {
                         // On iOS versions prior to 13, fall back to doing a raycast from a screen point, for now don't support translating the offset ray.
                         auto hitTestResults = [session.currentFrame hitTest:CGPointMake(.5, .5) types:(ARHitTestResultTypeExistingPlane)];
                         for (ARHitTestResult* result in hitTestResults) {
-                            auto hitResult = transformToHitResult(result.worldTransform);
-                            hitResult.NativeTrackable = result.anchor;
-                            filteredResults.push_back(hitResult);
+                            filteredResults.push_back(transformToHitResult(result.worldTransform));
                         }
                     }
                 }
@@ -741,7 +736,7 @@ namespace xr {
          Create an ARKit anchor for the given pose and/or hit test result.
          */
         xr::Anchor CreateAnchor(Pose pose){
-            // Pull out the transform into a pose.
+            // Pull out the pose into a float 4x4 transform that is usable by ARKit.
             auto poseTransform = PoseToTransform(pose);
             
             // Create the anchor and add it to the ARKit session.
@@ -767,7 +762,7 @@ namespace xr {
         }
         
         /**
-         Deletes the ArKit anchor associated with this anchor if it still exists.
+         Deletes the ArKit anchor associated with this XR anchor if it still exists.
          */
         void DeleteAnchor(xr::Anchor& anchor) {
             // If this anchor has not already been deleted, then remove it from the current AR session,
@@ -782,7 +777,7 @@ namespace xr {
         }
         
         /**
-         Deallocates the native ARKit anchor object, and removes it from our anchor list.
+         Deallocates the native ARKit anchor object, and removes it from the anchor list.
          */
         void CleanupAnchor(ARAnchor* arAnchor)
         {

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -30,14 +30,14 @@ namespace {
     /**
      Helper function to convert a transform into an xr::pose.
      */
-    static xr::Pose TransformToPose(simd_float4x4 transform){
+    static xr::Pose TransformToPose(simd_float4x4 transform) {
         // Set orientation.
         xr::Pose pose{};
         auto orientation = simd_quaternion(transform);
         pose.Orientation = { orientation.vector.x
             , orientation.vector.y
             , orientation.vector.z
-            , orientation.vector.w};
+            , orientation.vector.w };
         
         // Set the translation.
         pose.Position = { transform.columns[3][0]
@@ -50,7 +50,7 @@ namespace {
     /**
      Helper function to convert an xr pose into a transform.
      */
-    static simd_float4x4 PoseToTransform(xr::Pose pose){
+    static simd_float4x4 PoseToTransform(xr::Pose pose) {
         auto poseQuaternion = simd_quaternion(pose.Orientation.X, pose.Orientation.Y, pose.Orientation.Z, pose.Orientation.W);
         auto poseTransform = simd_matrix4x4(poseQuaternion);
         poseTransform.columns[3][0] = pose.Position.X;
@@ -734,7 +734,7 @@ namespace xr {
         /**
          Create an ARKit anchor for the given pose.
          */
-        xr::Anchor CreateAnchor(Pose pose){
+        xr::Anchor CreateAnchor(Pose pose) {
             // Pull out the pose into a float 4x4 transform that is usable by ARKit.
             auto poseTransform = PoseToTransform(pose);
             
@@ -777,8 +777,7 @@ namespace xr {
         /**
          Deallocates the native ARKit anchor object, and removes it from the anchor list.
          */
-        void CleanupAnchor(ARAnchor* arAnchor)
-        {
+        void CleanupAnchor(ARAnchor* arAnchor) {
             // Iterate over the list of anchors if arAnchor is nil then clean up all anchors
             // otherwise clean up only the target anchor and return.
             auto anchorIter = nativeAnchors.begin();


### PR DESCRIPTION
Implementing Create/Update/Delete support for anchors on ARKit.  This is the iOS equivalent of #289, and is part of the ARKit support described in #278.

This essentially works the same way as on Android.  We create a new ARKit anchor at the given pose, and update it once per frame as part of the WebXR update loop.  The main difference here is you cannot tie an ARKit anchor to a given plane, so we instead always create an independently tracked anchor whether we're given a hit result or not.