### PR TITLE
Fix OpenXR debug build break in Plane Detection

### DIFF
--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -878,6 +878,6 @@ namespace xr
 
     void System::Session::SetPlaneDetectionEnabled(bool) const
     {
-        assert(!enabled);
+        throw std::runtime_error("Planes not yet implemented for OpenXR");
     }
 }


### PR DESCRIPTION
Incorrectly trying to turn on disabled features will crash the app either way if someone tries to enable plane detection so I think the right thing to do is just throw like all the other unsupported features.