### PR TITLE
Use correct buffer size in SetViewport

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1640,13 +1640,20 @@ namespace Babylon
         const auto width = info[2].As<Napi::Number>().FloatValue();
         const auto height = info[3].As<Napi::Number>().FloatValue();
 
-        const auto backbufferWidth = bgfx::getStats()->width;
-        const auto backbufferHeight = bgfx::getStats()->height;
+        auto backbufferWidth = bgfx::getStats()->width;
+        auto backbufferHeight = bgfx::getStats()->height;
         const float yOrigin = bgfx::getCaps()->originBottomLeft ? y : (1.f - y - height);
 
-        m_frameBufferManager.GetBound().UseViewId(m_frameBufferManager.GetNewViewId());
-        const bgfx::ViewId viewId = m_frameBufferManager.GetBound().ViewId;
-        bgfx::setViewFrameBuffer(viewId, m_frameBufferManager.GetBound().FrameBuffer);
+        auto& boundFrameBufferData = m_frameBufferManager.GetBound();
+
+        if (boundFrameBufferData.ViewId != m_frameBufferManager.DEFAULT_FRAME_BUFFER_VIEW_ID)
+        {
+            backbufferWidth = boundFrameBufferData.Width;
+            backbufferHeight = boundFrameBufferData.Height;
+        }
+
+        const bgfx::ViewId viewId = boundFrameBufferData.ViewId;
+        bgfx::setViewFrameBuffer(viewId, boundFrameBufferData.FrameBuffer);
         bgfx::setViewRect(viewId,
             static_cast<uint16_t>(x * backbufferWidth),
             static_cast<uint16_t>(yOrigin * backbufferHeight),

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -224,9 +224,11 @@ namespace Babylon
 
     struct FrameBufferManager final
     {
+        static constexpr uint16_t DEFAULT_FRAME_BUFFER_VIEW_ID = 0;
+
         FrameBufferManager()
         {
-            m_boundFrameBuffer = m_backBuffer = new FrameBufferData(BGFX_INVALID_HANDLE, GetNewViewId(), bgfx::getStats()->width, bgfx::getStats()->height);
+            m_boundFrameBuffer = m_backBuffer = new FrameBufferData(BGFX_INVALID_HANDLE, DEFAULT_FRAME_BUFFER_VIEW_ID, bgfx::getStats()->width, bgfx::getStats()->height);
         }
 
         FrameBufferData* CreateNew(bgfx::FrameBufferHandle frameBufferHandle, uint16_t width, uint16_t height)
@@ -245,7 +247,10 @@ namespace Babylon
 
             // TODO: Consider doing this only on bgfx::reset(); the effects of this call don't survive reset, but as
             // long as there's no reset this doesn't technically need to be called every time the frame buffer is bound.
-            m_boundFrameBuffer->SetUpView(GetNewViewId());
+            m_boundFrameBuffer->SetUpView(
+                m_boundFrameBuffer == m_backBuffer
+                    ? DEFAULT_FRAME_BUFFER_VIEW_ID
+                    : GetNewViewId());
 
             // bgfx::setTexture()? Why?
             // TODO: View order?
@@ -273,13 +278,13 @@ namespace Babylon
 
         void Reset()
         {
-            m_nextId = 0;
+            m_nextId = DEFAULT_FRAME_BUFFER_VIEW_ID;
         }
 
     private:
         FrameBufferData* m_boundFrameBuffer{nullptr};
         FrameBufferData* m_backBuffer{nullptr};
-        uint16_t m_nextId{0};
+        uint16_t m_nextId{DEFAULT_FRAME_BUFFER_VIEW_ID};
     };
 
     struct UniformInfo final


### PR DESCRIPTION
We were seeing a bug on some WMR HMD's as well as on HoloLens 2 where a region of the left eye view was cleared to the background color, and the region size corresponded to the size of the window created during initialization.

This was caused by two things: framebuffers being assigned view id's multiple times, and a framebuffer sharing the default framebuffer's view id after the default framebuffer is no longer used.

This fix keeps the default frame buffer distinct, as its size is tied to `bgfx::getStats()->[Width|Height]()`, so that the other bound framebuffers can be cleared properly and separately at their true sizes.