### PR TITLE
Roll back XHR fix to see if it fixes CI flakeyness

### DIFF
--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
@@ -51,7 +51,6 @@ namespace Babylon::Polyfills::Internal
         namespace EventType
         {
             constexpr const char* ReadyStateChange = "readystatechange";
-            constexpr const char* LoadEnd = "loadend";
         }
     }
 
@@ -62,26 +61,26 @@ namespace Babylon::Polyfills::Internal
         static constexpr auto JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME = "XMLHttpRequest";
 
         Napi::Function func = DefineClass(
-            env,
-            JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME,
-            {
-                StaticValue("UNSENT", Napi::Value::From(env, 0)),
-                StaticValue("OPENED", Napi::Value::From(env, 1)),
-                StaticValue("HEADERS_RECEIVED", Napi::Value::From(env, 2)),
-                StaticValue("LOADING", Napi::Value::From(env, 3)),
-                StaticValue("DONE", Napi::Value::From(env, 4)),
-                InstanceAccessor("readyState", &XMLHttpRequest::GetReadyState, nullptr),
-                InstanceAccessor("response", &XMLHttpRequest::GetResponse, nullptr),
-                InstanceAccessor("responseText", &XMLHttpRequest::GetResponseText, nullptr),
-                InstanceAccessor("responseType", &XMLHttpRequest::GetResponseType, &XMLHttpRequest::SetResponseType),
-                InstanceAccessor("responseURL", &XMLHttpRequest::GetResponseURL, nullptr),
-                InstanceAccessor("status", &XMLHttpRequest::GetStatus, nullptr),
-                InstanceMethod("addEventListener", &XMLHttpRequest::AddEventListener),
-                InstanceMethod("removeEventListener", &XMLHttpRequest::RemoveEventListener),
-                InstanceMethod("abort", &XMLHttpRequest::Abort),
-                InstanceMethod("open", &XMLHttpRequest::Open),
-                InstanceMethod("send", &XMLHttpRequest::Send),
-            });
+                env,
+                JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME,
+                {
+                        StaticValue("UNSENT", Napi::Value::From(env, 0)),
+                        StaticValue("OPENED", Napi::Value::From(env, 1)),
+                        StaticValue("HEADERS_RECEIVED", Napi::Value::From(env, 2)),
+                        StaticValue("LOADING", Napi::Value::From(env, 3)),
+                        StaticValue("DONE", Napi::Value::From(env, 4)),
+                        InstanceAccessor("readyState", &XMLHttpRequest::GetReadyState, nullptr),
+                        InstanceAccessor("response", &XMLHttpRequest::GetResponse, nullptr),
+                        InstanceAccessor("responseText", &XMLHttpRequest::GetResponseText, nullptr),
+                        InstanceAccessor("responseType", &XMLHttpRequest::GetResponseType, &XMLHttpRequest::SetResponseType),
+                        InstanceAccessor("responseURL", &XMLHttpRequest::GetResponseURL, nullptr),
+                        InstanceAccessor("status", &XMLHttpRequest::GetStatus, nullptr),
+                        InstanceMethod("addEventListener", &XMLHttpRequest::AddEventListener),
+                        InstanceMethod("removeEventListener", &XMLHttpRequest::RemoveEventListener),
+                        InstanceMethod("abort", &XMLHttpRequest::Abort),
+                        InstanceMethod("open", &XMLHttpRequest::Open),
+                        InstanceMethod("send", &XMLHttpRequest::Send),
+                });
 
         if (env.Global().Get(JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME).IsUndefined())
         {
@@ -92,8 +91,8 @@ namespace Babylon::Polyfills::Internal
     }
 
     XMLHttpRequest::XMLHttpRequest(const Napi::CallbackInfo& info)
-        : Napi::ObjectWrap<XMLHttpRequest>{info}
-        , m_runtimeScheduler{JsRuntime::GetFromJavaScript(info.Env())}
+            : Napi::ObjectWrap<XMLHttpRequest>{info}
+            , m_runtimeScheduler{JsRuntime::GetFromJavaScript(info.Env())}
     {
     }
 
@@ -182,25 +181,16 @@ namespace Babylon::Polyfills::Internal
 
     void XMLHttpRequest::Send(const Napi::CallbackInfo& /*info*/)
     {
-        m_request.SendAsync().then(m_runtimeScheduler, arcana::cancellation::none(), [this](const arcana::expected<void, std::exception_ptr>&) {
+        m_request.SendAsync().then(m_runtimeScheduler, arcana::cancellation::none(), [this]() {
             SetReadyState(ReadyState::Done);
-            RaiseEvent(EventType::LoadEnd);
-
-            // Assume the XMLHttpRequest will only be used for a single request and clear the event handlers.
-            // Single use seems to be the standard pattern, and we need to release our strong refs to event handlers.
-            m_eventHandlerRefs.clear();
         });
     }
 
     void XMLHttpRequest::SetReadyState(ReadyState readyState)
     {
         m_readyState = readyState;
-        RaiseEvent(EventType::ReadyStateChange);
-    }
 
-    void XMLHttpRequest::RaiseEvent(const char* eventType)
-    {
-        auto it = m_eventHandlerRefs.find(eventType);
+        auto it = m_eventHandlerRefs.find(EventType::ReadyStateChange);
         if (it != m_eventHandlerRefs.end())
         {
             const auto& eventHandlerRefs = it->second;

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.h
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.h
@@ -38,7 +38,6 @@ namespace Babylon::Polyfills::Internal
         void Send(const Napi::CallbackInfo& info);
 
         void SetReadyState(ReadyState readyState);
-        void RaiseEvent(const char* eventType);
 
         UrlLib::UrlRequest m_request{};
         JsRuntimeScheduler m_runtimeScheduler;


### PR DESCRIPTION
Empirical evidence suggests this change caused the CI validation tests to become flakey. Rolling it back for now while we investigate.