### PR TITLE
small fix to setTimeout

### DIFF
--- a/Polyfills/Window/Source/Window.cpp
+++ b/Polyfills/Window/Source/Window.cpp
@@ -98,16 +98,16 @@ namespace Babylon::Polyfills::Internal
         std::shared_ptr<Napi::FunctionReference> function,
         std::chrono::system_clock::time_point whenToRun)
     {
-        if (std::chrono::system_clock::now() >= whenToRun)
-        {
-            function->Call({});
-        }
-        else
-        {
-            m_runtime.Dispatch([this, function = std::move(function), whenToRun](Napi::Env) {
+        m_runtime.Dispatch([this, function = std::move(function), whenToRun](Napi::Env) {
+            if (std::chrono::system_clock::now() >= whenToRun)
+            {
+                function->Call({});
+            }
+            else
+            {
                 RecursiveWaitOrCall(std::move(function), whenToRun);
-            });
-        }
+            }
+        });
     }
 }
 


### PR DESCRIPTION
Right now setTimeout(0) executes synchronously. This breaks logic in Babylon.js. In this change we force all setTimeout callbacks to have to occur on the next frame.