### PR TITLE
UrlLib/XMLHttpRequest error handling

### DIFF
--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
@@ -108,10 +108,14 @@ namespace java::lang
     {
     public:
         Throwable(jthrowable throwable);
+        ~Throwable();
 
         String GetMessage() const;
 
         const char* what() const noexcept override;
+
+    private:
+        jobject m_throwableRef;
     };
 }
 

--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
@@ -103,6 +103,14 @@ namespace java::lang
         JNIEnv* m_env;
         jstring m_string;
     };
+
+    class Throwable : public Object
+    {
+    public:
+        Throwable(jthrowable throwable);
+
+        String GetMessage() const;
+    };
 }
 
 namespace java::io

--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
@@ -104,12 +104,14 @@ namespace java::lang
         jstring m_string;
     };
 
-    class Throwable : public Object
+    class Throwable : public Object, public std::exception
     {
     public:
         Throwable(jthrowable throwable);
 
         String GetMessage() const;
+
+        const char* what() const noexcept override;
     };
 }
 

--- a/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
+++ b/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
@@ -79,7 +79,13 @@ namespace java::lang
 
     Throwable::Throwable(jthrowable throwable)
         : Object{"java/lang/Throwable", throwable}
+        , m_throwableRef{m_env->NewGlobalRef(throwable)}
     {
+    }
+
+    Throwable::~Throwable()
+    {
+        m_env->DeleteGlobalRef(m_throwableRef);
     }
 
     String Throwable::GetMessage() const
@@ -149,7 +155,9 @@ namespace java::net
 
     int HttpURLConnection::GetResponseCode() const
     {
-        return m_env->CallIntMethod(m_object, m_env->GetMethodID(m_class, "getResponseCode", "()I"));
+        auto responseCode = m_env->CallIntMethod(m_object, m_env->GetMethodID(m_class, "getResponseCode", "()I"));
+        ThrowIfFaulted(m_env);
+        return responseCode;
     }
 
     URL::URL(lang::String url)

--- a/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
+++ b/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
@@ -12,8 +12,7 @@ namespace
         {
             auto jthrowable{env->ExceptionOccurred()};
             env->ExceptionClear();
-            java::lang::Throwable throwable{jthrowable};
-            throw std::runtime_error{throwable.GetMessage()};
+            throw java::lang::Throwable{jthrowable};
         }
     }
 }
@@ -86,6 +85,12 @@ namespace java::lang
     String Throwable::GetMessage() const
     {
         return {(jstring)m_env->CallObjectMethod(m_object, m_env->GetMethodID(m_class, "getMessage", "()Ljava/lang/String;"))};
+    }
+
+    const char* Throwable::what() const noexcept
+    {
+        std::string message = GetMessage();
+        return message.c_str();
     }
 }
 

--- a/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
+++ b/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
@@ -52,7 +52,7 @@ namespace UrlLib
                 }
                 url = [NSURL fileURLWithPath:path];
             }
-            
+
             NSURLSession* session{[NSURLSession sharedSession]};
             NSURLRequest* request{[NSURLRequest requestWithURL:url]};
 

--- a/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
+++ b/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
@@ -48,7 +48,8 @@ namespace UrlLib
                 NSString* path{[[NSBundle mainBundle] pathForResource:url.path ofType:nil]};
                 if (path == nil)
                 {
-                    return arcana::task_from_error<void>(std::make_exception_ptr(std::runtime_error{"Invalid resource path in app bundle."}));
+                    // Complete the task, but retain the default status code of 0 to indicate a client side error.
+                    return arcana::task_from_result<std::exception_ptr>();
                 }
                 url = [NSURL fileURLWithPath:path];
             }
@@ -62,7 +63,9 @@ namespace UrlLib
             {
                 if (error != nil)
                 {
-                    taskCompletionSource.complete(arcana::make_unexpected(std::make_exception_ptr(std::runtime_error{[[error localizedDescription] UTF8String]})));
+                    // Complete the task, but retain the default status code of 0 to indicate a client side error.
+                    // TODO: Consider logging or otherwise exposing the error message in some way via: [[error localizedDescription] UTF8String]
+                    taskCompletionSource.complete();
                     return;
                 }
                 
@@ -126,7 +129,7 @@ namespace UrlLib
         {
             if (m_responseBuffer)
             {
-                return { reinterpret_cast<const std::byte*>(m_responseBuffer.bytes), static_cast<long>(m_responseBuffer.length) };
+                return {reinterpret_cast<const std::byte*>(m_responseBuffer.bytes), static_cast<long>(m_responseBuffer.length)};
             }
 
             return {};

--- a/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
+++ b/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
@@ -12,6 +12,10 @@ namespace UrlLib
         ~Impl()
         {
             Abort();
+            if (m_responseBuffer)
+            {
+                [m_responseBuffer release];
+            }
         }
 
         void Abort()
@@ -37,8 +41,6 @@ namespace UrlLib
 
         arcana::task<void, std::exception_ptr> SendAsync()
         {
-            __block arcana::task_completion_source<void, std::exception_ptr> taskCompletionSource{};
-            
             NSURL* url{[NSURL URLWithString:[NSString stringWithUTF8String:m_url.data()]]};
             NSString* scheme{url.scheme};
             if ([scheme isEqual:@"app"])
@@ -46,19 +48,22 @@ namespace UrlLib
                 NSString* path{[[NSBundle mainBundle] pathForResource:url.path ofType:nil]};
                 if (path == nil)
                 {
-                    throw std::runtime_error{"Invalid resource path in app bundle."};
+                    return arcana::task_from_error<void>(std::make_exception_ptr(std::runtime_error{"Invalid resource path in app bundle."}));
                 }
                 url = [NSURL fileURLWithPath:path];
             }
             
             NSURLSession* session{[NSURLSession sharedSession]};
             NSURLRequest* request{[NSURLRequest requestWithURL:url]};
-            
+
+            __block arcana::task_completion_source<void, std::exception_ptr> taskCompletionSource{};
+
             id completionHandler{^(NSData* data, NSURLResponse* response, NSError* error)
             {
                 if (error != nil)
                 {
-                    throw std::runtime_error{[[error localizedDescription] UTF8String]};
+                    taskCompletionSource.complete(arcana::make_unexpected(std::make_exception_ptr(std::runtime_error{[[error localizedDescription] UTF8String]})));
+                    return;
                 }
                 
                 if ([response class] == [NSHTTPURLResponse class])
@@ -82,14 +87,13 @@ namespace UrlLib
                         }
                         case UrlResponseType::Buffer:
                         {
-                            // TODO: Is it better to avoid copying and retain NSData instead?
-                            m_responseBuffer.resize(data.length);
-                            std::memcpy(m_responseBuffer.data(), data.bytes, data.length);
+                            [data retain];
+                            m_responseBuffer = data;
                             break;
                         }
                         default:
                         {
-                            throw std::runtime_error{"Invalid response type"};
+                            taskCompletionSource.complete(arcana::make_unexpected(std::make_exception_ptr(std::runtime_error{"Invalid response type"})));
                         }
                     }
                 }
@@ -120,7 +124,12 @@ namespace UrlLib
 
         gsl::span<const std::byte> ResponseBuffer() const
         {
-            return m_responseBuffer;
+            if (m_responseBuffer)
+            {
+                return { reinterpret_cast<const std::byte*>(m_responseBuffer.bytes), static_cast<long>(m_responseBuffer.length) };
+            }
+
+            return {};
         }
 
     private:
@@ -131,7 +140,7 @@ namespace UrlLib
         UrlStatusCode m_statusCode{UrlStatusCode::None};
         std::string m_responseUrl{};
         std::string m_responseString{};
-        std::vector<std::byte> m_responseBuffer{};
+        NSData* m_responseBuffer{};
     };
 }
 

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
@@ -183,6 +183,10 @@ namespace Babylon::Polyfills::Internal
     void XMLHttpRequest::Send(const Napi::CallbackInfo& /*info*/)
     {
         m_request.SendAsync().then(m_runtimeScheduler, arcana::cancellation::none(), [this](const arcana::expected<void, std::exception_ptr>&) {
+            // NOTE: In the case of a client side error (e.g. no internet connection), the task returned by SendAsync will complete in an
+            // exceptional state. However, UrlRequest::StatusCode() should return 0 in this case, which is consistent with the browser,
+            // so we can safely ignore the exception.
+
             SetReadyState(ReadyState::Done);
             RaiseEvent(EventType::LoadEnd);
 


### PR DESCRIPTION
On both Android and iOS, if a client side error (such as no internet connection) occurred, the app would crash. In the case of iOS, it was because we were throwing exceptions inside a Cocoa callback rather than propagating them throw the arcana task returned from `SendAsync`. In the case of Android, it was because we were not checking for Java exceptions and converting them to C++ exceptions.

I also snuck one other small change in here, which is to not copy data out of `NSData` into a `std::vector`, but rather just take a strong reference to the `NSData` and return a `gsl::span` that directly references the `NSData`. This just eliminates an extra data copy, which can be rather large depending on the file being downloaded.

This mostly addresses https://github.com/BabylonJS/BabylonNative/issues/465, though we also need https://github.com/BabylonJS/Babylon.js/pull/9335 (included in @babylonjs/core@4.2.0-rc.2) for everything to be fully working.