### PR TITLE
Add Reinitialize function to NativeWindow

### DIFF
--- a/Plugins/NativeWindow/Include/Babylon/Plugins/NativeWindow.h
+++ b/Plugins/NativeWindow/Include/Babylon/Plugins/NativeWindow.h
@@ -5,6 +5,6 @@
 namespace Babylon::Plugins::NativeWindow
 {
     void Initialize(Napi::Env env, void* windowPtr, size_t width, size_t height);
-
+    void Reinitialize(Napi::Env env, void* windowPtr, size_t width, size_t height);
     void UpdateSize(Napi::Env env, size_t width, size_t height);
 }

--- a/Plugins/NativeWindow/Source/NativeWindow.cpp
+++ b/Plugins/NativeWindow/Source/NativeWindow.cpp
@@ -88,9 +88,15 @@ namespace Babylon::Plugins::NativeWindow
         NativeWindow::Initialize(env, windowPtr, width, height);
     }
 
+    void Reinitialize(Napi::Env env, void* windowPtr, size_t width, size_t height)
+    {
+        auto& window = NativeWindow::GetFromJavaScript(env);
+        window.Resize(width, height, windowPtr);
+    }
+
     void UpdateSize(Napi::Env env, size_t width, size_t height)
     {
         auto& window = NativeWindow::GetFromJavaScript(env);
-        window.Resize(static_cast<size_t>(width), static_cast<size_t>(height));
+        window.Resize(width, height);
     }
 }


### PR DESCRIPTION
We currently have no way to update the `windowPtr` held by `NativeWindow`, even though the window can in fact change through the lifetime of Babylon Native. `NativeXR.cpp` relies on `NativeWindow` to pass down the `windowPtr`. The iOS XR implementation (`XR.mm`) uses this to get the size, and also to create a sub view for the XR rendering. This means that if the `windowPtr` changes (e.g. disable and reenable the view in Babylon React Native), it operates against the original `windowPtr`, and things blow up. So this change just adds a `Reinitialize` function to `NativeWindow`, which I will call in the React Native integration layer.

This caused https://github.com/BabylonJS/BabylonReactNative/issues/57 to still repro (from a different root cause) on iOS.