### PR TITLE
Implementing hand tracking via OpenXR for BabylonNative

### DIFF
--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -140,6 +140,12 @@ namespace xr
                     Pose Pose;
                 };
 
+                struct JointSpace : Space
+                {
+                    bool PoseTracked{ false };
+                    float PoseRadius{};
+                };
+
                 struct View
                 {
                     Space Space{};
@@ -178,9 +184,11 @@ namespace xr
 
                     const Identifier ID{ NEXT_ID++ };
                     bool TrackedThisFrame{};
+                    bool JointsTrackedThisFrame{};
                     Space GripSpace{};
                     Space AimSpace{};
                     HandednessEnum Handedness{};
+                    std::vector<JointSpace> HandJoints{};
 
                 private:
                     static inline Identifier NEXT_ID{ 0 };

--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -142,8 +142,8 @@ namespace xr
 
                 struct JointSpace : Space
                 {
-                    bool PoseTracked{ false };
                     float PoseRadius{};
+                    bool PoseTracked{ false };
                 };
 
                 struct View

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -326,7 +326,7 @@ namespace xr
             {
                 for (const HandInfo& handInfo : HandData.HandsInfo)
                 {
-                    XrCheck(HmdImpl.Extensions->xrDestroyHandTrackerEXT(handInfo.HandTracker));
+                    XrCheck(HmdImpl.Context.Extensions()->xrDestroyHandTrackerEXT(handInfo.HandTracker));
                 }
 
                 HandData.HandsInitialized = false;
@@ -524,7 +524,7 @@ namespace xr
             XrCheck(xrGetSystemProperties(instance, systemId, &systemProperties));
 
             // Initialize the hand resources
-            HandData.SupportsHandTracking = handTrackingSystemProperties.supportsHandTracking && HmdImpl.Extensions->HandTrackingSupported;
+            HandData.SupportsHandTracking = handTrackingSystemProperties.supportsHandTracking && HmdImpl.Context.Extensions()->HandTrackingSupported;
             InitializeHandResources();
 
             const XrViewConfigurationType primaryType = HmdImpl.PrimaryViewConfigurationType;
@@ -546,6 +546,7 @@ namespace xr
                 return;
             }
 
+            const auto& session = HmdImpl.Context.Session();
             constexpr std::array<XrHandEXT, 2> HANDEDNESS_EXT{XR_HAND_LEFT_EXT, XR_HAND_RIGHT_EXT};
             XrHandTrackerCreateInfoEXT trackerCreateInfo{XR_TYPE_HAND_TRACKER_CREATE_INFO_EXT};
             trackerCreateInfo.handJointSet = XR_HAND_JOINT_SET_DEFAULT_EXT;
@@ -555,7 +556,7 @@ namespace xr
                 // Create the hand trackers
                 HandData.HandsInfo[i].Hand = HANDEDNESS_EXT[i];
                 trackerCreateInfo.hand = HANDEDNESS_EXT[i];
-                XrCheck(HmdImpl.Extensions->xrCreateHandTrackerEXT(Session, &trackerCreateInfo, &HandData.HandsInfo[i].HandTracker));
+                XrCheck(HmdImpl.Context.Extensions()->xrCreateHandTrackerEXT(session, &trackerCreateInfo, &HandData.HandsInfo[i].HandTracker));
             }
 
             HandData.HandsInitialized = true;
@@ -1165,11 +1166,11 @@ namespace xr
                 if (sessionImpl.HandData.HandsInitialized)
                 {
                     XrHandJointsLocateInfoEXT jointLocateInfo{XR_TYPE_HAND_JOINTS_LOCATE_INFO_EXT};
-                    jointLocateInfo.baseSpace = m_impl->sessionImpl.SceneSpace;
-                    jointLocateInfo.time = m_impl->displayTime;
+                    jointLocateInfo.baseSpace = sceneSpace;
+                    jointLocateInfo.time = displayTime;
 
                     auto handInfo = sessionImpl.HandData.HandsInfo[idx];
-                    XrCheck(sessionImpl.HmdImpl.Extensions->xrLocateHandJointsEXT(handInfo.HandTracker, &jointLocateInfo, &handInfo.Locations));
+                    XrCheck(sessionImpl.HmdImpl.Context.Extensions()->xrLocateHandJointsEXT(handInfo.HandTracker, &jointLocateInfo, &handInfo.Locations));
                     
                     auto& inputSource = InputSources[idx];
                     inputSource.JointsTrackedThisFrame = handInfo.Locations.isActive;

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -551,7 +551,7 @@ namespace xr
             XrHandTrackerCreateInfoEXT trackerCreateInfo{XR_TYPE_HAND_TRACKER_CREATE_INFO_EXT};
             trackerCreateInfo.handJointSet = XR_HAND_JOINT_SET_DEFAULT_EXT;
 
-            for (int i = 0; i < HandData.HandsInfo.size(); i++)
+            for (size_t i = 0; i < HandData.HandsInfo.size(); i++)
             {
                 // Create the hand trackers
                 HandData.HandsInfo[i].Hand = HANDEDNESS_EXT[i];

--- a/Dependencies/xr/Source/OpenXR/XrSupportedExtensions.h
+++ b/Dependencies/xr/Source/OpenXR/XrSupportedExtensions.h
@@ -30,7 +30,7 @@ namespace xr
             SpatialAnchorSupported = TryEnableExtension(XR_MSFT_SPATIAL_ANCHOR_EXTENSION_NAME);
             SecondaryViewConfigurationSupported = TryEnableExtension(XR_MSFT_SECONDARY_VIEW_CONFIGURATION_EXTENSION_NAME);
             FirstPersonObserverSupported = TryEnableExtension(XR_MSFT_FIRST_PERSON_OBSERVER_EXTENSION_NAME);
-            HandTrackingSupported = TryEnableExtension(XR_EXT_HAND_TRACKING_EXTENSION_NAME, extensionProperties);
+            HandTrackingSupported = TryEnableExtension(XR_EXT_HAND_TRACKING_EXTENSION_NAME);
         }
 
         bool TryEnableExtension(const char* extensionName)

--- a/Dependencies/xr/Source/OpenXR/XrSupportedExtensions.h
+++ b/Dependencies/xr/Source/OpenXR/XrSupportedExtensions.h
@@ -30,6 +30,7 @@ namespace xr
             SpatialAnchorSupported = TryEnableExtension(XR_MSFT_SPATIAL_ANCHOR_EXTENSION_NAME);
             SecondaryViewConfigurationSupported = TryEnableExtension(XR_MSFT_SECONDARY_VIEW_CONFIGURATION_EXTENSION_NAME);
             FirstPersonObserverSupported = TryEnableExtension(XR_MSFT_FIRST_PERSON_OBSERVER_EXTENSION_NAME);
+            HandTrackingSupported = TryEnableExtension(XR_EXT_HAND_TRACKING_EXTENSION_NAME, extensionProperties);
         }
 
         bool TryEnableExtension(const char* extensionName)
@@ -62,6 +63,7 @@ namespace xr
         bool SpatialAnchorSupported{ false };
         bool SecondaryViewConfigurationSupported{ false };
         bool FirstPersonObserverSupported{ false };
+        bool HandTrackingSupported{ false };
 
     private:
         std::vector<XrExtensionProperties> m_extensionProperties{};


### PR DESCRIPTION
This change introduces the hand tracking backbone in XR.cpp and NativeXR.cpp to implement hand tracking when using openXR in BabylonNative. It works with the existing hand tracking code for BabylonJS, found [here](https://github.com/BabylonJS/Babylon.js/pull/8753).

This resolves #394 