### PR TITLE
XMLHttpRequest related improvements

### DIFF
--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
@@ -111,6 +111,7 @@ namespace java::io
     {
     public:
         ByteArrayOutputStream();
+        ByteArrayOutputStream(int size);
         ByteArrayOutputStream(jobject object);
 
         void Write(lang::ByteArray b, int off, int len);
@@ -158,6 +159,8 @@ namespace java::net
         void Connect();
 
         URL GetURL() const;
+
+        int GetContentLength() const;
 
         io::InputStream GetInputStream() const;
 

--- a/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
+++ b/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
@@ -73,6 +73,12 @@ namespace java::io
         m_object = m_env->NewObject(m_class, m_env->GetMethodID(m_class, "<init>", "()V"));
     }
 
+    ByteArrayOutputStream::ByteArrayOutputStream(int size)
+        : Object{"java/io/ByteArrayOutputStream", nullptr}
+    {
+        m_object = m_env->NewObject(m_class, m_env->GetMethodID(m_class, "<init>", "(I)V"), size);
+    }
+
     ByteArrayOutputStream::ByteArrayOutputStream(jobject object)
         : Object{"java/io/ByteArrayOutputStream", object}
     {
@@ -151,6 +157,11 @@ namespace java::net
     URL URLConnection::GetURL() const
     {
         return {m_env->CallObjectMethod(m_object, m_env->GetMethodID(m_class, "getURL", "()Ljava/net/URL;"))};
+    }
+
+    int URLConnection::GetContentLength() const
+    {
+        return m_env->CallIntMethod(m_object, m_env->GetMethodID(m_class, "getContentLength", "()I"));
     }
 
     io::InputStream URLConnection::GetInputStream() const

--- a/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
@@ -95,9 +95,13 @@ namespace UrlLib
                     connection.Connect();
 
                     m_statusCode = static_cast<UrlStatusCode>(((HttpURLConnection)connection).GetResponseCode());
+                    int contentLength = connection.GetContentLength();
+                    if (contentLength < 0) {
+                        contentLength = 0;
+                    }
 
                     InputStream inputStream{connection.GetInputStream()};
-                    ByteArrayOutputStream byteArrayOutputStream{};
+                    ByteArrayOutputStream byteArrayOutputStream{contentLength};
 
                     ByteArray byteArray{4096};
                     int bytesRead{};

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
@@ -58,9 +58,11 @@ namespace Babylon::Polyfills::Internal
     {
         Napi::HandleScope scope{env};
 
+        static constexpr auto JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME = "XMLHttpRequest";
+
         Napi::Function func = DefineClass(
             env,
-            "XMLHttpRequest",
+            JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME,
             {
                 StaticValue("UNSENT", Napi::Value::From(env, 0)),
                 StaticValue("OPENED", Napi::Value::From(env, 1)),
@@ -80,7 +82,12 @@ namespace Babylon::Polyfills::Internal
                 InstanceMethod("send", &XMLHttpRequest::Send),
             });
 
-        env.Global().Set(JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME, func);
+        if (env.Global().Get(JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME).IsUndefined())
+        {
+            env.Global().Set(JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME, func);
+        }
+
+        JsRuntime::NativeObject::GetFromJavaScript(env).Set(JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME, func);
     }
 
     XMLHttpRequest::XMLHttpRequest(const Napi::CallbackInfo& info)

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.h
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.h
@@ -11,8 +11,6 @@ namespace Babylon::Polyfills::Internal
 {
     class XMLHttpRequest final : public Napi::ObjectWrap<XMLHttpRequest>
     {
-        static constexpr auto JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME = "XMLHttpRequest";
-
     public:
         static void Initialize(Napi::Env env);
 


### PR DESCRIPTION
This change both (slightly) improves implementation details of `XMLHttpRequest` on Android, and also makes it possible for Babylon.js to use Babylon Native's `XMLHttpRequest` even in the context of React Native (which provides it's own problematic `XMLHttpRequest`).
- In `JavaWrappers` expose the `ByteArrayOutputStream` constructor that takes an initial size. Otherwise if we start at zero, the heuristic for growing the underlying buffer is very aggressive and ends up way over allocating and causing too much memory pressure.
- In `JavaWrappers` expose the `URLConnection.GetContentLength()` function. Sometimes this will provide too small a value (e.g. compressed streams) or no value (when its not known), but it gives us a good chance of getting the actual size so we can pass it to `ByteArrayOutputStream` to pre-allocate the right amount of space.
- In `URLRequest` use `GetContentLength()` to help determine how to size the `ByteArrayOutputStream` initially.
- In `XMLHttpRequest::Initialize(...)` only define `XMLHttpRequest` in the global scope if it is not already defined, and always define it under the `_native` object. Babylon.js's `WebRequest` will check for this before creating an `XMLHttpRequest` from the global scope. See https://github.com/BabylonJS/Babylon.js/commit/7cb5aef616cf195a146eea8c1aca565f1462f059.