### PR TITLE
Compensate aspect ratio AR

### DIFF
--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -221,25 +221,6 @@ namespace {
     float fov =  atanf(1 / yScale);
     frameView.FieldOfView.AngleDown = -(frameView.FieldOfView.AngleUp = fov);
     frameView.FieldOfView.AngleLeft = -(frameView.FieldOfView.AngleRight = fov * aspectRatio);
-    
-    // Angles for FieldOfView respect the viewport ratio
-    // but tangent is not a linear function and ratio of values(l,r,b,t) computed
-    // in CreateProjectionMatrix do not respect that ratio
-    // so, here, a ratio after tangent is computed
-    // and a second derivative ratio computed to compensate
-    // the aspect ratio delta after tangent calls
-    const float n = frameView.DepthNearZ;
-    const float r{std::tanf(frameView.FieldOfView.AngleRight) * n};
-    const float l{std::tanf(frameView.FieldOfView.AngleLeft) * n};
-    const float t{std::tanf(frameView.FieldOfView.AngleUp) * n};
-    const float b{std::tanf(frameView.FieldOfView.AngleDown) * n};
-    
-    float deltax = (r - l);
-    float deltay = (t - b);
-    float afterTangentAspectRatio = deltax / deltay;
-    float compensationRatio = afterTangentAspectRatio / aspectRatio;
-    frameView.FieldOfView.AngleDown *= compensationRatio;
-    frameView.FieldOfView.AngleUp *= compensationRatio;
 }
 
 /**

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -221,6 +221,25 @@ namespace {
     float fov =  atanf(1 / yScale);
     frameView.FieldOfView.AngleDown = -(frameView.FieldOfView.AngleUp = fov);
     frameView.FieldOfView.AngleLeft = -(frameView.FieldOfView.AngleRight = fov * aspectRatio);
+    
+    // Angles for FieldOfView respect the viewport ratio
+    // but tangent is not a linear function and ratio of values(l,r,b,t) computed
+    // in CreateProjectionMatrix do not respect that ratio
+    // so, here, a ratio after tangent is computed
+    // and a second derivative ratio computed to compensate
+    // the aspect ratio delta after tangent calls
+    const float n = frameView.DepthNearZ;
+    const float r{std::tanf(frameView.FieldOfView.AngleRight) * n};
+    const float l{std::tanf(frameView.FieldOfView.AngleLeft) * n};
+    const float t{std::tanf(frameView.FieldOfView.AngleUp) * n};
+    const float b{std::tanf(frameView.FieldOfView.AngleDown) * n};
+    
+    float deltax = (r - l);
+    float deltay = (t - b);
+    float afterTangentAspectRatio = deltax / deltay;
+    float compensationRatio = afterTangentAspectRatio / aspectRatio;
+    frameView.FieldOfView.AngleDown *= compensationRatio;
+    frameView.FieldOfView.AngleUp *= compensationRatio;
 }
 
 /**

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -54,8 +54,22 @@ namespace
         const float t{std::tanf(view.FieldOfView.AngleUp) * n};
         const float b{std::tanf(view.FieldOfView.AngleDown) * n};
 
+        // Angles for FieldOfView respect the viewport ratio
+        // but tangent is not a linear function and ratio of values(l,r,b,t) computed
+        // in CreateProjectionMatrix do not respect that ratio
+        // so, here, a ratio after tangent is computed
+        // and a second derivative ratio computed to compensate
+        // the aspect ratio delta after tangent calls
+        const float aspectRatio = static_cast<float>(view.ColorTextureSize.Width) / static_cast<float>(view.ColorTextureSize.Height);
+        const float deltax = (r - l);
+        const float deltay = (t - b);
+        const float afterTangentAspectRatio = deltax / deltay;
+        const float compensationRatio = afterTangentAspectRatio / aspectRatio;
+        const float tc{std::tanf(view.FieldOfView.AngleUp * compensationRatio) * n};
+        const float bc{std::tanf(view.FieldOfView.AngleDown * compensationRatio) * n};
+
         std::array<float, 16> bxResult{};
-        bx::mtxProj(bxResult.data(), t, b, l, r, n, f, false, bx::Handness::Right);
+        bx::mtxProj(bxResult.data(), tc, bc, l, r, n, f, false, bx::Handness::Right);
 
         return bxResult;
     }


### PR DESCRIPTION
Long story short, the aspect ratio is not good when creating the projectionMatrix because tan function is not linear.
So, I've added code to compensate the ratio deviation. I didn't want to do the change in NativeXR to not break the existing.