### PR TITLE
Unicode fixes for NAPI/JSI

### DIFF
--- a/Dependencies/napi/napi-jsi/include/napi/napi-inl.h
+++ b/Dependencies/napi/napi-jsi/include/napi/napi-inl.h
@@ -1,4 +1,7 @@
 #include <stdexcept>
+#include <locale>
+#include <codecvt>
+#include <cstring>
 
 namespace Napi {
 
@@ -342,24 +345,21 @@ inline String String::New(napi_env env, const std::u16string& val) {
 }
 
 inline String String::New(napi_env env, const char* val) {
-  return String(env, {env->rt, jsi::String::createFromUtf8(env->rt, val)});
+  return {env, {env->rt, jsi::String::createFromUtf8(env->rt, reinterpret_cast<const uint8_t*>(val), std::strlen(val))}};
 }
 
 inline String String::New(napi_env env, const char16_t* val) {
-  (void)env;
-  (void)val;
-  throw std::runtime_error("TODO");
+  std::string u8{std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>{}.to_bytes(val)};
+  return {env, {env->rt, jsi::String::createFromUtf8(env->rt, u8)}};
 }
 
 inline String String::New(napi_env env, const char* val, size_t length) {
-  return String(env, {env->rt, jsi::String::createFromUtf8(env->rt, reinterpret_cast<const uint8_t*>(val), length)});
+  return {env, {env->rt, jsi::String::createFromUtf8(env->rt, reinterpret_cast<const uint8_t*>(val), length)}};
 }
 
 inline String String::New(napi_env env, const char16_t* val, size_t length) {
-  (void)env;
-  (void)val;
-  (void)length;
-  throw std::runtime_error("TODO");
+  std::string u8{std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>{}.to_bytes(val, val + length)};
+  return {env, {env->rt, jsi::String::createFromUtf8(env->rt, u8)}};
 }
 
 inline String::String(napi_env env, jsi::Value value)

--- a/Polyfills/Window/Source/Window.cpp
+++ b/Polyfills/Window/Source/Window.cpp
@@ -77,23 +77,10 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value Window::DecodeBase64(const Napi::CallbackInfo& info)
     {
-        std::string encoded = info[0].As<Napi::String>().Utf8Value();
-        std::vector<uint8_t> decoded;
-        bn::decode_b64(encoded.begin(), encoded.end(), std::back_inserter(decoded));
-        std::string utf8;
-        for (uint8_t ch : decoded)
-        {
-           if (ch < 0x80)
-           {
-              utf8.push_back(ch);
-           }
-           else
-           {
-              utf8.push_back(0xC0 | (ch >> 6));
-              utf8.push_back(0x80 | (ch & 0x3F));
-           }
-        }
-        return Napi::Value::From(info.Env(), utf8);
+        std::string encodedData = info[0].As<Napi::String>().Utf8Value();
+        std::u16string decodedData;
+        bn::decode_b64(encodedData.begin(), encodedData.end(), std::back_inserter(decodedData));
+        return Napi::Value::From(info.Env(), decodedData);
     }
 
     void Window::AddEventListener(const Napi::CallbackInfo& /*info*/)


### PR DESCRIPTION
Unicode conversion is a mess in C++. Using codecvt directly results in crashes on certain platforms. But using deprecated codecvt facets API works just fine.