### PR TITLE
Remove bgfx::touch so that view clear doesn't clip stereo rendering

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -159,7 +159,6 @@ namespace Babylon
             bgfx::setViewClear(m_viewId, m_clearState.Flags, m_clearState.Color(), m_clearState.Depth, m_clearState.Stencil);
             // discard any previous set state
             bgfx::discard();
-            bgfx::touch(m_viewId);
         }
 
         uint16_t m_viewId{};


### PR DESCRIPTION
A preliminary fix to address (#362), we are removing the call to `bgfx::touch` which forces a clear even when no draw calls have been committed (clearing doesn't count for bgfx like it does in OpenGL, for example). This extra clear was clearing content drawn to the left eye texture for some VR HMD's (such as HP Reverb) and on HoloLens 2.

