### PR TITLE
Workaround for crash on startup on devices without XR runtimes.

### DIFF
--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -24,9 +24,9 @@ namespace xr
 
             return swapchainImageIndex;
         };
-    }
 
-    XrSessionContext XrRegistry::s_context{};
+        std::unique_ptr<XrSessionContext> globalXrSessionContext{};
+    }
 
     struct XrSessionContext::Impl
     {
@@ -70,6 +70,16 @@ namespace xr
     const XrSession XrSessionContext::Session() const { return ContextImpl->Session.Get(); }
     const XrSessionState XrSessionContext::State() const { return ContextImpl->State; }
     const XrSpace XrSessionContext::Space() const { return ContextImpl->SceneSpace.Get(); }
+
+    const XrSessionContext& XrRegistry::Context()
+    {
+        if (globalXrSessionContext == nullptr)
+        {
+            globalXrSessionContext = std::make_unique<XrSessionContext>();
+        }
+
+        return *globalXrSessionContext;
+    }
 
     struct System::Impl
     {

--- a/Dependencies/xr/Source/OpenXR/XrRegistry.h
+++ b/Dependencies/xr/Source/OpenXR/XrRegistry.h
@@ -23,13 +23,6 @@ namespace xr
 
     struct XrRegistry
     {
-    public:
-        static const XrSessionContext& Context()
-        {
-            return s_context;
-        }
-
-    private:
-        static XrSessionContext s_context;
+        static const XrSessionContext& Context();
     };
 }


### PR DESCRIPTION
A recent change to XR introduced the XrRegistry, which included a static member whose constructor depended upon the existence of an OpenXR runtime. This was causing the app to crash on initialization when running on a device without an OpenXR runtime because the constructor of the XrSessionContext would fail.

To avoid this, this PR switches from a static member to a global singleton, thereby avoiding static-ness as well. This isn't my favorite pattern, but it's the simplest adaptation I've thought of so far that behaves similarly to the original intent while not crashing if OpenXR isn't available. Definitely open to other designs, though, if a better one comes to mind.