### PR TITLE
Set cmake overrides for OpenXR-SDK's jsoncpp dependency to unblock ci build

### DIFF
--- a/Dependencies/xr/CMakeLists.txt
+++ b/Dependencies/xr/CMakeLists.txt
@@ -12,6 +12,9 @@ elseif (IOS)
     set(SOURCES ${SOURCES}
         "Source/ARKit/XR.mm")
 else()
+    # Avoid picking up system installed jsoncpp in favor of source distributed with openxr_loader project
+    set(JSONCPP_FOUND OFF CACHE BOOL "disable using system installed jsoncpp" FORCE)
+    set(BUILD_WITH_SYSTEM_JSONCPP OFF CACHE BOOL "disable using system installed jsoncpp" FORCE)
     add_subdirectory(Dependencies/OpenXR-SDK)
 
     set(SOURCES ${SOURCES}

--- a/Dependencies/xr/CMakeLists.txt
+++ b/Dependencies/xr/CMakeLists.txt
@@ -13,7 +13,7 @@ elseif (IOS)
         "Source/ARKit/XR.mm")
 else()
     # Avoid picking up system installed jsoncpp in favor of source distributed with openxr_loader project
-    set(BUILD_WITH_SYSTEM_JSONCPP OFF CACHE BOOL "disable using system installed jsoncpp" FORCE)
+    set(BUILD_WITH_SYSTEM_JSONCPP OFF CACHE BOOL "disable using system installed jsoncpp")
     add_subdirectory(Dependencies/OpenXR-SDK)
 
     set(SOURCES ${SOURCES}

--- a/Dependencies/xr/CMakeLists.txt
+++ b/Dependencies/xr/CMakeLists.txt
@@ -13,7 +13,6 @@ elseif (IOS)
         "Source/ARKit/XR.mm")
 else()
     # Avoid picking up system installed jsoncpp in favor of source distributed with openxr_loader project
-    set(JSONCPP_FOUND OFF CACHE BOOL "disable using system installed jsoncpp" FORCE)
     set(BUILD_WITH_SYSTEM_JSONCPP OFF CACHE BOOL "disable using system installed jsoncpp" FORCE)
     add_subdirectory(Dependencies/OpenXR-SDK)
 


### PR DESCRIPTION
CI machines now resolve jsoncpp based on C:/msys64/mingw64/lib/cmake/jsoncpp, which did not exist before. This change updates our cmake to never use system resolve jsoncpp