### PR TITLE
Improve framebuffer view logic

### DIFF
--- a/Apps/ValidationTests/Scripts/config.json
+++ b/Apps/ValidationTests/Scripts/config.json
@@ -43,6 +43,7 @@
         {
             "title": "Black and White post-process",
             "playgroundId": "#N55Q2M#0",
+            "renderCount": 20,
             "referenceImage": "bwpp.png"
         },
         {

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1386,12 +1386,16 @@ namespace Babylon
                     bgfx::setUniform({it.first}, value.Data.data(), value.ElementLength);
                 }
             }
-            // change culling
+
+            // We need to explicitly swap the culling state flags (instead of XOR)
+            // because we would like to preserve the no culling configuration, which is 00.
+            const auto cullCW  = (m_engineState & BGFX_STATE_CULL_CCW) != 0 ? BGFX_STATE_CULL_CW : 0;
+            const auto cullCCW = (m_engineState & BGFX_STATE_CULL_CW) != 0 ? BGFX_STATE_CULL_CCW : 0;
+
             uint64_t m_engineStateYFlipped = m_engineState;
-            if (m_engineStateYFlipped & ~BGFX_STATE_CULL_MASK)
-            {
-                m_engineStateYFlipped ^= BGFX_STATE_CULL_MASK;
-            }
+            m_engineStateYFlipped &= ~BGFX_STATE_CULL_MASK;
+            m_engineStateYFlipped |= (cullCW | cullCCW) << BGFX_STATE_CULL_SHIFT;
+
             bgfx::setState(m_engineStateYFlipped | fillModeState);
         }
         else
@@ -1455,19 +1459,9 @@ namespace Babylon
         const auto y = info[1].As<Napi::Number>().FloatValue();
         const auto width = info[2].As<Napi::Number>().FloatValue();
         const auto height = info[3].As<Napi::Number>().FloatValue();
-
-        const auto backbufferWidth = bgfx::getStats()->width;
-        const auto backbufferHeight = bgfx::getStats()->height;
         const float yOrigin = bgfx::getCaps()->originBottomLeft ? y : (1.f - y - height);
 
-        m_frameBufferManager.GetBound().UseViewId(m_frameBufferManager.GetNewViewId());
-        const bgfx::ViewId viewId = m_frameBufferManager.GetBound().ViewId;
-        bgfx::setViewFrameBuffer(viewId, m_frameBufferManager.GetBound().FrameBuffer);
-        bgfx::setViewRect(viewId,
-            static_cast<uint16_t>(x * backbufferWidth),
-            static_cast<uint16_t>(yOrigin * backbufferHeight),
-            static_cast<uint16_t>(width * backbufferWidth),
-            static_cast<uint16_t>(height * backbufferHeight));
+        m_frameBufferManager.GetBound().SetViewPort(x, yOrigin, width, height);
     }
 
     void NativeEngine::GetFramebufferData(const Napi::CallbackInfo& info)

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -149,19 +149,22 @@ namespace Babylon
         void UpdateViewId(uint16_t viewId)
         {
             m_viewId = viewId;
-            Update();
+            Update(false);
         }
 
     private:
 
-        void Update() const
+        void Update(bool forceClear = true) const
         {
             bgfx::setViewClear(m_viewId, m_clearState.Flags, m_clearState.Color(), m_clearState.Depth, m_clearState.Stencil);
-            // Discard any previously set state
-            bgfx::discard();
-            // Submit an empty primitive so we always clear the framebuffer on bgfx::frame,
-            // even if no other geometry is rendered to this view.
-            bgfx::touch(m_viewId);
+            if (forceClear)
+            {
+                // Discard any previously set state
+                bgfx::discard();
+                // Submit an empty primitive so we always clear the framebuffer on bgfx::frame,
+                // even if no other geometry is rendered to this view.
+                bgfx::touch(m_viewId);
+            }
         }
 
         uint16_t m_viewId{};

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -252,11 +252,7 @@ namespace Babylon
     {
         FrameBufferManager()
         {
-            // Create the default back buffer, which for bgfx corresponds to view id 0 by default.
-            // If we bind BGFX_INVALID_HANDLE to any other view id, bgfx will still just render
-            // to the default back buffer (view id 0). We also resize the default back buffer to
-            // the window size, so we can pass in 0 for width & height.
-            Bind(m_defaultBackBuffer = new FrameBufferData(BGFX_INVALID_HANDLE, m_activeFrameBuffers, 0, 0, 0, true, true));
+            Bind(m_defaultBackBuffer = new FrameBufferData(BGFX_INVALID_HANDLE, m_activeFrameBuffers, GetNewViewId(), 0, 0, true, true));
         }
 
         FrameBufferData* CreateNew(bgfx::FrameBufferHandle frameBufferHandle, uint16_t width, uint16_t height)
@@ -307,11 +303,7 @@ namespace Babylon
         {
             m_nextId = 0;
             m_activeFrameBuffers.apply_to_all([](auto frameBufferData) {
-                // Mark all except the default back buffer as dirty, since
-                // view id 0 is always BGFX_INVALID_HANDLE, and Babylon.js
-                // will always explicitly set up the rendering state of the
-                // default back buffer per-frame, as this is what WebGL requires.
-                frameBufferData->IsViewIdDirty = frameBufferData->ViewId != 0;
+                frameBufferData->IsViewIdDirty = true;
             });
         }
 

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -157,8 +157,11 @@ namespace Babylon
         void Update() const
         {
             bgfx::setViewClear(m_viewId, m_clearState.Flags, m_clearState.Color(), m_clearState.Depth, m_clearState.Stencil);
-            // discard any previous set state
+            // Discard any previously set state
             bgfx::discard();
+            // Submit an empty primitive so we always clear the framebuffer on bgfx::frame,
+            // even if no other geometry is rendered to this view.
+            bgfx::touch(m_viewId);
         }
 
         uint16_t m_viewId{};
@@ -169,31 +172,34 @@ namespace Babylon
     struct FrameBufferData final
     {
     private:
+        arcana::weak_table<FrameBufferData*>::ticket m_managerTicket;
         std::unique_ptr<ClearState> m_clearState{};
 
     public:
-        FrameBufferData(bgfx::FrameBufferHandle frameBuffer, uint16_t viewId, uint16_t width, uint16_t height, bool actAsBackBuffer = false)
-            : m_clearState{std::make_unique<ClearState>()}
+        FrameBufferData(bgfx::FrameBufferHandle frameBuffer, arcana::weak_table<FrameBufferData*>& managerTable, uint16_t viewId, uint16_t width, uint16_t height, bool actAsBackBuffer = false, bool sizeViewToWindow = false)
+            : m_managerTicket{managerTable.insert(this)}
+            , m_clearState{std::make_unique<ClearState>()}
             , FrameBuffer{frameBuffer}
-            , ViewId{viewId}
-            , ViewClearState{ViewId, *m_clearState}
+            , ViewClearState{viewId, *m_clearState}
             , Width{width}
             , Height{height}
             , ActAsBackBuffer{actAsBackBuffer}
+            , SizeViewToWindow{sizeViewToWindow}
         {
-            assert(ViewId < bgfx::getCaps()->limits.maxViews);
+            UseViewId(viewId);
         }
 
-        FrameBufferData(bgfx::FrameBufferHandle frameBuffer, uint16_t viewId, ClearState& clearState, uint16_t width, uint16_t height, bool actAsBackBuffer = false)
-            : m_clearState{}
+        FrameBufferData(bgfx::FrameBufferHandle frameBuffer, arcana::weak_table<FrameBufferData*>& managerTable, uint16_t viewId, ClearState& clearState, uint16_t width, uint16_t height, bool actAsBackBuffer = false, bool sizeViewToWindow = false)
+            : m_managerTicket{managerTable.insert(this)}
+            , m_clearState{}
             , FrameBuffer{frameBuffer}
-            , ViewId{viewId}
-            , ViewClearState{ViewId, clearState}
+            , ViewClearState{viewId, clearState}
             , Width{width}
             , Height{height}
             , ActAsBackBuffer{actAsBackBuffer}
+            , SizeViewToWindow{sizeViewToWindow}
         {
-            assert(ViewId < bgfx::getCaps()->limits.maxViews);
+            UseViewId(viewId);
         }
 
         FrameBufferData(FrameBufferData&) = delete;
@@ -205,22 +211,36 @@ namespace Babylon
 
         void UseViewId(uint16_t viewId)
         {
-            ViewId = viewId;
-            ViewClearState.UpdateViewId(ViewId);
+            assert(viewId < bgfx::getCaps()->limits.maxViews);
+            // Only update if we need to.
+            if (IsViewIdDirty || viewId != ViewId)
+            {
+                ViewId = viewId;
+                bgfx::setViewFrameBuffer(ViewId, FrameBuffer);
+                SetViewPort(0, 0, 1, 1); // Default to full viewport
+                ViewClearState.UpdateViewId(ViewId);
+                IsViewIdDirty = false;
+            }
         }
 
-        void SetUpView(uint16_t viewId)
+        void SetViewPort(const float x, const float y, const float width, const float height)
         {
-            bgfx::setViewFrameBuffer(viewId, FrameBuffer);
-            UseViewId(viewId);
-            bgfx::setViewRect(ViewId, 0, 0, Width, Height);
+            const auto viewRectWidth = SizeViewToWindow ? bgfx::getStats()->width : Width;
+            const auto viewRectHeight = SizeViewToWindow ? bgfx::getStats()->height : Height;
+            bgfx::setViewRect(ViewId,
+                static_cast<uint16_t>(x * viewRectWidth),
+                static_cast<uint16_t>(y * viewRectHeight),
+                static_cast<uint16_t>(width * viewRectWidth),
+                static_cast<uint16_t>(height * viewRectHeight));
         }
 
         bgfx::FrameBufferHandle FrameBuffer{bgfx::kInvalidHandle};
-        bgfx::ViewId ViewId{};
+        bgfx::ViewId ViewId{uint16_t(~0)};
+        bool IsViewIdDirty{true};
         Babylon::ViewClearState ViewClearState;
         uint16_t Width{};
         uint16_t Height{};
+        bool SizeViewToWindow{false};
         // When a FrameBuffer acts as a back buffer, it means it will not be used as a texture in a shader.
         // For example as a post process. It will be used as-is in a swapchain or for direct rendering (XR)
         // When this flag is true, projection matrix will not be flipped for API that would normaly need it.
@@ -232,26 +252,29 @@ namespace Babylon
     {
         FrameBufferManager()
         {
-            m_boundFrameBuffer = m_backBuffer = new FrameBufferData(BGFX_INVALID_HANDLE, GetNewViewId(), bgfx::getStats()->width, bgfx::getStats()->height);
+            // Create the default back buffer, which for bgfx corresponds to view id 0 by default.
+            // If we bind BGFX_INVALID_HANDLE to any other view id, bgfx will still just render
+            // to the default back buffer (view id 0). We also resize the default back buffer to
+            // the window size, so we can pass in 0 for width & height.
+            Bind(m_defaultBackBuffer = new FrameBufferData(BGFX_INVALID_HANDLE, m_activeFrameBuffers, 0, 0, 0, true, true));
         }
 
         FrameBufferData* CreateNew(bgfx::FrameBufferHandle frameBufferHandle, uint16_t width, uint16_t height)
         {
-            return new FrameBufferData(frameBufferHandle, GetNewViewId(), width, height);
+            return new FrameBufferData(frameBufferHandle, m_activeFrameBuffers, GetNewViewId(), width, height);
         }
 
         FrameBufferData* CreateNew(bgfx::FrameBufferHandle frameBufferHandle, ClearState& clearState, uint16_t width, uint16_t height, bool actAsBackBuffer)
         {
-            return new FrameBufferData(frameBufferHandle, GetNewViewId(), clearState, width, height, actAsBackBuffer);
+            return new FrameBufferData(frameBufferHandle, m_activeFrameBuffers, GetNewViewId(), clearState, width, height, actAsBackBuffer);
         }
 
         void Bind(FrameBufferData* data)
         {
             m_boundFrameBuffer = data;
 
-            // TODO: Consider doing this only on bgfx::reset(); the effects of this call don't survive reset, but as
-            // long as there's no reset this doesn't technically need to be called every time the frame buffer is bound.
-            m_boundFrameBuffer->SetUpView(GetNewViewId());
+            const auto fbViewId = m_boundFrameBuffer->IsViewIdDirty ? GetNewViewId() : m_boundFrameBuffer->ViewId;
+            m_boundFrameBuffer->UseViewId(fbViewId);
 
             // bgfx::setTexture()? Why?
             // TODO: View order?
@@ -265,11 +288,12 @@ namespace Babylon
 
         void Unbind(FrameBufferData* data)
         {
-            // this assert is commented because of an issue with XR described here : https://github.com/BabylonJS/BabylonNative/issues/344
-            //assert(m_boundFrameBuffer == data);
             (void)data;
-            m_boundFrameBuffer = m_backBuffer;
-            m_renderingToTarget = false;
+            if (m_boundFrameBuffer != m_defaultBackBuffer)
+            {
+                assert(m_boundFrameBuffer == data);
+                Bind(m_defaultBackBuffer);
+            }
         }
 
         uint16_t GetNewViewId()
@@ -282,6 +306,13 @@ namespace Babylon
         void Reset()
         {
             m_nextId = 0;
+            m_activeFrameBuffers.apply_to_all([](auto frameBufferData) {
+                // Mark all except the default back buffer as dirty, since
+                // view id 0 is always BGFX_INVALID_HANDLE, and Babylon.js
+                // will always explicitly set up the rendering state of the
+                // default back buffer per-frame, as this is what WebGL requires.
+                frameBufferData->IsViewIdDirty = frameBufferData->ViewId != 0;
+            });
         }
 
         bool IsRenderingToTarget() const
@@ -291,7 +322,8 @@ namespace Babylon
 
     private:
         FrameBufferData* m_boundFrameBuffer{nullptr};
-        FrameBufferData* m_backBuffer{nullptr};
+        FrameBufferData* m_defaultBackBuffer{nullptr};
+        arcana::weak_table<FrameBufferData*> m_activeFrameBuffers{};
         uint16_t m_nextId{0};
         bool m_renderingToTarget{false};
     };

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -183,8 +183,8 @@ namespace Babylon
             , ViewClearState{viewId, *m_clearState}
             , Width{width}
             , Height{height}
-            , ActAsBackBuffer{actAsBackBuffer}
             , SizeViewToWindow{sizeViewToWindow}
+            , ActAsBackBuffer{actAsBackBuffer}
         {
             UseViewId(viewId);
         }
@@ -196,8 +196,8 @@ namespace Babylon
             , ViewClearState{viewId, clearState}
             , Width{width}
             , Height{height}
-            , ActAsBackBuffer{actAsBackBuffer}
             , SizeViewToWindow{sizeViewToWindow}
+            , ActAsBackBuffer{actAsBackBuffer}
         {
             UseViewId(viewId);
         }


### PR DESCRIPTION
This PR improves the logic around managing view id assignments for framebuffers: 
* Assign new view id's per-frame instead of per-bind, and notify framebuffers of dirty view id's by maintaining a table of self-destructible weak references.
* Set the view rect to the size of the framebuffer by default, and conditionally set the size to match the window, instead of always just sizing to the window, since in XR we aren't always rendering to a window-sized backbuffer.
* Keep the default backbuffer assigned to view id 0 in order to stay consistent with bgfx's convention. This is strictly better than what we were doing before (assigning `BGFX_INVALID_HANDLE` to view id 1) because we were effectively assigning two view id's to the default backbuffer, one through default bgfx behavior and one explicitly in the framebuffer manager constructor.
* Fix a bug in the culling swap logic for render targets (discovered when a post-processing validation test failed) by manually swapping the bits instead of using XOR.
* Re-add bgfx::touch call so that we clear our views even when no geometry is rendered inside the clipping volume.