### PR TITLE
Support updating window in ARKit XR

### DIFF
--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -229,12 +229,12 @@ namespace xr
                 std::unique_ptr<Impl> m_impl{};
             };
 
-            static arcana::task<std::shared_ptr<Session>, std::exception_ptr> CreateAsync(System& system, void* graphicsDevice, void* window);
+            static arcana::task<std::shared_ptr<Session>, std::exception_ptr> CreateAsync(System& system, void* graphicsDevice, std::function<void*()> windowProvider);
             ~Session();
 
             // Do not use, call CreateAsync instead. Kept public to keep compatibility with make_shared.
             // Move to private when changing to unique_ptr.
-            Session(System& system, void* graphicsDevice, void* window);
+            Session(System& system, void* graphicsDevice, std::function<void*()> windowProvider);
 
             std::unique_ptr<Frame> GetNextFrame(bool& shouldEndSession, bool& shouldRestartSession, std::function<void(void* texturePointer)> deletedTextureCallback = [](void*){});
             void RequestEndSession();

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -1236,21 +1236,21 @@ namespace xr
         return arcana::task_from_result<std::exception_ptr>(false);
     }
 
-    arcana::task<std::shared_ptr<System::Session>, std::exception_ptr> System::Session::CreateAsync(System& system, void* graphicsDevice, void* window)
+    arcana::task<std::shared_ptr<System::Session>, std::exception_ptr> System::Session::CreateAsync(System& system, void* graphicsDevice, std::function<void*()> windowProvider)
     {
         // First perform the ARCore installation check, request install if not yet installed.
         return CheckAndInstallARCoreAsync().then(arcana::inline_scheduler, arcana::cancellation::none(), []()
         {
             // Next check for camera permissions, and request if not already granted.
             return CheckCameraPermissionAsync();
-        }).then(arcana::inline_scheduler, arcana::cancellation::none(), [&system, graphicsDevice, window]()
+        }).then(arcana::inline_scheduler, arcana::cancellation::none(), [&system, graphicsDevice, windowProvider{ std::move(windowProvider) }]()
         {
             // Finally if the previous two tasks succeed, start the AR session.
-            return std::make_shared<System::Session>(system, graphicsDevice, window);
+            return std::make_shared<System::Session>(system, graphicsDevice, windowProvider);
         });
     }
 
-    System::Session::Session(System& system, void* graphicsDevice, void*)
+    System::Session::Session(System& system, void* graphicsDevice, std::function<void*()>)
         : m_impl{ std::make_unique<System::Session::Impl>(*system.m_impl, graphicsDevice) }
     {}
 

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -542,16 +542,17 @@ namespace xr {
         float DepthNearZ{ DEFAULT_DEPTH_NEAR_Z };
         float DepthFarZ{ DEFAULT_DEPTH_FAR_Z };
         
-        Impl(System::Impl& systemImpl, void* graphicsContext, void* window)
-            : SystemImpl{ systemImpl } {
-            metalDevice = id<MTLDevice>(graphicsContext);
-            UIView* MainView = (UIView*)window;
-            
+        Impl(System::Impl& systemImpl, void* graphicsContext, std::function<void*()> windowProvider)
+            : SystemImpl{ systemImpl }
+            , getMainView{ [windowProvider{ std::move(windowProvider) }] { return reinterpret_cast<UIView*>(windowProvider()); } }
+            , metalDevice{ id<MTLDevice>(graphicsContext) } {
+
+            UIView* mainView = getMainView();
+
             // Create the XR View to stay within the safe area of the main view.
             dispatch_sync(dispatch_get_main_queue(), ^{
-                xrView = [[MTKView alloc] initWithFrame:MainView.bounds device:metalDevice];
-                [MainView addSubview:xrView];
-                [xrView release];
+                xrView = [[MTKView alloc] initWithFrame:mainView.bounds device:metalDevice];
+                [mainView addSubview:xrView];
                 xrView.userInteractionEnabled = false;
                 xrView.colorPixelFormat = MTLPixelFormatBGRA8Unorm;
                 xrView.depthStencilPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
@@ -563,8 +564,8 @@ namespace xr {
 #pragma clang diagnostic pop
                 metalLayer.device = metalDevice;
                 auto scale = UIScreen.mainScreen.scale;
-                viewportSize.x = MainView.bounds.size.width * scale;
-                viewportSize.y = MainView.bounds.size.height * scale;
+                viewportSize.x = mainView.bounds.size.width * scale;
+                viewportSize.y = mainView.bounds.size.height * scale;
             });
 
             // Create the ARSession enable plane detection, and disable lighting estimation.
@@ -573,8 +574,7 @@ namespace xr {
             configuration.planeDetection = ARPlaneDetectionHorizontal | ARPlaneDetectionVertical;
             configuration.lightEstimationEnabled = false;
             configuration.worldAlignment = ARWorldAlignmentGravity;
-            
-            metalDevice = id<MTLDevice>(graphicsContext);
+
             sessionDelegate = [[SessionDelegate new]init:&ActiveFrameViews metalContext:metalDevice viewportSize:CGSizeMake(viewportSize.x, viewportSize.y)];
             session.delegate = sessionDelegate;
             xrView.delegate = sessionDelegate;
@@ -634,6 +634,7 @@ namespace xr {
             [xrView releaseDrawables];
             dispatch_sync(dispatch_get_main_queue(), ^{
                 [xrView removeFromSuperview]; });
+            [xrView release];
             xrView = nil;
         }
         
@@ -656,18 +657,28 @@ namespace xr {
         }
 
         std::unique_ptr<System::Session::Frame> GetNextFrame(bool& shouldEndSession, bool& shouldRestartSession, std::function<void(void* texturePointer)> deletedTextureCallback) {
+            shouldEndSession = sessionEnded;
+            shouldRestartSession = false;
+
+            dispatch_sync(dispatch_get_main_queue(), ^{
+                // Check whether the main view has changed, and if so, reparent the xr view.
+                UIView* currentSuperview = [xrView superview];
+                UIView* desiredSuperview = getMainView();
+                if (currentSuperview != desiredSuperview) {
+                    [xrView removeFromSuperview];
+                    [xrView setFrame:desiredSuperview.bounds];
+                    [desiredSuperview addSubview:xrView];
+                }
+                
+                ARFrame* currentFrame = [session currentFrame];
+                [sessionDelegate session:session didUpdateFrameInternal:currentFrame];
+            });
+
             auto viewSize = [sessionDelegate viewSize];
             viewportSize.x = viewSize.width;
             viewportSize.y = viewSize.height;
             uint32_t width = viewportSize.x;
             uint32_t height = viewportSize.y;
-            shouldEndSession = sessionEnded;
-            shouldRestartSession = false;
-
-            dispatch_sync(dispatch_get_main_queue(), ^{
-                ARFrame* currentFrame = [session currentFrame];
-                [sessionDelegate session:session didUpdateFrameInternal:currentFrame];
-            });
             
             if (ActiveFrameViews[0].ColorTextureSize.Width != width || ActiveFrameViews[0].ColorTextureSize.Height != height) {
                 // Color texture
@@ -1001,6 +1012,7 @@ namespace xr {
 
         private:
             ARSession* session{};
+            std::function<UIView*()> getMainView{};
             MTKView* xrView{};
             bool sessionEnded{ false };
             id<MTLDevice> metalDevice{};
@@ -1202,15 +1214,15 @@ namespace xr {
         return arcana::task_from_result<std::exception_ptr>(sessionType == SessionType::IMMERSIVE_AR);
     }
 
-    arcana::task<std::shared_ptr<System::Session>, std::exception_ptr> System::Session::CreateAsync(System& system, void* graphicsDevice, void* window) {
-        auto session = std::make_shared<System::Session>(system, graphicsDevice, window);
+    arcana::task<std::shared_ptr<System::Session>, std::exception_ptr> System::Session::CreateAsync(System& system, void* graphicsDevice, std::function<void*()> windowProvider) {
+        auto session = std::make_shared<System::Session>(system, graphicsDevice, std::move(windowProvider));
         return session->m_impl->WhenReady().then(arcana::inline_scheduler, arcana::cancellation::none(), [session] {
             return session;
         });
     }
 
-    System::Session::Session(System& system, void* graphicsDevice, void* window)
-        : m_impl{ std::make_unique<System::Session::Impl>(*system.m_impl, graphicsDevice, window) } {}
+    System::Session::Session(System& system, void* graphicsDevice, std::function<void*()> windowProvider)
+        : m_impl{ std::make_unique<System::Session::Impl>(*system.m_impl, graphicsDevice, std::move(windowProvider)) } {}
 
     System::Session::~Session() {
         // Free textures

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -546,7 +546,6 @@ namespace xr {
             : SystemImpl{ systemImpl }
             , getMainView{ [windowProvider{ std::move(windowProvider) }] { return reinterpret_cast<UIView*>(windowProvider()); } }
             , metalDevice{ id<MTLDevice>(graphicsContext) } {
-
             UIView* mainView = getMainView();
 
             // Create the XR View to stay within the safe area of the main view.

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -1373,12 +1373,12 @@ namespace xr
         return arcana::task_from_result<std::exception_ptr>(sessionType == SessionType::IMMERSIVE_VR);
     }
 
-    arcana::task<std::shared_ptr<System::Session>, std::exception_ptr> System::Session::CreateAsync(System& system, void* graphicsDevice, void* window)
+    arcana::task<std::shared_ptr<System::Session>, std::exception_ptr> System::Session::CreateAsync(System& system, void* graphicsDevice, std::function<void*()> windowProvider)
     {
-        return arcana::task_from_result<std::exception_ptr>(std::make_shared<System::Session>(system, graphicsDevice, window));
+        return arcana::task_from_result<std::exception_ptr>(std::make_shared<System::Session>(system, graphicsDevice, windowProvider));
     }
 
-    System::Session::Session(System& headMountedDisplay, void* graphicsDevice, void*)
+    System::Session::Session(System& headMountedDisplay, void* graphicsDevice, std::function<void*()>)
         : m_impl{ std::make_unique<System::Session::Impl>(*headMountedDisplay.m_impl, graphicsDevice) }
     {}
 

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -340,7 +340,7 @@ namespace Babylon
         }
     }
 
-    arcana::task<void, std::exception_ptr> NativeXr::BeginSession(Napi::Env env)
+    arcana::task<void, std::exception_ptr> NativeXr::BeginSession(Napi::Env /*env*/)
     {
         assert(m_session == nullptr);
         assert(m_frame == nullptr);
@@ -353,8 +353,8 @@ namespace Babylon
             }
         }
 
-        return m_graphicsImpl.GetAfterRenderTask().then(arcana::inline_scheduler, arcana::cancellation::none(), [this, windowPtr = Graphics::Impl::GetFromJavaScript(env).GetNativeWindow()]() {
-            return xr::System::Session::CreateAsync(m_system, bgfx::getInternalData()->context, windowPtr).then(arcana::inline_scheduler, m_cancellationSource, [this](std::shared_ptr<xr::System::Session> session) {
+        return m_graphicsImpl.GetAfterRenderTask().then(arcana::inline_scheduler, arcana::cancellation::none(), [this, getWindow = std::bind(&Graphics::Impl::GetNativeWindow, &m_graphicsImpl)]() {
+            return xr::System::Session::CreateAsync(m_system, bgfx::getInternalData()->context, std::move(getWindow)).then(arcana::inline_scheduler, m_cancellationSource, [this](std::shared_ptr<xr::System::Session> session) {
                 m_session = std::move(session);
             });
         });


### PR DESCRIPTION
We were previously just passing a `void* windowPtr` into the XR layer (specifically for iOS/ARKit right now), but this isn't good enough since the window can change during an XR session. The change here is to instead pass in a `std::function<void*()> windowProvider` so the XR layer can query the current window. This happens inside `GetNextFramed`, which is similar to what the ARCore XR layer does (it polls the current gl surface on each GetNextFrame). This addresses https://github.com/BabylonJS/BabylonReactNative/issues/106. Note the reason it was *crashing* before is because we immediately released the `xrView` and allowed the superview to manage its lifetime, but the superview (the window) can be replaced, in which case the `xrView` is released and we continue to try to use it. Now we retain shared ownership and don't release the `xrView` until we end the session.