### PR TITLE
fix XR renderTarget regression

### DIFF
--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -441,7 +441,8 @@ namespace Babylon
                     frameBuffer,
                     m_clearState,
                     static_cast<uint16_t>(view.ColorTextureSize.Width),
-                    static_cast<uint16_t>(view.ColorTextureSize.Height));
+                    static_cast<uint16_t>(view.ColorTextureSize.Height),
+                    true);
 
                 // WebXR, at least in its current implementation, specifies an implicit default clear to black.
                 // https://immersive-web.github.io/webxr/#xrwebgllayer-interface


### PR DESCRIPTION
Because of a vertical flip needed for render targets on Direct3D and Metal, XR rendertarget was also flipped.
But as it is used for direct use with particular UV on Metal and as back buffer on Windows, the 3D displayed was flipped.
For XR, the render target must behave like a back buffer and not like a render target that would be reused by a pixel shader.
