### PR TITLE
Reassign framebuffer view id's per-frame instead of per-bind

### DIFF
--- a/Apps/ValidationTests/Scripts/config.json
+++ b/Apps/ValidationTests/Scripts/config.json
@@ -9,7 +9,7 @@
         {
             "title": "Chromatic aberration",
             "playgroundId": "#NAW8EA#0",
-            "renderCount": 20,
+            "renderCount": 30,
             "referenceImage": "chromaticAberration.png"
         },
         {
@@ -43,7 +43,7 @@
         {
             "title": "Black and White post-process",
             "playgroundId": "#N55Q2M#0",
-            "renderCount": 20,
+            "renderCount": 30,
             "referenceImage": "bwpp.png"
         },
         {

--- a/Apps/ValidationTests/Scripts/config.json
+++ b/Apps/ValidationTests/Scripts/config.json
@@ -43,6 +43,7 @@
         {
             "title": "Black and White post-process",
             "playgroundId": "#N55Q2M#0",
+            "renderCount": 20,
             "referenceImage": "bwpp.png"
         },
         {

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1397,7 +1397,7 @@ namespace Babylon
 
             uint64_t m_engineStateYFlipped = m_engineState;
             m_engineStateYFlipped &= ~BGFX_STATE_CULL_MASK;
-            m_engineStateYFlipped |= (cullCCW | cullCCW) << BGFX_STATE_CULL_SHIFT;
+            m_engineStateYFlipped |= (cullCW | cullCCW) << BGFX_STATE_CULL_SHIFT;
 
             bgfx::setState(m_engineStateYFlipped | fillModeState);
         }

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1462,20 +1462,9 @@ namespace Babylon
         const auto y = info[1].As<Napi::Number>().FloatValue();
         const auto width = info[2].As<Napi::Number>().FloatValue();
         const auto height = info[3].As<Napi::Number>().FloatValue();
-
-        auto& backBuffer = m_frameBufferManager.GetBound();
-        const auto isDefault = m_frameBufferManager.IsRenderingToDefault();
-
-        const auto backbufferWidth = isDefault ? bgfx::getStats()->width : backBuffer.Width;
-        const auto backbufferHeight = isDefault ? bgfx::getStats()->height : backBuffer.Height;
         const float yOrigin = bgfx::getCaps()->originBottomLeft ? y : (1.f - y - height);
 
-        const bgfx::ViewId viewId = m_frameBufferManager.GetBound().ViewId;
-        bgfx::setViewRect(viewId,
-            static_cast<uint16_t>(x * backbufferWidth),
-            static_cast<uint16_t>(yOrigin * backbufferHeight),
-            static_cast<uint16_t>(width * backbufferWidth),
-            static_cast<uint16_t>(height * backbufferHeight));
+        m_frameBufferManager.GetBound().SetViewPort(x, yOrigin, width, height);
     }
 
     void NativeEngine::GetFramebufferData(const Napi::CallbackInfo& info)

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -275,8 +275,11 @@ namespace Babylon
         void Unbind(FrameBufferData* data)
         {
             (void)data;
-            assert(m_boundFrameBuffer == m_backBuffer || m_boundFrameBuffer == data);
-            Bind(m_backBuffer);
+            if (m_boundFrameBuffer != m_backBuffer)
+            {
+                assert(m_boundFrameBuffer == data);
+                Bind(m_backBuffer);
+            }
         }
 
         uint16_t GetNewViewId()
@@ -288,15 +291,16 @@ namespace Babylon
 
         void Reset()
         {
-            m_nextId = 1; // Don't overwrite m_backBuffer view id.
+            m_nextId = 1; // Don't overwrite m_backBuffer view id assignment.
             m_activeFrameBuffers.apply_to_all([this](FrameBufferData* frameBufferData) {
                 // We don't need to reassign m_backBuffer's view id since it's not transient.
                 if (frameBufferData != m_backBuffer)
                     frameBufferData->ViewIdDirty = true;
             });
 
-            // Rebind to the default back buffer
-            Unbind(m_boundFrameBuffer);
+            // TODO: Investigate performance implications of unbinding on reset when in VR mode.
+            // See https://github.com/BabylonJS/BabylonNative/issues/344
+            // Unbind(m_boundFrameBuffer);
         }
 
         inline bool IsRenderingToTarget() const

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -299,8 +299,7 @@ namespace Babylon
             });
 
             // TODO: Investigate performance implications of unbinding on reset when in VR mode.
-            // See https://github.com/BabylonJS/BabylonNative/issues/344
-            // Unbind(m_boundFrameBuffer);
+            Unbind(m_boundFrameBuffer);
         }
 
         inline bool IsRenderingToTarget() const

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -172,8 +172,8 @@ namespace Babylon
     struct FrameBufferData final
     {
     private:
-        std::unique_ptr<ClearState> m_clearState{};
         arcana::weak_table<FrameBufferData*>::ticket m_managerTicket;
+        std::unique_ptr<ClearState> m_clearState{};
 
     public:
         FrameBufferData(bgfx::FrameBufferHandle frameBuffer, arcana::weak_table<FrameBufferData*>& managerTable, uint16_t width, uint16_t height, bool actAsBackBuffer = false)
@@ -270,6 +270,7 @@ namespace Babylon
 
         void Unbind(FrameBufferData* data)
         {
+            (void)data;
             assert(m_boundFrameBuffer == data);
             Bind(m_backBuffer);
         }

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -288,12 +288,14 @@ namespace Babylon
 
         void Reset()
         {
-            m_nextId = 0;
-            m_activeFrameBuffers.apply_to_all([](FrameBufferData* frameBufferData) {
-                frameBufferData->ViewIdDirty = true;
+            m_nextId = 1; // Don't overwrite m_backBuffer view id.
+            m_activeFrameBuffers.apply_to_all([this](FrameBufferData* frameBufferData) {
+                // We don't need to reassign m_backBuffer's view id since it's not transient.
+                if (frameBufferData != m_backBuffer)
+                    frameBufferData->ViewIdDirty = true;
             });
 
-            // Rebind the default back buffer and reset its view
+            // Rebind to the default back buffer
             Unbind(m_boundFrameBuffer);
         }
 

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -243,12 +243,16 @@ namespace Babylon
 
         FrameBufferData* CreateNew(bgfx::FrameBufferHandle frameBufferHandle, uint16_t width, uint16_t height, bool actAsBackBuffer = false)
         {
-            return new FrameBufferData(frameBufferHandle, m_activeFrameBuffers, width, height, actAsBackBuffer);
+            const auto fbd = new FrameBufferData(frameBufferHandle, m_activeFrameBuffers, width, height, actAsBackBuffer);
+            fbd->SetUpView(GetNewViewId());
+            return fbd;
         }
 
         FrameBufferData* CreateNew(bgfx::FrameBufferHandle frameBufferHandle, ClearState& clearState, uint16_t width, uint16_t height, bool actAsBackBuffer)
         {
-            return new FrameBufferData(frameBufferHandle, m_activeFrameBuffers, clearState, width, height, actAsBackBuffer);
+            const auto fbd = new FrameBufferData(frameBufferHandle, m_activeFrameBuffers, clearState, width, height, actAsBackBuffer);
+            fbd->SetUpView(GetNewViewId());
+            return fbd;
         }
 
         void Bind(FrameBufferData* data)
@@ -271,7 +275,7 @@ namespace Babylon
         void Unbind(FrameBufferData* data)
         {
             (void)data;
-            assert(m_boundFrameBuffer == data);
+            assert(m_boundFrameBuffer == m_backBuffer || m_boundFrameBuffer == data);
             Bind(m_backBuffer);
         }
 


### PR DESCRIPTION
This PR:

1) Keeps us from unnecessarily creating multiple views for a single framebuffer per-frame.

2) Fixes bug #387, re-adding the call to `bgfx::touch` so that bgfx properly clears the view even when no geometry is submitted to the view for rendering.

3) Addresses bug #344, unbinding the currently-bound frame buffer at the end of the frame.

4) Fixes an issue where we were clearing the view as a side-effect of setting the viewport. Because Babylon.js does not unbind the frame buffer to which the scene was last rendered, the left eye was getting clipped by a call to setViewport at the beginning of the right eye being rendered. On top of this, the size of the view rect created by setViewport always corresponded to the size of the default back buffer (defined by `bgfx::getStats()->[width/height]()`), and not to the currently bound back buffer. [See here for a discussion of this issue on the Babylon.js forum.](https://forum.babylonjs.com/t/bound-active-camera-frame-buffer-not-unbound-in-scene-render/14559)