### PR TITLE
Disable Chakra debugging on ARM platforms

### DIFF
--- a/Core/AppRuntime/Source/AppRuntimeChakra.cpp
+++ b/Core/AppRuntime/Source/AppRuntimeChakra.cpp
@@ -46,7 +46,7 @@ namespace Babylon
             &dispatchFunction));
         ThrowIfFailed(JsProjectWinRTNamespace(L"Windows"));
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && !(defined(_M_ARM64) || defined(_M_ARM))
         // Put Chakra in debug mode.
         ThrowIfFailed(JsStartDebugging());
 #endif

--- a/Core/AppRuntime/Source/AppRuntimeChakra.cpp
+++ b/Core/AppRuntime/Source/AppRuntimeChakra.cpp
@@ -46,9 +46,15 @@ namespace Babylon
             &dispatchFunction));
         ThrowIfFailed(JsProjectWinRTNamespace(L"Windows"));
 
-#if defined(_DEBUG) && !(defined(_M_ARM64) || defined(_M_ARM))
+#if defined(_DEBUG)
         // Put Chakra in debug mode.
-        ThrowIfFailed(JsStartDebugging());
+        {
+            auto result = JsStartDebugging();
+            if (result != JsErrorCode::JsNoError)
+            {
+                OutputDebugStringW(L"Failed to initialize debugging support.\n");
+            }
+        }
 #endif
 
         Napi::Env env = Napi::Attach();

--- a/Core/AppRuntime/Source/AppRuntimeChakra.cpp
+++ b/Core/AppRuntime/Source/AppRuntimeChakra.cpp
@@ -52,7 +52,7 @@ namespace Babylon
             auto result = JsStartDebugging();
             if (result != JsErrorCode::JsNoError)
             {
-                OutputDebugStringW(L"Failed to initialize debugging support.\n");
+                OutputDebugStringW(L"Failed to initialize JavaScript debugging support.\n");
             }
         }
 #endif


### PR DESCRIPTION
Visual Studio currently doesn't deploy the required binaries needed for JS debugging on ARM-based platforms such as HoloLens 2. While we wait for the required VS fixes, this change disables the `JsStartDebugging` call on those architectures.

Related to #409 