### PR TITLE
Reduce XR swimmyness on iOS

### DIFF
--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -635,7 +635,9 @@ namespace xr {
             xrView = nil;
         }
         
-        // After the ARSession starts, it takes a little time before AR frames become available. This function just makes it easy to roll this into CreateAsync.
+        /**
+         After the ARSession starts, it takes a little time before AR frames become available. This function just makes it easy to roll this into CreateAsync.
+         */
         arcana::task<void, std::exception_ptr> WhenReady() {
             __block arcana::task_completion_source<void, std::exception_ptr> tcs;
             CFRunLoopRef mainRunLoop = CFRunLoopGetMain();

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -161,7 +161,6 @@ namespace {
  Returns the orientation of the app based on the current status bar orientation.
 */
 - (UIInterfaceOrientation)orientation {
-//    return UIInterfaceOrientationPortrait;
     auto sharedApplication = [UIApplication sharedApplication];
     auto window = sharedApplication.windows.firstObject;
     if (@available(iOS 13.0, *)) {

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -197,20 +197,20 @@ namespace {
         // Update both metal textures used by the renderer to display the camera image.
         CVMetalTextureRef newCameraTextureY = [self getCameraTexture:frame.capturedImage plane:0];
         CVMetalTextureRef newCameraTextureCbCr = [self getCameraTexture:frame.capturedImage plane:1];
-        
+
         // Swap the camera textures, do this under synchronization lock to prevent null access.
         @synchronized(self) {
             [self cleanupTextures];
             _cameraTextureY = newCameraTextureY;
             _cameraTextureCbCr = newCameraTextureCbCr;
         }
-         
+
         // Check if our orientation or size has changed and update camera UVs if necessary.
         if ([self checkAndUpdateCameraUVs:frame]) {
             // If our camera UVs updated, then also update the FoV to match the updated UVs.
             [self updateFoV:frame.camera];
         }
-        
+
         // Finally update the XR pose based on the current transform from ARKit.
         [self updateDisplayOrientedPose:(frame.camera)];
     }


### PR DESCRIPTION
XR was quite swimmy on iOS (as described in issue #74). With this change I am *attempting* to fix this. Unfortunately while it reduces the swimmyness, it still does not eliminate it, but I'm out of time for now to investigate this, so I want to check in this change since it is still an improvement.

The main change here is to try to switch from a "push" model for ARKit consumption to a "pull/poll" model. Practically what this means is to not implement the `didUpdateFrame` protocol in the `ARSessionDelegate`, and instead evaluate the `currentFrame` property of the `ARSession`. This basically makes it so ARKit only updates things when `currentFrame` is evaluated *and* a new camera frame has become available.

I can only get `currentFrame` to work correctly if called from the main thread, and unfortunately every single example I can find does everything (updating ARKit, rendering, etc.) on the main thread, so I don't really know at this point how to properly use ARKit when you own your own render thread. I will continue to see if I can get more info on this at a lower priority and expect this will take some time. In the mean time, I have to make a blocking call evaluate `currentFrame` on the main thread from the `GetNextFrame` function. This seems pretty awful, but doesn't impact perf in any noticeable way in my tests.

With these changes, swimmyness is reduced, but still present. I suspect we won't be able to sort this out until we understand exactly how to use ARKit when you own your own render thread. Because we probably need to continue this investigation and don't have high confidence in the current structure of the code, I tried to leave it in tact to make it easy to switch between the push and pull model.