### PR TITLE
Github action for night build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,36 @@
+name: Nightly build
+
+on:
+  schedule:
+    - cron: 0 23 * * 1-5
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+      with:
+        submodules: 'recursive'
+    - name: Make Solution
+      run: mkdir buildWin32_x64 && 
+        cd buildWin32_x64 &&
+        cmake -G "Visual Studio 16 2019" -A x64 ..
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.1
+    - name: Download babylon.max.js
+      run: curl.exe -o Apps\BabylonScripts/babylon.max.js https://raw.githubusercontent.com/BabylonJS/Babylon.js/master/dist/preview%20release/babylon.max.js
+    - name: Download babylonjs.materials.js
+      run: curl.exe -o Apps\BabylonScripts/babylonjs.materials.js https://raw.githubusercontent.com/BabylonJS/Babylon.js/master/dist/preview%20release/materialsLibrary/babylonjs.materials.js
+    - name: Download babylon.glTF2FileLoader.js
+      run: curl.exe -o Apps\BabylonScripts/babylon.glTF2FileLoader.js https://raw.githubusercontent.com/BabylonJS/Babylon.js/master/dist/preview%20release/loaders/babylon.glTF2FileLoader.js
+    - name: Build Win32
+      run: msbuild buildWin32_x64/BabylonNative.sln -p:Configuration="Release" -p:Platform=x64
+    - name: Make validation directories 
+      run: cd buildWin32_x64/Apps/ValidationTests &&
+          mkdir Results &&
+          mkdir Errors 
+    - name: Run Validation Tests
+      run: ./ValidationTests.exe
+      working-directory: buildWin32_x64/Apps/ValidationTests/Release


### PR DESCRIPTION
Runs working days at 11pm

Checkout repo, download distpreview for babylonjs, build ValidationTests and runs it.
No configuration to do on the CI.