### PR TITLE
Fix XMLHttpRequest memory leak

### DIFF
--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -647,6 +647,7 @@ namespace xr {
             CFRunLoopTimerRef timer = CFRunLoopTimerCreateWithHandler(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent(), intervalInSeconds, 0, 0, ^(CFRunLoopTimerRef timer){
                 if ([session currentFrame] != nil) {
                     CFRunLoopRemoveTimer(mainRunLoop, timer, kCFRunLoopCommonModes);
+                    CFRelease(timer);
                     tcs.complete();
                 }
             });

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
@@ -185,6 +185,10 @@ namespace Babylon::Polyfills::Internal
         m_request.SendAsync().then(m_runtimeScheduler, arcana::cancellation::none(), [this](const arcana::expected<void, std::exception_ptr>&) {
             SetReadyState(ReadyState::Done);
             RaiseEvent(EventType::LoadEnd);
+
+            // Assume the XMLHttpRequest will only be used for a single request and clear the event handlers.
+            // Single use seems to be the standard pattern, and we need to release our strong refs to event handlers.
+            m_eventHandlerRefs.clear();
         });
     }
 

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.h
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.h
@@ -38,6 +38,7 @@ namespace Babylon::Polyfills::Internal
         void Send(const Napi::CallbackInfo& info);
 
         void SetReadyState(ReadyState readyState);
+        void RaiseEvent(const char* eventType);
 
         UrlLib::UrlRequest m_request{};
         JsRuntimeScheduler m_runtimeScheduler;


### PR DESCRIPTION
This change addresses leaking the platform agnostic byte buffer as well as the platform specific byte buffer of the downloaded file. So for example, when loading the 5.5mb Surface Pro model, we were leaking about 11mb for each load. There were a couple issues:
1. We didn't have the `loadend` event, which the Babylon.js side uses to complete certain operations and let go of the `WebRequest` that wraps the `XMLHttpRequest`. I added this event.
1. We hold `FunctionReference`s to the event handler callbacks, which are strong references that prevent the JavaScript garbage collector from collecting an otherwise unrooted object graph. I'm now clearing out the event handlers after the request completes.

This partially addresses https://github.com/BabylonJS/BabylonReactNative/issues/102. The other changes that fix the bigger memory leak are in BabylonReactNative, so I will send out a separate PR for that one after this PR.

There was also a really tiny leak in XR.mm, which Cedric noticed and it was also showing up in my profiles so I fixed it (though we may rewrite that bit of code when we expose tracking state).