### PR TITLE
Fix some regressions in XR mode on Android and iOS

### DIFF
--- a/Dependencies/napi/napi-jsi/include/napi/napi-inl.h
+++ b/Dependencies/napi/napi-jsi/include/napi/napi-inl.h
@@ -2569,22 +2569,13 @@ inline typename ObjectWrap<T>::PropertyDescriptor ObjectWrap<T>::StaticAccessor(
     StaticSetterCallback setter,
     napi_property_attributes attributes,
     void* data) {
-  (void)utf8name;
-  (void)getter;
-  (void)setter;
-  (void)attributes;
-  (void)data;
-  //StaticAccessorCallbackData* callbackData =
-  //  new StaticAccessorCallbackData({ getter, setter, data });
-
-  //PropertyDescriptor desc = napi_property_descriptor();
-  //desc.utf8name = utf8name;
-  //desc.getter = getter != nullptr ? T::StaticGetterCallbackWrapper : nullptr;
-  //desc.setter = setter != nullptr ? T::StaticSetterCallbackWrapper : nullptr;
-  //desc.data = callbackData;
-  //desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
-  //return desc;
-  throw std::runtime_error{"TODO"};
+  PropertyDescriptor desc{};
+  desc.utf8name = utf8name;
+  desc.staticGetter = getter;
+  desc.staticSetter = setter;
+  desc.attributes = attributes;
+  desc.data = data;
+  return desc;
 }
 
 template <typename T>

--- a/Dependencies/napi/napi-jsi/include/napi/napi-inl.h
+++ b/Dependencies/napi/napi-jsi/include/napi/napi-inl.h
@@ -1692,6 +1692,7 @@ inline Reference<T>& Reference<T>::operator =(Reference<T>&& other) {
   _object = std::move(other._object);
   _suppressDestruct = other._suppressDestruct;
   other._env = nullptr;
+  other._suppressDestruct = false;
   return *this;
 }
 

--- a/Dependencies/napi/napi-jsi/include/napi/napi-inl.h
+++ b/Dependencies/napi/napi-jsi/include/napi/napi-inl.h
@@ -1691,6 +1691,7 @@ inline Reference<T>& Reference<T>::operator =(Reference<T>&& other) {
   _env = other._env;
   _object = std::move(other._object);
   _suppressDestruct = other._suppressDestruct;
+  other._env = nullptr;
   return *this;
 }
 
@@ -1953,7 +1954,7 @@ inline FunctionReference& FunctionReference::operator =(Reference<Function>&& ot
 }
 
 inline FunctionReference::FunctionReference(FunctionReference&& other)
-  : Reference<Function>(other) {
+  : Reference<Function>(std::move(other)) {
 }
 
 inline FunctionReference& FunctionReference::operator =(FunctionReference&& other) {

--- a/Dependencies/napi/napi-jsi/include/napi/napi-inl.h
+++ b/Dependencies/napi/napi-jsi/include/napi/napi-inl.h
@@ -1763,12 +1763,8 @@ inline uint32_t Reference<T>::Unref() {
 
 template <typename T>
 inline void Reference<T>::Reset() {
-  //if (_object != nullptr) {
-  //  napi_status status = napi_delete_reference(_env, _object);
-  //  NAPI_THROW_IF_FAILED_VOID(_env, status);
-  //  _object = nullptr;
-  //}
-  //throw std::runtime_error{"TODO"};
+  _env = {};
+  _object = {};
 }
 
 template <typename T>

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -512,12 +512,12 @@ namespace Babylon
 
             try
             {
-                if (!m_requestAnimationFrameCalback.IsEmpty())
+                if (!m_requestAnimationFrameCallback.IsEmpty())
                 {
                     // We can get here from either the normal RequestAnimationFrame or the XR RequestAnimationFrame,
                     // so we need to clear out the regular RequestAnimationFrame callback to make sure we don't incorrectly
                     // call it when we have transitioned to the XR RequestAnimationFrame.
-                    auto callback{std::move(m_requestAnimationFrameCalback)};
+                    auto callback{std::move(m_requestAnimationFrameCallback)};
                     callback({});
                 }
                 GetFrameBufferManager().Reset();
@@ -584,10 +584,10 @@ namespace Babylon
     {
         auto callback = info[0].As<Napi::Function>();
 
-        if (m_requestAnimationFrameCalback.IsEmpty() ||
-            m_requestAnimationFrameCalback.Value() != callback)
+        if (m_requestAnimationFrameCallback.IsEmpty() ||
+            m_requestAnimationFrameCallback.Value() != callback)
         {
-            m_requestAnimationFrameCalback = Napi::Persistent(callback);
+            m_requestAnimationFrameCallback = Napi::Persistent(callback);
         }
 
         ScheduleRender();

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -512,7 +512,15 @@ namespace Babylon
 
             try
             {
-                m_requestAnimationFrameCalback.Call({});
+                if (!m_requestAnimationFrameCalback.IsEmpty())
+                {
+                    // We can get here from either the normal RequestAnimationFrame or the XR RequestAnimationFrame,
+                    // so we need to clear out the regular RequestAnimationFrame callback to make sure we don't incorrectly
+                    // call it when we have transitioned to the XR RequestAnimationFrame.
+                    auto callback = std::move(m_requestAnimationFrameCalback);
+                    m_requestAnimationFrameCalback.Reset();
+                    callback({});
+                }
                 GetFrameBufferManager().Reset();
             }
             catch (const std::exception& ex)

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -517,8 +517,7 @@ namespace Babylon
                     // We can get here from either the normal RequestAnimationFrame or the XR RequestAnimationFrame,
                     // so we need to clear out the regular RequestAnimationFrame callback to make sure we don't incorrectly
                     // call it when we have transitioned to the XR RequestAnimationFrame.
-                    auto callback = std::move(m_requestAnimationFrameCalback);
-                    m_requestAnimationFrameCalback.Reset();
+                    auto callback{std::move(m_requestAnimationFrameCalback)};
                     callback({});
                 }
                 GetFrameBufferManager().Reset();

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -530,7 +530,7 @@ namespace Babylon
         // Scratch vector used for data alignment.
         std::vector<float> m_scratch{};
         
-        Napi::FunctionReference m_requestAnimationFrameCalback{};
+        Napi::FunctionReference m_requestAnimationFrameCallback{};
 
         // webgl/opengl draw call parameters allow to set first index and number of indices used for that call
         // but with bgfx, those parameters must be set when binding the index buffer

--- a/Plugins/NativeInput/Source/DeviceInputSystem.cpp
+++ b/Plugins/NativeInput/Source/DeviceInputSystem.cpp
@@ -22,7 +22,7 @@ namespace Babylon::Plugins
                 })
         };
 
-        env.Global().Get(JsRuntime::JS_NATIVE_NAME).As<Napi::Object>().Set(JS_CONSTRUCTOR_NAME, func);
+        JsRuntime::NativeObject::GetFromJavaScript(env).Set(JS_CONSTRUCTOR_NAME, func);
     }
 
     // TODO: The JavaScript contract is such that the constructor takes an Engine, but really it should take some kind of view id, which should be passed through to NativeInput::GetFromJavaScript.

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -176,7 +176,7 @@ namespace
             {
                 auto napiJoint = Napi::External<std::decay_t<decltype(*inputSource.HandJoints.begin())>>::New(env, &inputSource.HandJoints[i]);
                 handJointCollection.Set(static_cast<int>(i), napiJoint);
-                handJointCollection.Set(Napi::String::New(env, HAND_JOINT_NAMES[i]), static_cast<int>(i));
+                handJointCollection.Set(HAND_JOINT_NAMES[i], static_cast<int>(i));
             }
 
             handJointCollection.Set("length", static_cast<int>(HAND_JOINT_NAMES.size()));
@@ -1468,7 +1468,7 @@ namespace Babylon
             {
                 Napi::HandleScope scope{env};
 
-                std::vector<Napi::ClassPropertyDescriptor<XRHand>> initList{};
+                std::vector<XRHand::PropertyDescriptor> initList{};
                 initList.reserve(HAND_JOINT_NAMES.size() + 1);
 
                 for (size_t idx = 0; idx < HAND_JOINT_NAMES.size(); idx++)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ but are expected to be supported in the future. Note that this list is not exhau
 - User input.
 - Font rendering.
 - Sub-window, multi-window, and out-of-process rendering.
-- React Native integration.
 
 This section will be updated frequently. If you have any questions, please reach out
 to us on [the Babylon forum](https://forum.babylonjs.com).


### PR DESCRIPTION
Several changes were recently made that broke XR on Android and iOS, and this PR fixes them.
- NAPI JSI needs a `StaticAccessor` implementation that doesn't throw and a `Reference::Reset` that is functional. I think there is more we need to do to actually make `StaticAccessor` work rather than just not crash. If that's the case, I can add a comment or something.
- NativeEngine needs to clear out the `RequestAnimationFrame` callback after calling it so that when we transition to XR mode we don't end up rendering twice (e.g. calling the stale callback for the regular `RequestAnimationFrame` in addition to the current callback for the XR `RequestAnimationFrame`).
- `DeviceInputSystem` needs to access the JS native object via the new `NativeObject` class.
- NativeXR should use the `Set` overload that takes a `const char*` (there should be no need to wrap it in a napi string, and we don't have that implemented for NAPI JSI currently).
- NativeXR should use `XRHand::PropertyDescriptor` rather than `ClassPropertyDescriptor<XRHand>`. In NAPI direct, `ObjectWrap<T>::PropertyDescriptor` is just type defed as `ClassPropertyDescriptor<T>`, so this is really more correct in that case. In NAPI JSI, `ClassPropertyDescriptor<T>` doesn't even exist, so we must use `ObjectWrap<T>::PropertyDescriptor` at this point.
- Removed the line from the README that says we don't have React Native integration. :)