### PR TITLE
Fix texture data lifetime management issues

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1064,7 +1064,7 @@ namespace Babylon
         const auto onError = info[5].As<Napi::Function>();
 
         const auto dataSpan = gsl::make_span(static_cast<uint8_t*>(data.ArrayBuffer().Data()) + data.ByteOffset(), data.ByteLength());
-//
+
         arcana::make_task(arcana::threadpool_scheduler, m_cancelSource,
             [this, dataSpan, dataRef = Napi::Persistent(data), generateMips, invertY]() {
                 bimg::ImageContainer* image = bimg::imageParse(&m_allocator, dataSpan.data(), static_cast<uint32_t>(dataSpan.size()));

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1064,7 +1064,7 @@ namespace Babylon
         const auto onError = info[5].As<Napi::Function>();
 
         const auto dataSpan = gsl::make_span(static_cast<uint8_t*>(data.ArrayBuffer().Data()) + data.ByteOffset(), data.ByteLength());
-
+//
         arcana::make_task(arcana::threadpool_scheduler, m_cancelSource,
             [this, dataSpan, dataRef = Napi::Persistent(data), generateMips, invertY]() {
                 bimg::ImageContainer* image = bimg::imageParse(&m_allocator, dataSpan.data(), static_cast<uint32_t>(dataSpan.size()));

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1063,14 +1063,13 @@ namespace Babylon
         const auto onSuccess = info[4].As<Napi::Function>();
         const auto onError = info[5].As<Napi::Function>();
 
-        const auto dataSpan = gsl::make_span(static_cast<uint8_t*>(data.ArrayBuffer().Data()) + data.ByteOffset(), data.ByteLength());
-
         arcana::make_task(arcana::threadpool_scheduler, m_cancelSource,
-            [this, dataSpan, generateMips, invertY]() {
+            [this, data = Napi::Persistent(data), generateMips, invertY]() {
+                const auto dataSpan = gsl::make_span(static_cast<uint8_t*>(data.Value().ArrayBuffer().Data()) + data.Value().ByteOffset(), data.Value().ByteLength());
                 bimg::ImageContainer* image = bimg::imageParse(&m_allocator, dataSpan.data(), static_cast<uint32_t>(dataSpan.size()));
                 if (image == nullptr)
                 {
-                    throw std::runtime_error("Unable to decode image."); // exeption will be forwarded to JS
+                    throw std::runtime_error("Unable to decode image."); // exception will be forwarded to JS
                 }
                 if (invertY)
                 {
@@ -1112,8 +1111,8 @@ namespace Babylon
         for (uint32_t face = 0; face < data.Length(); face++)
         {
             const auto typedArray = data[face].As<Napi::TypedArray>();
-            const auto dataSpan = gsl::make_span(static_cast<uint8_t*>(typedArray.ArrayBuffer().Data()) + typedArray.ByteOffset(), typedArray.ByteLength());
-            tasks[face] = arcana::make_task(arcana::threadpool_scheduler, m_cancelSource, [this, dataSpan, generateMips]() {
+            tasks[face] = arcana::make_task(arcana::threadpool_scheduler, m_cancelSource, [this, typedArray = Napi::Persistent(typedArray), generateMips]() {
+                const auto dataSpan = gsl::make_span(static_cast<uint8_t*>(typedArray.Value().ArrayBuffer().Data()) + typedArray.Value().ByteOffset(), typedArray.Value().ByteLength());
                 bimg::ImageContainer* image = bimg::imageParse(&m_allocator, dataSpan.data(), static_cast<uint32_t>(dataSpan.size()));
                 if (generateMips)
                 {
@@ -1156,8 +1155,8 @@ namespace Babylon
             for (uint32_t face = 0; face < 6; face++)
             {
                 const auto typedArray = faceData[face].As<Napi::TypedArray>();
-                const auto dataSpan = gsl::make_span(static_cast<uint8_t*>(typedArray.ArrayBuffer().Data()) + typedArray.ByteOffset(), typedArray.ByteLength());
-                tasks[(face * numMips) + mip] = arcana::make_task(arcana::threadpool_scheduler, m_cancelSource, [this, dataSpan]() {
+                tasks[(face * numMips) + mip] = arcana::make_task(arcana::threadpool_scheduler, m_cancelSource, [this, typedArray = Napi::Persistent(typedArray)]() {
+                    const auto dataSpan = gsl::make_span(static_cast<uint8_t*>(typedArray.Value().ArrayBuffer().Data()) + typedArray.Value().ByteOffset(), typedArray.Value().ByteLength());
                     bimg::ImageContainer* image = bimg::imageParse(&m_allocator, dataSpan.data(), static_cast<uint32_t>(dataSpan.size()));
                     FlipY(image);
                     return image;

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1140,7 +1140,7 @@ namespace Babylon
                 }
             });
     }
-//
+
     void NativeEngine::LoadCubeTextureWithMips(const Napi::CallbackInfo& info)
     {
         const auto texture = info[0].As<Napi::External<TextureData>>().Data();

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1140,7 +1140,7 @@ namespace Babylon
                 }
             });
     }
-
+//
     void NativeEngine::LoadCubeTextureWithMips(const Napi::CallbackInfo& info)
     {
         const auto texture = info[0].As<Napi::External<TextureData>>().Data();

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
@@ -105,7 +105,9 @@ namespace Babylon::Polyfills::Internal
     Napi::Value XMLHttpRequest::GetResponse(const Napi::CallbackInfo&)
     {
         gsl::span<const std::byte> responseBuffer{m_request.ResponseBuffer()};
-        return Napi::ArrayBuffer::New(Env(), const_cast<std::byte*>(responseBuffer.data()), responseBuffer.size());
+        auto arrayBuffer{Napi::ArrayBuffer::New(Env(), responseBuffer.size())};
+        std::memcpy(arrayBuffer.Data(), responseBuffer.data(), arrayBuffer.ByteLength());
+        return std::move(arrayBuffer);
     }
 
     Napi::Value XMLHttpRequest::GetResponseText(const Napi::CallbackInfo&)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,7 @@ jobs:
   - script: |
       mkdir buildWin32_x64
       cd buildWin32_x64
-      cmake -G "Visual Studio 16 2019" -A x64 -DNAPI_JAVASCRIPT_ENGINE=V8 ..
+      cmake -G "Visual Studio 16 2019" -A x64 ..
     displayName: 'Generate Win32_x64 solution'
 
   - task: MSBuild@1
@@ -150,7 +150,7 @@ jobs:
   - script: |
       mkdir buildWin32_x86
       cd buildWin32_x86
-      cmake .. -G "Visual Studio 16 2019" -A Win32 -DNAPI_JAVASCRIPT_ENGINE=V8
+      cmake .. -G "Visual Studio 16 2019" -A Win32
     displayName: 'Generate Win32_x86 solution'
 
   - task: MSBuild@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,7 +95,7 @@ jobs:
   - script: |
       reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\ValidationTests.exe"
       reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\ValidationTests.exe" /v DumpType /t REG_DWORD /d 2
-      reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\ValidationTests.exe" /v DumpCount /t REG_DWORD /d 2
+      reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\ValidationTests.exe" /v DumpCount /t REG_DWORD /d 1
       reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\ValidationTests.exe" /v DumpFolder /t REG_SZ /d "$(Build.ArtifactStagingDirectory)/Dumps"
     displayName: 'Enable Crash Dumps'
 
@@ -163,7 +163,7 @@ jobs:
   - script: |
       reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\ValidationTests.exe"
       reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\ValidationTests.exe" /v DumpType /t REG_DWORD /d 2
-      reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\ValidationTests.exe" /v DumpCount /t REG_DWORD /d 2
+      reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\ValidationTests.exe" /v DumpCount /t REG_DWORD /d 1
       reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\ValidationTests.exe" /v DumpFolder /t REG_SZ /d "$(Build.ArtifactStagingDirectory)/Dumps"
     displayName: 'Enable Crash Dumps'
 


### PR DESCRIPTION
There were a couple of problems with our lifetime management of buffers obtained through `XMLHttpRequest` that contain texture data loaded asynchronously:
1. The native memory was managed by the lifetime of the underlying `UrlRequest`, owned by the native `XMLHttpRequest`. If the JavaScript side asks for the `ArrayBuffer` of the downloaded data and holds onto it but doesn't hold onto the `XMLHttpRequest`, then that native memory is deleted from under us and we end up accessing deleted memory while asynchronously loading a texture (or possibly other data). The fix for this for now is to make a copy of the data into the `ArrayBuffer` so the JS side can own it. We could improve on this by ref counting the native memory, but we should address that with #445.
1. The native code that does the async texture loading does not take a strong reference on the JS `ArrayBuffer`, so it could be garbage collected before we finish reading it to create a texture. The fix for this is to capture a strong ref via `Napi::Persistent`.

Having these fixes in place, I'm also switching back to Chakra instead of V8 for Windows as it seems to reveal these issues better (maybe a more aggressive garbage collector).

One other change I'm sneaking in to this PR is to reduce the max dump count from 2 to 1. I originally used 2 just so we would know if something unexpected is happening, but when you re-run an existing build, it re-runs on the same agent and will add a second crash dump to the dump folder which is then uploaded with the artifact. We don't want this - we just want the dump that was generated for the current run. Setting the max dump count to 1 will result in any previous dumps being deleted before the new one is written.