### PR TITLE
Disabled certain V8 warnings

### DIFF
--- a/Core/AppRuntime/Source/AppRuntimeV8.cpp
+++ b/Core/AppRuntime/Source/AppRuntimeV8.cpp
@@ -1,6 +1,8 @@
 #include "AppRuntime.h"
 
+#ifndef __clang__
 #pragma warning(disable : 4100 4267)
+#endif
 #include <v8.h>
 #include <libplatform/libplatform.h>
 

--- a/Core/AppRuntime/Source/AppRuntimeV8.cpp
+++ b/Core/AppRuntime/Source/AppRuntimeV8.cpp
@@ -1,5 +1,6 @@
 #include "AppRuntime.h"
 
+#pragma warning(disable : 4100 4267)
 #include <v8.h>
 #include <libplatform/libplatform.h>
 

--- a/Dependencies/napi/napi-direct/source/js_native_api_v8.cc
+++ b/Dependencies/napi/napi-direct/source/js_native_api_v8.cc
@@ -51,7 +51,9 @@
     (out) = v8::type::New((buffer), (byte_offset), (length));                  \
   } while (0)
 
+#ifndef __clang__
 #pragma warning(disable: 4100 4267)
+#endif
 
 namespace v8impl {
 

--- a/Dependencies/napi/napi-direct/source/js_native_api_v8.cc
+++ b/Dependencies/napi/napi-direct/source/js_native_api_v8.cc
@@ -51,6 +51,8 @@
     (out) = v8::type::New((buffer), (byte_offset), (length));                  \
   } while (0)
 
+#pragma warning(disable: 4100 4267)
+
 namespace v8impl {
 
 namespace {


### PR DESCRIPTION
Disabled certain V8 warnings that were causing problems due to warnings being treated as errors. These errors were preventing usage of V8 by a partner team. Will open an issue to track this to determine whether we want to fix these warnings in our V8 implementation (which might introduce deviation from versions in other N-API repos), though even that wouldn't fix the warnings coming from the V8 files from the NuGet.