### PR TITLE
replaced bindbuffer function with bindvertexarray calls

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -503,7 +503,6 @@ namespace Babylon
                     },
                     &m_bytes);
 
-                m_vertexLayoutHandle = bgfx::createVertexLayout(layout);
                 m_handle = bgfx::createVertexBuffer(memory, layout);
             };
             const auto dynamic = [&layout, this](auto handle) {
@@ -519,7 +518,6 @@ namespace Babylon
                     },
                     &m_bytes);
 
-                m_vertexLayoutHandle = bgfx::createVertexLayout(layout);
                 m_handle = bgfx::createDynamicVertexBuffer(memory, layout);
             };
             DoForHandleTypes(nonDynamic, dynamic);
@@ -546,9 +544,8 @@ namespace Babylon
             DoForHandleTypes(nonDynamic, dynamic);
         }
 
-        void SetAsBgfxVertexBuffer(uint8_t index, uint32_t startVertex) const
+        void SetAsBgfxVertexBuffer(uint8_t index, uint32_t startVertex, bgfx::VertexLayoutHandle layout) const
         {
-            bgfx::VertexLayoutHandle layout{ m_vertexLayoutHandle };
             const auto nonDynamic = [index, startVertex, layout](auto handle) {
                 bgfx::setVertexBuffer(index, handle, startVertex, UINT32_MAX, layout);
             };
@@ -560,7 +557,6 @@ namespace Babylon
 
     private:
         std::vector<uint8_t> m_bytes{};
-        bgfx::VertexLayoutHandle m_vertexLayoutHandle{};
     };
 
     void NativeEngine::InitializeWindow(void* nativeWindowPtr, uint32_t width, uint32_t height)
@@ -667,7 +663,6 @@ namespace Babylon
                 InstanceMethod("setViewPort", &NativeEngine::SetViewPort),
                 InstanceMethod("getFramebufferData", &NativeEngine::GetFramebufferData),
                 InstanceMethod("getRenderAPI", &NativeEngine::GetRenderAPI),
-                InstanceMethod("bindBuffer", &NativeEngine::BindBuffer),
             });
 
         env.Global().Get(JsRuntime::JS_NATIVE_NAME).As<Napi::Object>().Set(JS_ENGINE_CONSTRUCTOR_NAME, func);
@@ -768,39 +763,21 @@ namespace Babylon
         delete info[0].As<Napi::External<VertexArray>>().Data();
     }
 
-    void NativeEngine::BindBuffer(const Napi::CallbackInfo& info)
-    {
-        VertexBufferData* vertexBufferData = info[0].As<Napi::External<VertexBufferData>>().Data();
-
-        const uint32_t location = info[1].As<Napi::Number>().Uint32Value();
-        const uint32_t byteStride = info[3].As<Napi::Number>().Uint32Value();
-        const uint32_t numElements = info[4].As<Napi::Number>().Uint32Value();
-        const uint32_t type = info[5].As<Napi::Number>().Uint32Value();
-        const bool normalized = info[6].As<Napi::Boolean>().Value();
-
-        bgfx::VertexLayout vertexLayout{};
-        vertexLayout.begin();
-        const bgfx::Attrib::Enum attrib = static_cast<bgfx::Attrib::Enum>(location);
-        const bgfx::AttribType::Enum attribType = ConvertAttribType(static_cast<WebGLAttribType>(type));
-        vertexLayout.add(attrib, static_cast<uint8_t>(numElements), attribType, normalized);
-        vertexLayout.m_stride = static_cast<uint16_t>(byteStride);
-        vertexLayout.end();
-
-        vertexBufferData->EnsureFinalized(info.Env(), vertexLayout);
-        vertexBufferData->SetAsBgfxVertexBuffer(static_cast<uint8_t>(location), 0);
-    }
-
     void NativeEngine::BindVertexArray(const Napi::CallbackInfo& info)
     {
         const auto& vertexArray = *(info[0].As<Napi::External<VertexArray>>().Data());
 
-        vertexArray.indexBuffer.data->SetBgfxIndexBuffer();
+        // a vertex array might not have an index buffer associated with
+        if (vertexArray.indexBuffer.data)
+        {
+            vertexArray.indexBuffer.data->SetBgfxIndexBuffer();
+        }
 
         const auto& vertexBuffers = vertexArray.vertexBuffers;
         for (uint8_t index = 0; index < vertexBuffers.size(); ++index)
         {
             const auto& vertexBuffer = vertexBuffers[index];
-            vertexBuffer.data->SetAsBgfxVertexBuffer(index, vertexBuffer.startVertex);
+            vertexBuffer.data->SetAsBgfxVertexBuffer(index, vertexBuffer.startVertex, vertexBuffer.vertexLayoutHandle);
         }
     }
 
@@ -874,7 +851,7 @@ namespace Babylon
 
         vertexBufferData->EnsureFinalized(info.Env(), vertexLayout);
 
-        vertexArray.vertexBuffers.push_back({vertexBufferData, byteOffset / byteStride});
+        vertexArray.vertexBuffers.push_back({vertexBufferData, byteOffset / byteStride, bgfx::createVertexLayout(vertexLayout) });
     }
 
     void NativeEngine::UpdateDynamicVertexBuffer(const Napi::CallbackInfo& info)

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -356,6 +356,14 @@ namespace Babylon
 
     struct VertexArray final
     {
+        ~VertexArray()
+        {
+            for (auto& vertexBuffer : vertexBuffers)
+            {
+                bgfx::destroy(vertexBuffer.vertexLayoutHandle);
+            }
+        }
+
         struct IndexBuffer
         {
             const IndexBufferData* data{};
@@ -367,6 +375,7 @@ namespace Babylon
         {
             const VertexBufferData* data{};
             uint32_t startVertex{};
+            bgfx::VertexLayoutHandle vertexLayoutHandle{};
         };
 
         std::vector<VertexBuffer> vertexBuffers{};
@@ -461,7 +470,6 @@ namespace Babylon
         Napi::Value GetRenderHeight(const Napi::CallbackInfo& info);
         void SetViewPort(const Napi::CallbackInfo& info);
         void GetFramebufferData(const Napi::CallbackInfo& info);
-        void BindBuffer(const Napi::CallbackInfo& info);
         Napi::Value GetRenderAPI(const Napi::CallbackInfo& info);
 
         void UpdateSize(size_t width, size_t height);


### PR DESCRIPTION
fixes #358 
babylon.max.js version with commit https://github.com/BabylonJS/Babylon.js/pull/8697/commits/7dd3d8607015a4b95aec52039ee558092e981b54
PR on babylonjs : https://github.com/BabylonJS/Babylon.js/pull/8697
Use a vertex array object instead of binding individual streams

tested ok win32, Android and iOS