### PR TITLE
 Fixes for Android shader compile

### DIFF
--- a/Plugins/NativeEngine/Source/ShaderCompilerOpenGL.cpp
+++ b/Plugins/NativeEngine/Source/ShaderCompilerOpenGL.cpp
@@ -36,12 +36,14 @@ namespace Babylon
 
             auto compiler = std::make_unique<spirv_cross::CompilerGLSL>(parser->get_parsed_ir());
 
+#if !ANDROID
             compiler->build_combined_image_samplers();
+#endif
 
             spirv_cross::CompilerGLSL::Options options = compiler->get_common_options();
 
-#ifdef ANDROID
-            options.version = 310;
+#if ANDROID
+            options.version = 300;
             options.es = true;
 #else
             options.version = 330;
@@ -88,7 +90,10 @@ namespace Babylon
         ShaderCompilerTraversers::IdGenerator ids{};
         auto cutScope = ShaderCompilerTraversers::ChangeUniformTypes(program, ids);
         ShaderCompilerTraversers::AssignLocationsAndNamesToVertexVaryings(program, ids);
+
+#if !ANDROID
         ShaderCompilerTraversers::SplitSamplersIntoSamplersAndTextures(program, ids);
+#endif
 
         std::string vertexGLSL(vertexSource.data(), vertexSource.size());
         auto [vertexParser, vertexCompiler] = CompileShader(program, EShLangVertex, vertexGLSL);


### PR DESCRIPTION
Fixes #371, #372, #385.

Also fixes BabylonJS/BabylonReactNative#61 once BabylonReactNative picks up this change.

The main issue with the Android shader code path is that the sampler locations for textures are wrong. This change include a couple of fixes to address this:

1. The conversion to SPIRV is now as minimal as possible. The splitting of samplers into texture/sampler and then recombining them is now gone. [Removing SPIRV for OpenGL situations](https://github.com/BabylonJS/BabylonNative/issues/300) should be easier after this change. This is a problem because when SPIRV recombines the texture/sampler pair, it mangles the name and thus bgfx can't bind the locations properly. I couldn't find a way for SPIRV not to do this, but removing this splitting/recombining fixes this issue. Lowering to ES 300 version also then removes the binding attributes completely.
2. Because the binding has been removed completely, the "stage" as bgfx calls them, needs to be generated explicitly. As far as I can tell, for WebGL/OpenGL, this is simply the order they appear in the shader. The change to AppendSamplers reflects this fix.

Finally, I purposefully did not fix Linux in this change. I expect Linux will have exactly the same issue as Android, but I don't want to handle that in this PR. Will address it separately.