### PR TITLE
Enable hit testing against different entityTypes in BabylonNative

### DIFF
--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -4,8 +4,8 @@ var logfps = true;
 var ibl = false;
 var rtt = false;
 var vr = false;
-var ar = true;
-var xrHitTest = true;
+var ar = false;
+var xrHitTest = false;
 var text = false;
 
 function CreateBoxAsync() {
@@ -136,11 +136,13 @@ CreateBoxAsync().then(function () {
         setTimeout(function () {
             scene.createDefaultXRExperienceAsync({ disableDefaultUI: true, disableTeleportation: true }).then((xr) => {
                 if (xrHitTest) {
+                    // Create the hit test module. OffsetRay specifies the target direction, and entityTypes can be any combination of "mesh", "plane", and "polygon".
                     const xrHitTestModule = xr.baseExperience.featuresManager.enableFeature(
                         BABYLON.WebXRFeatureName.HIT_TEST,
                         "latest",
-                         {offsetRay: {origin: {x: 0, y: 0, z: 0}, direction: {x: 0, y: 0, z: -1}}, entityTypes: ["plane"]});
+                         {offsetRay: {origin: {x: 0, y: 0, z: 0}, direction: {x: 0, y: 0, z: -1}}, entityTypes: ["mesh"]});
 
+                    // When we receive hit test results, if there were any valid hits move the position of the mesh to the hit test point.
                     xrHitTestModule.onHitTestResultObservable.add((results) => {
                         if (results.length) {
                             scene.meshes[0].position.x = results[0].position.x;

--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -4,8 +4,8 @@ var logfps = true;
 var ibl = false;
 var rtt = false;
 var vr = false;
-var ar = false;
-var xrHitTest = false;
+var ar = true;
+var xrHitTest = true;
 var text = false;
 
 function CreateBoxAsync() {
@@ -139,7 +139,7 @@ CreateBoxAsync().then(function () {
                     const xrHitTestModule = xr.baseExperience.featuresManager.enableFeature(
                         BABYLON.WebXRFeatureName.HIT_TEST,
                         "latest",
-                         {offsetRay: {origin: {x: 0, y: 0, z: 0}, direction: {x: 0, y: 0, z: -1}}});
+                         {offsetRay: {origin: {x: 0, y: 0, z: 0}, direction: {x: 0, y: 0, z: -1}}, entityTypes: ["plane"]});
 
                     xrHitTestModule.onHitTestResultObservable.add((results) => {
                         if (results.length) {

--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -136,7 +136,7 @@ CreateBoxAsync().then(function () {
         setTimeout(function () {
             scene.createDefaultXRExperienceAsync({ disableDefaultUI: true, disableTeleportation: true }).then((xr) => {
                 if (xrHitTest) {
-                    // Create the hit test module. OffsetRay specifies the target direction, and entityTypes can be any combination of "mesh", "plane", and "polygon".
+                    // Create the hit test module. OffsetRay specifies the target direction, and entityTypes can be any combination of "mesh", "plane", and "point".
                     const xrHitTestModule = xr.baseExperience.featuresManager.enableFeature(
                         BABYLON.WebXRFeatureName.HIT_TEST,
                         "latest",

--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -30,6 +30,23 @@ namespace xr
         XYZ
     };
 
+    enum class HitTestTrackableType {
+        NONE = 0,
+        POINT = 1,
+        PLANE = 2,
+        MESH = 4,
+    };
+
+    constexpr enum HitTestTrackableType operator |(const enum HitTestTrackableType selfValue, const enum HitTestTrackableType inValue)
+    {
+        return (enum HitTestTrackableType)(uint32_t(selfValue) | uint32_t(inValue));
+    }
+
+    constexpr enum HitTestTrackableType operator &(const enum HitTestTrackableType selfValue, const enum HitTestTrackableType inValue)
+    {
+        return (enum HitTestTrackableType)(uint32_t(selfValue) & uint32_t(inValue));
+    }
+
     struct Size
     {
         size_t Width{};
@@ -172,7 +189,7 @@ namespace xr
                 Frame(System::Session::Impl&);
                 ~Frame();
 
-                void GetHitTestResults(std::vector<HitResult>&, Ray) const;
+                void GetHitTestResults(std::vector<HitResult>&, Ray, HitTestTrackableType) const;
                 Anchor CreateAnchor(Pose, NativeAnchorPtr) const;
                 void UpdateAnchor(Anchor&) const;
                 void DeleteAnchor(Anchor&) const;

--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -32,9 +32,9 @@ namespace xr
 
     enum class HitTestTrackableType {
         NONE = 0,
-        POINT = 1,
-        PLANE = 2,
-        MESH = 4,
+        POINT = 1 << 0,
+        PLANE = 1 << 1,
+        MESH = 1 << 2,
     };
 
     constexpr enum HitTestTrackableType operator |(const enum HitTestTrackableType selfValue, const enum HitTestTrackableType inValue)

--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -39,12 +39,18 @@ namespace xr
 
     constexpr enum HitTestTrackableType operator |(const enum HitTestTrackableType selfValue, const enum HitTestTrackableType inValue)
     {
-        return (enum HitTestTrackableType)(uint32_t(selfValue) | uint32_t(inValue));
+        return static_cast<const enum HitTestTrackableType>(std::underlying_type_t<HitTestTrackableType>(selfValue) | std::underlying_type_t<HitTestTrackableType>(inValue));
     }
 
     constexpr enum HitTestTrackableType operator &(const enum HitTestTrackableType selfValue, const enum HitTestTrackableType inValue)
     {
-        return (enum HitTestTrackableType)(uint32_t(selfValue) & uint32_t(inValue));
+        return static_cast<const enum HitTestTrackableType>(std::underlying_type_t<HitTestTrackableType>(selfValue) & std::underlying_type_t<HitTestTrackableType>(inValue));
+    }
+
+    constexpr enum HitTestTrackableType& operator |=(enum HitTestTrackableType& selfValue, const enum HitTestTrackableType inValue)
+    {
+        selfValue = selfValue | inValue;
+        return selfValue;
     }
 
     struct Size

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -674,9 +674,6 @@ namespace xr
 
                 if (trackableType == AR_TRACKABLE_PLANE)
                 {
-                    // Get the hit result pose.
-                    ArHitResult_getHitPose(session, hitResult, tempPose);
-
                     // If we are only hit testing against planes then mark the hit test as qualified otherwise check
                     // if the hit result is inside the plane mesh.
                     if ((validHitTestTypes & xr::HitTestTrackableType::PLANE) != xr::HitTestTrackableType::NONE)
@@ -686,6 +683,7 @@ namespace xr
                     else if ((validHitTestTypes & xr::HitTestTrackableType::MESH) != xr::HitTestTrackableType::NONE)
                     {
                         int32_t isPoseInPolygon{};
+                        ArHitResult_getHitPose(session, hitResult, tempPose);
                         ArPlane_isPoseInPolygon(session, (ArPlane*) trackable, tempPose, &isPoseInPolygon);
                         hitTestQualified = isPoseInPolygon != 0;
                     }
@@ -695,12 +693,12 @@ namespace xr
                     // Hit a feature point, which is valid for this hit test.
                     // Mark the result as qualified, and pull out the pose.
                     hitTestQualified = true;
-                    ArHitResult_getHitPose(session, hitResult, tempPose);
                 }
 
                 if (hitTestQualified)
                 {
                     float rawPose[7]{};
+                    ArHitResult_getHitPose(session, hitResult, tempPose);
                     ArPose_getPoseRaw(session, tempPose, rawPose);
                     HitResult hitResult{};
                     RawToPose(rawPose, hitResult.Pose);

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -667,35 +667,33 @@ namespace xr
                 ArTrackableType trackableType{};
                 ArTrackable* trackable;
 
+                bool hitTestResultValid = false;
                 ArHitResultList_getItem(session, hitResultList, i, hitResult);
                 ArHitResult_acquireTrackable(session, hitResult, &trackable);
                 ArTrackable_getType(session, trackable, &trackableType);
-                bool hitTestQualified = false;
-
                 if (trackableType == AR_TRACKABLE_PLANE)
                 {
-                    // If we are only hit testing against planes then mark the hit test as qualified otherwise check
+                    // If we are only hit testing against planes then mark the hit test as valid otherwise check
                     // if the hit result is inside the plane mesh.
                     if ((validHitTestTypes & xr::HitTestTrackableType::PLANE) != xr::HitTestTrackableType::NONE)
                     {
-                        hitTestQualified = true;
+                        hitTestResultValid = true;
                     }
                     else if ((validHitTestTypes & xr::HitTestTrackableType::MESH) != xr::HitTestTrackableType::NONE)
                     {
                         int32_t isPoseInPolygon{};
                         ArHitResult_getHitPose(session, hitResult, tempPose);
                         ArPlane_isPoseInPolygon(session, (ArPlane*) trackable, tempPose, &isPoseInPolygon);
-                        hitTestQualified = isPoseInPolygon != 0;
+                        hitTestResultValid = isPoseInPolygon != 0;
                     }
                 }
                 else if (trackableType == AR_TRACKABLE_POINT && (validHitTestTypes & xr::HitTestTrackableType::POINT) != xr::HitTestTrackableType::NONE)
                 {
-                    // Hit a feature point, which is valid for this hit test.
-                    // Mark the result as qualified, and pull out the pose.
-                    hitTestQualified = true;
+                    // Hit a feature point, which is valid for this hit test source.
+                    hitTestResultValid = true;
                 }
 
-                if (hitTestQualified)
+                if (hitTestResultValid)
                 {
                     float rawPose[7]{};
                     ArHitResult_getHitPose(session, hitResult, tempPose);

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -805,53 +805,18 @@ namespace xr {
             }
         }
 
-        void GetHitTestResults(std::vector<HitResult>& filteredResults, xr::Ray offsetRay) const {
+        void GetHitTestResults(std::vector<HitResult>& filteredResults, xr::Ray offsetRay, xr::HitTestTrackableType trackableTypes) const {
             @autoreleasepool {
                 if (session != nil && session.currentFrame != nil && session.currentFrame.camera != nil && [session.currentFrame.camera trackingState] == ARTrackingStateNormal) {
                     if (@available(iOS 13.0, *)) {
-                        // Push the camera origin into a simd_float3.
-                        auto cameraOrigin = simd_make_float3(
-                                                             ActiveFrameViews[0].Space.Pose.Position.X,
-                                                             ActiveFrameViews[0].Space.Pose.Position.Y,
-                                                             ActiveFrameViews[0].Space.Pose.Position.Z);
-                        
-                        // Push the camera direction into a simd_quaternion.
-                        auto cameraDirection = simd_quaternion(
-                                                               ActiveFrameViews[0].Space.Pose.Orientation.X,
-                                                               ActiveFrameViews[0].Space.Pose.Orientation.Y,
-                                                               ActiveFrameViews[0].Space.Pose.Orientation.Z,
-                                                               ActiveFrameViews[0].Space.Pose.Orientation.W);
-                        
-                        // Load the offset ray and direction into simd equivalents.
-                        auto offsetOrigin = simd_make_float3(offsetRay.Origin.X, offsetRay.Origin.Y, offsetRay.Origin.Z);
-                        auto offsetDirection = simd_make_float3(offsetRay.Direction.X, offsetRay.Direction.Y, offsetRay.Direction.Z);
-
-                        // Construct the ARRaycast query compositing the camera and offset ray origin + direction targetting existing plane geometry.
-                        auto raycastQuery = [[ARRaycastQuery alloc]
-                                             initWithOrigin:(cameraOrigin + offsetOrigin)
-                                             direction:simd_act(cameraDirection, offsetDirection)
-                                             allowingTarget:ARRaycastTargetExistingPlaneGeometry
-                                             alignment:ARRaycastTargetAlignmentAny];
-                        
-                        // Perform the actual raycast.
-                        auto rayCastResults = [session raycast:raycastQuery];
-                        [raycastQuery release];
-                        
-                        // Process the results and push them into the results list.
-                        for (ARRaycastResult* result in rayCastResults) {
-                            filteredResults.push_back(transformToHitResult(result.worldTransform));
-                        }
+                        GetHitTestResultsForiOS13(filteredResults, offsetRay, trackableTypes);
                     } else {
-                        // On iOS versions prior to 13, fall back to doing a raycast from a screen point, for now don't support translating the offset ray.
-                        auto hitTestResults = [session.currentFrame hitTest:CGPointMake(.5, .5) types:(ARHitTestResultTypeExistingPlane)];
-                        for (ARHitTestResult* result in hitTestResults) {
-                            filteredResults.push_back(transformToHitResult(result.worldTransform));
-                        }
+                        GetHitTestResultsLegacy(filteredResults, trackableTypes);
                     }
                 }
             }
         }
-        
+                
         /**
          Create an ARKit anchor for the given pose.
          */
@@ -1070,6 +1035,87 @@ namespace xr {
             plane.PolygonFormat = PolygonFormat::XYZ;
             updatedPlanes.push_back(plane.ID);
         }
+                
+        // For iOS 13.0 and up make use of the ARRaycastQuery protocol for raycasting against all target trackable types.
+        API_AVAILABLE(ios(13.0))
+        void GetHitTestResultsForiOS13(std::vector<HitResult>& filteredResults, xr::Ray offsetRay, xr::HitTestTrackableType trackableTypes) const{
+            // Push the camera origin into a simd_float3.
+            auto cameraOrigin = simd_make_float3(
+                                                 ActiveFrameViews[0].Space.Pose.Position.X,
+                                                 ActiveFrameViews[0].Space.Pose.Position.Y,
+                                                 ActiveFrameViews[0].Space.Pose.Position.Z);
+            
+            // Push the camera direction into a simd_quaternion.
+            auto cameraDirection = simd_quaternion(
+                                                   ActiveFrameViews[0].Space.Pose.Orientation.X,
+                                                   ActiveFrameViews[0].Space.Pose.Orientation.Y,
+                                                   ActiveFrameViews[0].Space.Pose.Orientation.Z,
+                                                   ActiveFrameViews[0].Space.Pose.Orientation.W);
+            
+            // Load the offset ray and direction into simd equivalents.
+            auto offsetOrigin = simd_make_float3(offsetRay.Origin.X, offsetRay.Origin.Y, offsetRay.Origin.Z);
+            auto offsetDirection = simd_make_float3(offsetRay.Direction.X, offsetRay.Direction.Y, offsetRay.Direction.Z);
+            auto rayOrigin = cameraOrigin + offsetOrigin;
+            auto rayDirection = simd_act(cameraDirection, offsetDirection);
+            
+            // Check which types we are meant to raycast against and perform their respective queries.
+            if ((trackableTypes & xr::HitTestTrackableType::MESH) != xr::HitTestTrackableType::NONE) {
+                PerformRaycastQueryAgainstTarget(filteredResults, ARRaycastTargetExistingPlaneGeometry, rayOrigin, rayDirection);
+            }
+            
+            if ((trackableTypes & xr::HitTestTrackableType::POINT) != xr::HitTestTrackableType::NONE) {
+                PerformRaycastQueryAgainstTarget(filteredResults, ARRaycastTargetEstimatedPlane, rayOrigin, rayDirection);
+            }
+            
+            if ((trackableTypes & xr::HitTestTrackableType::PLANE) != xr::HitTestTrackableType::NONE) {
+                PerformRaycastQueryAgainstTarget(filteredResults, ARRaycastTargetExistingPlaneInfinite, rayOrigin, rayDirection);
+            }
+        }
+        
+        API_AVAILABLE(ios(13.0))
+        void PerformRaycastQueryAgainstTarget(std::vector<HitResult>& filteredResults, ARRaycastTarget targetType, simd_float3 origin, simd_float3 direction) const {
+            auto raycastQuery = [[ARRaycastQuery alloc]
+                                 initWithOrigin:origin
+                                 direction:direction
+                                 allowingTarget:targetType
+                                 alignment:ARRaycastTargetAlignmentAny];
+            
+            // Perform the actual raycast.
+            auto rayCastResults = [session raycast:raycastQuery];
+            [raycastQuery release];
+            
+            // Process the results and push them into the results list.
+            for (ARRaycastResult* result in rayCastResults) {
+                filteredResults.push_back(transformToHitResult(result.worldTransform));
+            }
+        }
+        
+        // On iOS versions prior to 13, fall back to doing a raycast from a screen point, for now don't support translating the offset ray.
+        void GetHitTestResultsLegacy(std::vector<HitResult>& filteredResults, xr::HitTestTrackableType trackableTypes) const {
+            // First set the type filter based on the requested trackable types.
+            ARHitTestResultType typeFilter = 0;
+            if ((trackableTypes & xr::HitTestTrackableType::POINT) != xr::HitTestTrackableType::NONE) {
+                typeFilter |= ARHitTestResultTypeFeaturePoint;
+            }
+            
+            if ((trackableTypes & xr::HitTestTrackableType::PLANE) != xr::HitTestTrackableType::NONE) {
+                typeFilter |= ARHitTestResultTypeExistingPlane;
+            }
+
+            if ((trackableTypes & xr::HitTestTrackableType::POINT) != xr::HitTestTrackableType::NONE) {
+                if (@available(iOS 11.3, *)) {
+                    typeFilter |= ARHitTestResultTypeExistingPlaneUsingGeometry;
+                } else {
+                    typeFilter |= ARHitTestResultTypeExistingPlaneUsingExtent;
+                }
+            }
+
+            // Now perform the actual hit test and process the results
+            auto hitTestResults = [session.currentFrame hitTest:CGPointMake(.5, .5) types:(typeFilter)];
+            for (ARHitTestResult* result in hitTestResults) {
+                filteredResults.push_back(transformToHitResult(result.worldTransform));
+            }
+        }
     };
 
     struct System::Session::Frame::Impl {
@@ -1096,8 +1142,8 @@ namespace xr {
         m_impl->sessionImpl.DrawFrame();
     }
 
-    void System::Session::Frame::GetHitTestResults(std::vector<HitResult>& filteredResults, xr::Ray offsetRay) const {
-        m_impl->sessionImpl.GetHitTestResults(filteredResults, offsetRay);
+    void System::Session::Frame::GetHitTestResults(std::vector<HitResult>& filteredResults, xr::Ray offsetRay, xr::HitTestTrackableType trackableTypes) const {
+        m_impl->sessionImpl.GetHitTestResults(filteredResults, offsetRay, trackableTypes);
     }
 
     Anchor System::Session::Frame::CreateAnchor(Pose pose, NativeTrackablePtr) const {

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -816,7 +816,7 @@ namespace xr {
                 }
             }
         }
-                
+
         /**
          Create an ARKit anchor for the given pose.
          */

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -738,7 +738,7 @@ namespace xr
         }
     }
 
-    void System::Session::Frame::GetHitTestResults(std::vector<HitResult>&, Ray) const {
+    void System::Session::Frame::GetHitTestResults(std::vector<HitResult>&, Ray, xr::HitTestTrackableType) const {
         // Stubbed out for now, should be implemented if we want to support OpenXR based passthrough AR devices.
     }
 

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -713,10 +713,14 @@ namespace Babylon
             {
             }
 
-            void Update(const Napi::CallbackInfo& info, const xr::System::Session::Frame::Space& space, gsl::span<const xr::System::Session::Frame::View> views)
+            void Update(const Napi::CallbackInfo& info, gsl::span<const xr::System::Session::Frame::View> views)
             {
-                // Update the transform.
-                m_transform.Update(space, true);
+                // Update the transform, for now assume that the pose of the first view if it exists represents the viewer transform.
+                // This is correct for devices with a single view, but is likely incorrect for devices with multiple views (eg. VR/AR headsets with binocular views).
+                if (views.size() > 0)
+                {
+                    m_transform.Update(views[0].Space, true);
+                }
 
                 // Update the views array if necessary.
                 const auto oldSize = static_cast<uint32_t>(m_views.size());
@@ -1413,8 +1417,7 @@ namespace Babylon
 
                 // Updating the reference space is currently not supported. Until it is, we assume the
                 // reference space is unmoving at identity (which is usually true).
-
-                m_xrViewerPose.Update(info, {{{0, 0, 0}, {0, 0, 0, 1}}}, m_frame->Views);
+                m_xrViewerPose.Update(info, m_frame->Views);
 
                 return m_jsXRViewerPose.Value();
             }

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -1137,7 +1137,6 @@ namespace Babylon
                 if (options.Has("entityTypes"))
                 {
                     const auto entityTypeArray = options.Get("entityTypes").As<Napi::Array>();
-
                     for (uint32_t i = 0; i < entityTypeArray.Length(); i++)
                     {
                         const auto entityType = entityTypeArray.Get(i).As<Napi::String>().Utf8Value();

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -1156,10 +1156,10 @@ namespace Babylon
                     }
                 }
 
-                // Default to PLANE to match WebXR on Android
+                // Default to MESH if unspecified.
                 if (m_entityTypes == xr::HitTestTrackableType::NONE)
                 {
-                    m_entityTypes = xr::HitTestTrackableType::PLANE;
+                    m_entityTypes = xr::HitTestTrackableType::MESH;
                 }
             }
 

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -1142,15 +1142,15 @@ namespace Babylon
                         const auto entityType = entityTypeArray.Get(i).As<Napi::String>().Utf8Value();
                         if (entityType == XRHitTestTrackableType::POINT)
                         {
-                            m_entityTypes = m_entityTypes | xr::HitTestTrackableType::POINT;
+                            m_entityTypes |= xr::HitTestTrackableType::POINT;
                         }
                         else if (entityType == XRHitTestTrackableType::PLANE)
                         {
-                            m_entityTypes = m_entityTypes | xr::HitTestTrackableType::PLANE;
+                            m_entityTypes |= xr::HitTestTrackableType::PLANE;
                         }
                         else if (entityType == XRHitTestTrackableType::MESH)
                         {
-                            m_entityTypes = m_entityTypes | xr::HitTestTrackableType::MESH;
+                            m_entityTypes |= xr::HitTestTrackableType::MESH;
                         }
                     }
                 }


### PR DESCRIPTION
This is the BabylonNative half of Babylon.js change [#8724](https://github.com/BabylonJS/Babylon.js/pull/8724), which resolves #356.  This change enables hit testing against the three different supported entity types for WebXR: "plane", "mesh", and "point".

This just hooks up the API to the native hit test code for filtering our hit test queries.  The way I have represented the enum internally is as a bitfield enum to allow specifying multiple hit test target types.