### PR TITLE
throw runtime_error on bad image data or missing app bundle resource

### DIFF
--- a/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
+++ b/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
@@ -44,6 +44,10 @@ namespace UrlLib
             if ([scheme isEqual:@"app"])
             {
                 NSString* path{[[NSBundle mainBundle] pathForResource:url.path ofType:nil]};
+                if (path == nil)
+                {
+                    throw std::runtime_error{"Invalid resource path in app bundle."};
+                }
                 url = [NSURL fileURLWithPath:path];
             }
             

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1082,8 +1082,10 @@ namespace Babylon
         arcana::make_task(arcana::threadpool_scheduler, m_cancelSource,
             [this, dataSpan, generateMips, invertY]() {
                 bimg::ImageContainer* image = bimg::imageParse(&m_allocator, dataSpan.data(), static_cast<uint32_t>(dataSpan.size()));
-                // todo: bimg::imageParse will return nullptr when trying to load a texture with an url that is not a valid texture
-                // Like a 404 html page.
+                if (image == nullptr)
+                {
+                    throw std::runtime_error("Unable to decode image."); // exeption will be forwarded to JS
+                }
                 if (invertY)
                 {
                     FlipY(image);

--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ correct build system generator for CMake to use, as follows:
 cmake -G Xcode ..
 ```
 
+Starting with Xcode 12, it's mandatory to set the targeted CPU architectures (X86_64 and/or arm64).
+
+````
+cmake .. -GXcode "-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
+```
+
 CMake will generate a new `BabylonNative.xcodeproj` file in your working directory.
 Please be patient; this process can take several minutes. When the process is 
 completed, open the project by double-clicking on it in Finder or by entering the 


### PR DESCRIPTION
fixes #292 

 - Added a comment for building MacOS with Xcode 12
 - Correctly thow an exception that is catched by JS when unable to decode image
 - throw when a missing resource in app bundle 
 
engine.createTexture("https://url_to_an_invalid_image"); is correctly trapped with an error in the JS console (by the thow line 1087 n NativeEngine.cpp)

but

engine.createTexture("app:///invalidResource.png"); is not trapped and the program stops despite the throw line 49 in UrlRequest.mm

I tried to see what's the difference but I was not able to put a finger on it. Any clue @bghgary ?