### PR TITLE
Build RelWithDebInfo in CI

### DIFF
--- a/Dependencies/UrlLib/Source/Unix/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Unix/UrlRequest.cpp
@@ -94,6 +94,7 @@ namespace UrlLib
                 m_thread.join();
                 auto errCode = curl_multi_cleanup(m_multiHandle);
                 assert(errCode == CURLM_OK);
+                (void)errCode;
             }
 
             void AddHandle(CURL* handle)

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -923,6 +923,7 @@ namespace Babylon
 
         const size_t elementLength = matrix.ElementLength();
         assert(elementLength == size * size);
+        (void)elementLength;
 
         if constexpr (size < 4)
         {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
       scheme: 'Playground'
       sdk: 'macosx'
       useXcpretty: false
-      configuration: Release
+      configuration: RelWithDebInfo
     displayName: 'Build macOS'
     
 - job: iOS
@@ -66,7 +66,7 @@ jobs:
       scheme: 'Playground'
       sdk: 'iphoneos'
       useXcpretty: false
-      configuration: Release
+      configuration: RelWithDebInfo
     displayName: 'Build iOS'
     
 - job: win32_x64
@@ -224,7 +224,7 @@ jobs:
     inputs:
       solution: 'buildUWP_x64/BabylonNative.sln'
       maximumCpuCount: true
-      configuration: 'Release'
+      configuration: 'RelWithDebInfo'
       msbuildArgs: '/p:AppxPackageSigningEnabled=false'
     displayName: 'Build UWP_x64'
 
@@ -247,7 +247,7 @@ jobs:
     inputs:
       solution: 'buildUWP_arm64/BabylonNative.sln'
       maximumCpuCount: true
-      configuration: 'Release'
+      configuration: 'RelWithDebInfo'
       msbuildArgs: '/p:AppxPackageSigningEnabled=false'
     displayName: 'Build UWP_arm64'
 
@@ -270,7 +270,7 @@ jobs:
     inputs:
       solution: 'buildUWP_x86/BabylonNative.sln'
       maximumCpuCount: true
-      configuration: 'Release'
+      configuration: 'RelWithDebInfo'
       msbuildArgs: '/p:AppxPackageSigningEnabled=false'
     displayName: 'Build UWP_x86'
 
@@ -344,7 +344,7 @@ jobs:
   - script: |
       mkdir build
       cd build
-      cmake .. -GNinja -DJSCORE_LIBRARY=/usr/lib/x86_64-linux-gnu/libjavascriptcoregtk-4.0.so
+      cmake .. -GNinja -DJSCORE_LIBRARY=/usr/lib/x86_64-linux-gnu/libjavascriptcoregtk-4.0.so -DCMAKE_BUILD_TYPE=RelWithDebInfo
       ninja
     displayName: 'Build X11'
 
@@ -368,7 +368,7 @@ jobs:
   - script: |
       mkdir build
       cd build
-      cmake .. -GNinja -DJSCORE_LIBRARY=/usr/lib/x86_64-linux-gnu/libjavascriptcoregtk-4.0.so
+      cmake .. -GNinja -DJSCORE_LIBRARY=/usr/lib/x86_64-linux-gnu/libjavascriptcoregtk-4.0.so -DCMAKE_BUILD_TYPE=RelWithDebInfo
       ninja
     displayName: 'Build X11'
   - script: |


### PR DESCRIPTION
Ubuntu fails a lot because of timeout. It looks like we are running with a debug build. This change makes it build the RelWithDbgInfo configuration.

Also fixes a couple of warnings as error for unused variables.