### PR TITLE
Small fixes in JavaWrappers

### DIFF
--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
@@ -133,6 +133,7 @@ namespace java::lang
 
     private:
         jobject m_throwableRef;
+        std::string m_message;
     };
 }
 

--- a/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
+++ b/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
@@ -108,7 +108,10 @@ namespace java::lang
 
     String::operator std::string() const
     {
-        return m_env->GetStringUTFChars(m_string, nullptr);
+        const char* buffer{m_env->GetStringUTFChars(m_string, nullptr)};
+        std::string str{buffer};
+        m_env->ReleaseStringUTFChars(m_string, buffer);
+        return str;
     }
 
     Throwable::Throwable(jthrowable throwable)

--- a/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
+++ b/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
@@ -114,6 +114,7 @@ namespace java::lang
     Throwable::Throwable(jthrowable throwable)
         : Object{throwable}
         , m_throwableRef{m_env->NewGlobalRef(throwable)}
+        , m_message{GetMessage()}
     {
     }
 
@@ -129,8 +130,7 @@ namespace java::lang
 
     const char* Throwable::what() const noexcept
     {
-        std::string message = GetMessage();
-        return message.c_str();
+        return m_message.c_str();
     }
 }
 


### PR DESCRIPTION
- Release char buffers after we are done with them (e.g. copying them into an std::string).
- Don't return a pointer to a stack allocated char buffer from Throwable::what (instead store the message as an std::string in the Throwable).