### PR TITLE
Change XRViewerPose.Update to set the transform of the ViewerPose

### DIFF
--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -713,10 +713,13 @@ namespace Babylon
             {
             }
 
-            void Update(const Napi::CallbackInfo& info, const xr::System::Session::Frame::Space& space, gsl::span<const xr::System::Session::Frame::View> views)
+            void Update(const Napi::CallbackInfo& info, const xr::System::Session::Frame::Space&, gsl::span<const xr::System::Session::Frame::View> views)
             {
                 // Update the transform.
-                m_transform.Update(space, true);
+                if (views.size() > 0)
+                {
+                    m_transform.Update(views[0].Space, true);
+                }
 
                 // Update the views array if necessary.
                 const auto oldSize = static_cast<uint32_t>(m_views.size());

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -713,9 +713,10 @@ namespace Babylon
             {
             }
 
-            void Update(const Napi::CallbackInfo& info, const xr::System::Session::Frame::Space&, gsl::span<const xr::System::Session::Frame::View> views)
+            void Update(const Napi::CallbackInfo& info, gsl::span<const xr::System::Session::Frame::View> views)
             {
-                // Update the transform.
+                // Update the transform, for now assume that the pose of the first view if it exists represents the viewer transform.
+                // This is correct for devices with a single view, but is likely incorrect for devices with multiple views (eg. VR/AR headsets with binocular views).
                 if (views.size() > 0)
                 {
                     m_transform.Update(views[0].Space, true);
@@ -1416,8 +1417,7 @@ namespace Babylon
 
                 // Updating the reference space is currently not supported. Until it is, we assume the
                 // reference space is unmoving at identity (which is usually true).
-
-                m_xrViewerPose.Update(info, {{{0, 0, 0}, {0, 0, 0, 1}}}, m_frame->Views);
+                m_xrViewerPose.Update(info, m_frame->Views);
 
                 return m_jsXRViewerPose.Value();
             }


### PR DESCRIPTION
This change changes the logic of XRViewerPose.Update to populate its transform with the pose of the first active view.

The XRViewerPose's transform is supposed to represent the position of the "Viewer" (i.e. phone, headset, or other tracked device) relative to a given reference space.  

This change assuming this pose is equal to that of the first active view.  This works for screen based viewers such as a phone or tablet, but is likely incorrect for devices with multiple views.  We will need to come up with a proper way to represent the viewer for these cases.