### PR TITLE
XR animation frame request scheduling bug fix

### DIFF
--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -243,6 +243,10 @@ namespace Babylon
             }
             m_isFrameScheduled = true;
 
+            m_graphicsImpl.GetAfterRenderTask().then(arcana::inline_scheduler, arcana::cancellation::none(), [this] {
+                m_engineImpl->ScheduleRender();
+            });
+
             m_graphicsImpl.GetBeforeRenderTask().then(arcana::inline_scheduler, arcana::cancellation::none(), [this, callback = std::move(callback)] {
                 // Note: we are guaranteed to be on the render thread.
                 m_isFrameScheduled = false;
@@ -252,8 +256,6 @@ namespace Babylon
                 {
                     return;
                 }
-                
-                m_engineImpl->ScheduleRender();
 
                 BeginFrame();
 


### PR DESCRIPTION
Attempt to fix scheduling problems with animation frame requesting for scenarios where the creation of XR predates the creation of the render loop. Without this change, if there was no pre-existing render-loop, there was a one-frame gap before XR's render loop would become self-sustaining, and consequently it would never get started in earnest. I believe this may be the fix, or a meaningful part of it, for the recent soft-lock issues encountered by several teams consuming Babylon Native for XR on multiple platforms. I don't have access to all the required platforms, though, so further testing is needed to ensure this actually fixes the problem.