### PR TITLE
fflush after printf

### DIFF
--- a/Apps/Playground/X11/App.cpp
+++ b/Apps/Playground/X11/App.cpp
@@ -63,6 +63,7 @@ namespace
         runtime->Dispatch([](Napi::Env env) {
             Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
                 printf("%s", message);
+                fflush(stdout);
             });
 
             Babylon::Polyfills::Window::Initialize(env);

--- a/Apps/ValidationTests/Win32/App.cpp
+++ b/Apps/ValidationTests/Win32/App.cpp
@@ -102,8 +102,8 @@ namespace
 
                 Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
                     OutputDebugStringA(message);
+
                     printf("%s", message);
-                    // Ensure printfs are displayed, even if the app crashes
                     fflush(stdout);
                 });
 
@@ -137,9 +137,6 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     _In_ LPWSTR    lpCmdLine,
     _In_ int       nCmdShow)
 {
-    // Ensure printfs are displayed, even if the app crashes
-    setvbuf(stdout, NULL, _IONBF, 0);
-
     UNREFERENCED_PARAMETER(hPrevInstance);
     UNREFERENCED_PARAMETER(lpCmdLine);
 

--- a/Apps/ValidationTests/X11/App.cpp
+++ b/Apps/ValidationTests/X11/App.cpp
@@ -71,6 +71,7 @@ namespace
         runtime->Dispatch([window](Napi::Env env) {
             Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
                 printf("%s", message);
+                fflush(stdout);
             });
 
             Babylon::TestUtils::CreateInstance(env, (void*)(uintptr_t)window);


### PR DESCRIPTION
Ensure all validation tests are calling fflush after printf so that logs are accurate after a crash.