### PR TITLE
Ensure NativeEngine::ScheduleRender is called from the JS thread

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1083,7 +1083,7 @@ namespace Babylon
                 }
                 return image;
             })
-            .then(arcana::inline_scheduler, arcana::cancellation::none(), [this, texture](bimg::ImageContainer* image) {
+            .then(RuntimeScheduler, arcana::cancellation::none(), [this, texture](bimg::ImageContainer* image) {
                 ScheduleRender();
                 return m_graphicsImpl.GetAfterRenderTask().then(arcana::inline_scheduler, m_cancelSource, [texture, image] {
                     CreateTextureFromImage(texture, image);
@@ -1125,7 +1125,7 @@ namespace Babylon
         }
 
         arcana::when_all(gsl::make_span(tasks))
-            .then(arcana::inline_scheduler, arcana::cancellation::none(), [this, texture, generateMips](std::vector<bimg::ImageContainer*> images) {
+            .then(RuntimeScheduler, arcana::cancellation::none(), [this, texture, generateMips](std::vector<bimg::ImageContainer*> images) {
                 ScheduleRender();
                 return m_graphicsImpl.GetAfterRenderTask().then(arcana::inline_scheduler, m_cancelSource, [texture, generateMips, images = std::move(images)] {
                     CreateCubeTextureFromImages(texture, images, generateMips);
@@ -1167,7 +1167,7 @@ namespace Babylon
         }
 
         arcana::when_all(gsl::make_span(tasks))
-            .then(arcana::inline_scheduler, arcana::cancellation::none(), [this, texture](std::vector<bimg::ImageContainer*> images) {
+            .then(RuntimeScheduler, arcana::cancellation::none(), [this, texture](std::vector<bimg::ImageContainer*> images) {
                 ScheduleRender();
                 return m_graphicsImpl.GetAfterRenderTask().then(arcana::inline_scheduler, m_cancelSource, [texture, images = std::move(images)] {
                     CreateCubeTextureFromImages(texture, images, true);

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -413,6 +413,7 @@ namespace Babylon
         FrameBufferManager& GetFrameBufferManager();
         void Dispatch(std::function<void()>);
 
+        // IMPORTANT: Must be called from the JS thread.
         void ScheduleRender();
 
         const bool AutomaticRenderingEnabled{};


### PR DESCRIPTION
ScheduleRender is not thread-safe. We can either make it thread-safe or only call it from one thread. I've chosen the latter for now. We can revisit if necessary.

This should fix the intermittent issues we are having in the CI.