### PR TITLE
Removed CI Validation Tests for Linux/Clang

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -273,14 +273,14 @@ jobs:
         tasks: 'assembleRelease'
     displayName: 'Build androidJSC'
 
-- job: Ubuntu_Clang8_JSC
+- job: Ubuntu_Clang9_JSC
   timeoutInMinutes: 25
   pool:
     vmImage: 'ubuntu-latest'
 
   variables:
-    CC: clang-8
-    CXX: clang++-8
+    CC: clang-9
+    CXX: clang++-9
 
   steps:
   - script: |
@@ -288,7 +288,7 @@ jobs:
     displayName: 'Checkout dependencies'
   - script: |
       sudo apt-get update
-      sudo apt-get install libjavascriptcoregtk-4.0-dev libgl1-mesa-dev libcurl4-openssl-dev clang-8 libc++-8-dev libc++abi-8-dev lld-8 ninja-build
+      sudo apt-get install libjavascriptcoregtk-4.0-dev libgl1-mesa-dev libcurl4-openssl-dev clang-9 libc++-9-dev libc++abi-9-dev lld-9 ninja-build
     displayName: 'Install packages'
   - script: |
       mkdir build
@@ -307,15 +307,15 @@ jobs:
     displayName: 'Test on CI'
   - task: PublishBuildArtifacts@1
     inputs:
-      artifactName: 'Ubuntu_Clang8_JSC Rendered Pictures'
+      artifactName: 'Ubuntu_Clang9_JSC Rendered Pictures'
       pathtoPublish: 'build/Apps/ValidationTests/Results'
-    displayName: 'Publish Tests Ubuntu_Clang8_JSC Results'
+    displayName: 'Publish Tests Ubuntu_Clang9_JSC Results'
     condition: succeeded()
   - task: PublishBuildArtifacts@1
     inputs:
-      artifactName: 'Ubuntu_Clang8_JSC Error Pictures'
+      artifactName: 'Ubuntu_Clang9_JSC Error Pictures'
       pathtoPublish: 'build/Apps/ValidationTests/Errors'
-    displayName: 'Publish Tests Ubuntu_Clang8_JSC Errors'
+    displayName: 'Publish Tests Ubuntu_Clang9_JSC Errors'
     condition: failed()
 
 - job: Ubuntu_GCC9_JSC

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -296,27 +296,6 @@ jobs:
       cmake .. -GNinja -DJSCORE_LIBRARY=/usr/lib/x86_64-linux-gnu/libjavascriptcoregtk-4.0.so
       ninja
     displayName: 'Build X11'
-  - script: |
-      export DISPLAY=:98
-      Xvfb :98 -screen 0 1600x900x24 &
-      sleep 3
-      cd build/Apps/ValidationTests
-      mkdir Errors
-      mkdir Results
-      ./ValidationTests
-    displayName: 'Test on CI'
-  - task: PublishBuildArtifacts@1
-    inputs:
-      artifactName: 'Ubuntu_Clang8_JSC Rendered Pictures'
-      pathtoPublish: 'build/Apps/ValidationTests/Results'
-    displayName: 'Publish Tests Ubuntu_Clang8_JSC Results'
-    condition: succeeded()
-  - task: PublishBuildArtifacts@1
-    inputs:
-      artifactName: 'Ubuntu_Clang8_JSC Error Pictures'
-      pathtoPublish: 'build/Apps/ValidationTests/Errors'
-    displayName: 'Publish Tests Ubuntu_Clang8_JSC Errors'
-    condition: failed()
 
 - job: Ubuntu_GCC9_JSC
   timeoutInMinutes: 20

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -273,14 +273,14 @@ jobs:
         tasks: 'assembleRelease'
     displayName: 'Build androidJSC'
 
-- job: Ubuntu_Clang9_JSC
-  timeoutInMinutes: 25
+- job: Ubuntu_Clang8_JSC
+  timeoutInMinutes: 20
   pool:
     vmImage: 'ubuntu-latest'
 
   variables:
-    CC: clang-9
-    CXX: clang++-9
+    CC: clang-8
+    CXX: clang++-8
 
   steps:
   - script: |
@@ -288,7 +288,7 @@ jobs:
     displayName: 'Checkout dependencies'
   - script: |
       sudo apt-get update
-      sudo apt-get install libjavascriptcoregtk-4.0-dev libgl1-mesa-dev libcurl4-openssl-dev clang-9 libc++-9-dev libc++abi-9-dev lld-9 ninja-build
+      sudo apt-get install libjavascriptcoregtk-4.0-dev libgl1-mesa-dev libcurl4-openssl-dev clang-8 libc++-8-dev libc++abi-8-dev lld-8 ninja-build
     displayName: 'Install packages'
   - script: |
       mkdir build
@@ -296,30 +296,9 @@ jobs:
       cmake .. -GNinja -DJSCORE_LIBRARY=/usr/lib/x86_64-linux-gnu/libjavascriptcoregtk-4.0.so
       ninja
     displayName: 'Build X11'
-  - script: |
-      export DISPLAY=:99
-      Xvfb :99 -screen 0 1600x900x24 &
-      sleep 3
-      cd build/Apps/ValidationTests
-      mkdir Errors
-      mkdir Results
-      ./ValidationTests
-    displayName: 'Test on CI'
-  - task: PublishBuildArtifacts@1
-    inputs:
-      artifactName: 'Ubuntu_Clang9_JSC Rendered Pictures'
-      pathtoPublish: 'build/Apps/ValidationTests/Results'
-    displayName: 'Publish Tests Ubuntu_Clang9_JSC Results'
-    condition: succeeded()
-  - task: PublishBuildArtifacts@1
-    inputs:
-      artifactName: 'Ubuntu_Clang9_JSC Error Pictures'
-      pathtoPublish: 'build/Apps/ValidationTests/Errors'
-    displayName: 'Publish Tests Ubuntu_Clang9_JSC Errors'
-    condition: failed()
 
 - job: Ubuntu_GCC9_JSC
-  timeoutInMinutes: 25
+  timeoutInMinutes: 20
   pool:
     vmImage: 'ubuntu-latest'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -296,6 +296,27 @@ jobs:
       cmake .. -GNinja -DJSCORE_LIBRARY=/usr/lib/x86_64-linux-gnu/libjavascriptcoregtk-4.0.so
       ninja
     displayName: 'Build X11'
+  - script: |
+      export DISPLAY=:98
+      Xvfb :98 -screen 0 1600x900x24 &
+      sleep 3
+      cd build/Apps/ValidationTests
+      mkdir Errors
+      mkdir Results
+      ./ValidationTests
+    displayName: 'Test on CI'
+  - task: PublishBuildArtifacts@1
+    inputs:
+      artifactName: 'Ubuntu_Clang8_JSC Rendered Pictures'
+      pathtoPublish: 'build/Apps/ValidationTests/Results'
+    displayName: 'Publish Tests Ubuntu_Clang8_JSC Results'
+    condition: succeeded()
+  - task: PublishBuildArtifacts@1
+    inputs:
+      artifactName: 'Ubuntu_Clang8_JSC Error Pictures'
+      pathtoPublish: 'build/Apps/ValidationTests/Errors'
+    displayName: 'Publish Tests Ubuntu_Clang8_JSC Errors'
+    condition: failed()
 
 - job: Ubuntu_GCC9_JSC
   timeoutInMinutes: 20


### PR DESCRIPTION
For an unkown reason, tests on Linux with Clang are timing out. When it happens in a PR, re-running the task works just fine.
I tried to change display export, update clang to v9,... without success.

No other choice than removing the CI tests for now.

Related issue : https://github.com/BabylonJS/BabylonNative/issues/426