### PR TITLE
Fixing the UrlRequest on Android for local files

### DIFF
--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
@@ -82,6 +82,8 @@ namespace java::lang
         Class(const char* className);
         Class(const jclass classObj);
 
+        operator jclass() const;
+
         bool IsAssignableFrom(Class otherClass);
 
     protected:
@@ -99,9 +101,8 @@ namespace java::lang
         Object(const char* className, jobject object);
 
         JNIEnv* m_env;
-        const jclass m_class;
+        const class Class m_class;
         jobject m_object;
-        class Class m_classWrapper;
     };
 
     class String

--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
@@ -76,10 +76,24 @@ namespace java::lang
         jbyteArray m_byteArray;
     };
 
+    class Class
+    {
+    public:
+        Class(const char* className);
+        Class(const jclass classObj);
+
+        bool IsAssignableFrom(Class otherClass);
+
+    protected:
+        JNIEnv* m_env;
+        const jclass m_class;
+    };
+
     class Object
     {
     public:
         operator jobject() const;
+        Class Class();
 
     protected:
         Object(const char* className, jobject object);
@@ -87,6 +101,7 @@ namespace java::lang
         JNIEnv* m_env;
         const jclass m_class;
         jobject m_object;
+        class Class m_classWrapper;
     };
 
     class String

--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
@@ -98,7 +98,8 @@ namespace java::lang
         Class Class();
 
     protected:
-        Object(const char* className, jobject object);
+        Object(const char* className);
+        Object(jobject object);
 
         JNIEnv* m_env;
         const class Class m_class;

--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
@@ -95,14 +95,14 @@ namespace java::lang
     {
     public:
         operator jobject() const;
-        Class Class();
+        Class GetClass();
 
     protected:
         Object(const char* className);
         Object(jobject object);
 
         JNIEnv* m_env;
-        const class Class m_class;
+        Class m_class;
         jobject m_object;
     };
 
@@ -166,6 +166,8 @@ namespace java::net
     class HttpURLConnection : public lang::Object
     {
     public:
+        static lang::Class Class();
+
         HttpURLConnection(jobject object);
 
         int GetResponseCode() const;

--- a/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
+++ b/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
@@ -84,7 +84,7 @@ namespace java::lang
     {
     }
 
-    Class Object::Class()
+    Class Object::GetClass()
     {
         return m_class;
     }
@@ -185,6 +185,11 @@ namespace java::net
     HttpURLConnection::HttpURLConnection(jobject object)
         : Object{object}
     {
+    }
+
+    lang::Class HttpURLConnection::Class()
+    {
+        return {"java/net/HttpURLConnection"};
     }
 
     int HttpURLConnection::GetResponseCode() const

--- a/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
+++ b/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
@@ -70,10 +70,17 @@ namespace java::lang
         return m_object;
     }
 
-    Object::Object(const char* className, jobject object)
+    Object::Object(const char* className)
         : m_env{GetEnvForCurrentThread()}
-        , m_class{object == nullptr ? m_env->FindClass(className) : m_env->GetObjectClass(object)}
-        , m_object{object}
+        , m_class{m_env->FindClass(className)}
+        , m_object{nullptr}
+    {
+    }
+
+    Object::Object(jobject object)
+            : m_env{GetEnvForCurrentThread()}
+            , m_class{m_env->GetObjectClass(object)}
+            , m_object{object}
     {
     }
 
@@ -105,7 +112,7 @@ namespace java::lang
     }
 
     Throwable::Throwable(jthrowable throwable)
-        : Object{"java/lang/Throwable", throwable}
+        : Object{throwable}
         , m_throwableRef{m_env->NewGlobalRef(throwable)}
     {
     }
@@ -130,19 +137,19 @@ namespace java::lang
 namespace java::io
 {
     ByteArrayOutputStream::ByteArrayOutputStream()
-        : Object{"java/io/ByteArrayOutputStream", nullptr}
+        : Object{"java/io/ByteArrayOutputStream"}
     {
         m_object = m_env->NewObject(m_class, m_env->GetMethodID(m_class, "<init>", "()V"));
     }
 
     ByteArrayOutputStream::ByteArrayOutputStream(int size)
-        : Object{"java/io/ByteArrayOutputStream", nullptr}
+        : Object{"java/io/ByteArrayOutputStream"}
     {
         m_object = m_env->NewObject(m_class, m_env->GetMethodID(m_class, "<init>", "(I)V"), size);
     }
 
     ByteArrayOutputStream::ByteArrayOutputStream(jobject object)
-        : Object{"java/io/ByteArrayOutputStream", object}
+        : Object{object}
     {
     }
 
@@ -163,7 +170,7 @@ namespace java::io
     }
 
     InputStream::InputStream(jobject object)
-        : Object{"java/io/InputStream", object}
+        : Object{object}
     {
     }
 
@@ -176,7 +183,7 @@ namespace java::io
 namespace java::net
 {
     HttpURLConnection::HttpURLConnection(jobject object)
-        : Object{"java/net/HttpURLConnection", object}
+        : Object{object}
     {
     }
 
@@ -188,13 +195,13 @@ namespace java::net
     }
 
     URL::URL(lang::String url)
-        : Object{"java/net/URL", nullptr}
+        : Object{"java/net/URL"}
     {
         m_object = m_env->NewObject(m_class, m_env->GetMethodID(m_class, "<init>", "(Ljava/lang/String;)V"), (jstring)url);
     }
 
     URL::URL(jobject object)
-        : Object{"java/net/URL", object}
+        : Object{object}
     {
     }
 
@@ -211,7 +218,7 @@ namespace java::net
     }
 
     URLConnection::URLConnection(jobject object)
-        : Object{"java/net/URLConnection", object}
+        : Object{object}
     {
     }
 
@@ -263,7 +270,7 @@ namespace android
 namespace android::app
 {
     Activity::Activity(jobject object)
-        : Object{"android/app/Activity", object}
+        : Object{object}
     {
     }
 
@@ -281,7 +288,7 @@ namespace android::app
 namespace android::content
 {
     Context::Context(jobject object)
-        : Object{"android/content/Context", object}
+        : Object{object}
     {
     }
 
@@ -316,7 +323,7 @@ namespace android::content
 namespace android::content::res
 {
     AssetManager::AssetManager(jobject object)
-        : Object("android/content/res/AssetManager", object)
+        : Object(object)
     {
     }
 
@@ -329,7 +336,7 @@ namespace android::content::res
 namespace android::view
 {
     Display::Display(jobject object)
-            : Object("android/view/Display", object)
+            : Object(object)
     {
     }
 
@@ -339,7 +346,7 @@ namespace android::view
     }
 
     WindowManager::WindowManager(jobject object)
-        : Object("android/view/WindowManager", object)
+        : Object(object)
     {
     }
 
@@ -352,7 +359,7 @@ namespace android::view
 namespace android::net
 {
     Uri::Uri(jobject object)
-        : Object{"android/net/Uri", object}
+        : Object{object}
     {
     }
 

--- a/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
+++ b/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
@@ -55,6 +55,11 @@ namespace java::lang
     {
     }
 
+    Class::operator jclass() const
+    {
+        return m_class;
+    };
+
     bool Class::IsAssignableFrom(Class otherClass)
     {
         return m_env->IsAssignableFrom(m_class, otherClass.m_class);
@@ -69,13 +74,12 @@ namespace java::lang
         : m_env{GetEnvForCurrentThread()}
         , m_class{object == nullptr ? m_env->FindClass(className) : m_env->GetObjectClass(object)}
         , m_object{object}
-        , m_classWrapper{m_class}
     {
     }
 
     Class Object::Class()
     {
-        return m_classWrapper;
+        return m_class;
     }
 
     String::String(jstring string)

--- a/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
+++ b/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
@@ -43,6 +43,23 @@ namespace java::lang
         return result;
     }
 
+    Class::Class(const char* className)
+        : m_env{GetEnvForCurrentThread()}
+        , m_class{m_env->FindClass(className)}
+    {
+    }
+
+    Class::Class(const jclass classObj)
+        : m_env{GetEnvForCurrentThread()}
+        , m_class{classObj}
+    {
+    }
+
+    bool Class::IsAssignableFrom(Class otherClass)
+    {
+        return m_env->IsAssignableFrom(m_class, otherClass.m_class);
+    };
+
     Object::operator jobject() const
     {
         return m_object;
@@ -50,9 +67,15 @@ namespace java::lang
 
     Object::Object(const char* className, jobject object)
         : m_env{GetEnvForCurrentThread()}
-        , m_class{m_env->FindClass(className)}
+        , m_class{object == nullptr ? m_env->FindClass(className) : m_env->GetObjectClass(object)}
         , m_object{object}
+        , m_classWrapper{m_class}
     {
+    }
+
+    Class Object::Class()
+    {
+        return m_classWrapper;
     }
 
     String::String(jstring string)

--- a/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
@@ -98,7 +98,15 @@ namespace UrlLib
                         URLConnection connection{url.OpenConnection()};
                         connection.Connect();
 
-                        m_statusCode = static_cast<UrlStatusCode>(((HttpURLConnection)connection).GetResponseCode());
+                        if (connection.Class().IsAssignableFrom({"java/net/HttpURLConnection"}))
+                        {
+                            m_statusCode = static_cast<UrlStatusCode>(((HttpURLConnection)connection).GetResponseCode());
+                        }
+                        else
+                        {
+                            m_statusCode = UrlStatusCode::Ok;
+                        }
+
                         int contentLength = connection.GetContentLength();
                         if (contentLength < 0)
                         {

--- a/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
@@ -98,7 +98,7 @@ namespace UrlLib
                         URLConnection connection{url.OpenConnection()};
                         connection.Connect();
 
-                        if (connection.Class().IsAssignableFrom({"java/net/HttpURLConnection"}))
+                        if (connection.GetClass().IsAssignableFrom(HttpURLConnection::Class()))
                         {
                             m_statusCode = static_cast<UrlStatusCode>(((HttpURLConnection)connection).GetResponseCode());
                         }


### PR DESCRIPTION
With the current implementation of UrlRequest for Android it does not support loading local files. When using a URL in the format of `file://<local_path>` Babylon-Native crashes on Android (but does work on iOS).

The root cause of the crash is because of an incorrect cast from UrlConnection to HttpUrlConnection where depending on the URL the underlying class may be a FileUrlConnection. This change matches the iOS implementation where it checks if the UrlConnection is of the type HttpUrlConnection and if so it checks the response code. If the UrlConnection is of any other type it returns HTTP 200. I verified that if you give it a local file url that is invalid it gracefully handles the error and properly returns a status code of 0.

In order to accomadate the ability to check the java class type I refactored the wrapper class to expose the JNI function [IsAssignableFrom](https://docs.oracle.com/en/java/javase/13/docs/specs/jni/functions.html#isassignablefrom) on a new Class wapper object. The Class object can either be constructed from a string or from a jobject. I replaced the jclass property of the Object wrapper with the new Class wrapper class to make accessing it easier.

With the new changes you can do a typecheck like this:
`if (connection.Class().IsAssignableFrom({"java/net/HttpURLConnection"}))`