### PR TITLE
Push XR projection matrix generation down to platform implementations

### DIFF
--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -149,14 +149,7 @@ namespace xr
                 struct View
                 {
                     Space Space{};
-
-                    struct
-                    {
-                        float AngleLeft{};
-                        float AngleRight{};
-                        float AngleUp{};
-                        float AngleDown{};
-                    } FieldOfView;
+                    std::array<float, 16> ProjectionMatrix{};
 
                     TextureFormat ColorTextureFormat{};
                     void* ColorTexturePointer{};

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -527,15 +527,7 @@ namespace xr
                 // Get the current projection matrix
                 glm::mat4 projectionMatrix{};
                 ArCamera_getProjectionMatrix(session, camera, DepthNearZ, DepthFarZ, glm::value_ptr(projectionMatrix));
-
-                // Copy the projection matrix values into the view.
-                for(int row = 0; row < 4; row++)
-                {
-                    for(int column = 0; column < 4; column++)
-                    {
-                        ActiveFrameViews[0].ProjectionMatrix[row * 4 + column] = projectionMatrix[row][column];
-                    }
-                }
+                memcpy(ActiveFrameViews[0].ProjectionMatrix.data(), &projectionMatrix, sizeof(float) * 16);
             }
 
             ActiveFrameViews[0].DepthNearZ = DepthNearZ;

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -526,18 +526,16 @@ namespace xr
             {
                 // Get the current projection matrix
                 glm::mat4 projectionMatrix{};
-                ArCamera_getProjectionMatrix(session, camera, ActiveFrameViews[0].DepthNearZ, ActiveFrameViews[0].DepthFarZ, glm::value_ptr(projectionMatrix));
+                ArCamera_getProjectionMatrix(session, camera, DepthNearZ, DepthFarZ, glm::value_ptr(projectionMatrix));
 
-                // Calculate the aspect ratio and field of view
-                float a = projectionMatrix[0][0];
-                float b = projectionMatrix[1][1];
-
-                float aspectRatio = b / a;
-                float fieldOfView = std::atan(1.0f / b);
-
-                // Set the horizontal and vertical field of view
-                ActiveFrameViews[0].FieldOfView.AngleDown = -(ActiveFrameViews[0].FieldOfView.AngleUp = fieldOfView);
-                ActiveFrameViews[0].FieldOfView.AngleLeft = -(ActiveFrameViews[0].FieldOfView.AngleRight = fieldOfView * aspectRatio);
+                // Copy the projection matrix values into the view.
+                for(int row = 0; row < 4; row++)
+                {
+                    for(int column = 0; column < 4; column++)
+                    {
+                        ActiveFrameViews[0].ProjectionMatrix[row * 4 + column] = projectionMatrix[row][column];
+                    }
+                }
             }
 
             ActiveFrameViews[0].DepthNearZ = DepthNearZ;

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -525,9 +525,7 @@ namespace xr
             if (geometryChanged || ActiveFrameViews[0].DepthNearZ != DepthNearZ || ActiveFrameViews[0].DepthFarZ != DepthFarZ)
             {
                 // Get the current projection matrix
-                glm::mat4 projectionMatrix{};
-                ArCamera_getProjectionMatrix(session, camera, DepthNearZ, DepthFarZ, glm::value_ptr(projectionMatrix));
-                memcpy(ActiveFrameViews[0].ProjectionMatrix.data(), &projectionMatrix, sizeof(float) * 16);
+                ArCamera_getProjectionMatrix(session, camera, DepthNearZ, DepthFarZ, ActiveFrameViews[0].ProjectionMatrix.data());
             }
 
             ActiveFrameViews[0].DepthNearZ = DepthNearZ;

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -284,15 +284,7 @@ namespace {
     
     // Grab the projection matrix for the image based on the viewport.
     auto projectionMatrix = [camera projectionMatrixForOrientation:orientation viewportSize:viewportSize zNear:frameView.DepthNearZ zFar:frameView.DepthFarZ];
-
-    // Update the projection matrix of the view.
-    for(int row = 0; row < 4; row++)
-    {
-        for(int column = 0; column < 4; column++)
-        {
-            frameView.ProjectionMatrix[row * 4 + column] = projectionMatrix.columns[row][column];
-        }
-    }
+    memcpy(frameView.ProjectionMatrix.data(), projectionMatrix.columns, sizeof(float) * 16);
 }
 
 /**

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -283,14 +283,14 @@ namespace {
     auto orientation = [self orientation];
     
     // Grab the projection matrix for the image based on the viewport.
-    auto projection = [camera projectionMatrixForOrientation:orientation viewportSize:viewportSize zNear:frameView.DepthNearZ zFar:frameView.DepthFarZ];
+    auto projectionMatrix = [camera projectionMatrixForOrientation:orientation viewportSize:viewportSize zNear:frameView.DepthNearZ zFar:frameView.DepthFarZ];
 
     // Update the projection matrix of the view.
     for(int row = 0; row < 4; row++)
     {
         for(int column = 0; column < 4; column++)
         {
-            ActiveFrameViews[0].ProjectionMatrix[row * 4 + column] = projectionMatrix[row][column];
+            frameView.ProjectionMatrix[row * 4 + column] = projectionMatrix.columns[row][column];
         }
     }
 }
@@ -596,11 +596,6 @@ namespace xr {
             
             [pipelineStateDescriptor release];
             commandQueue = [metalDevice newCommandQueue];
-            
-            // default fov values to avoid NaN at startup
-            auto& frameView = ActiveFrameViews[0];
-            frameView.FieldOfView.AngleDown = -(frameView.FieldOfView.AngleUp = 0.5);
-            frameView.FieldOfView.AngleLeft = -(frameView.FieldOfView.AngleRight = 0.5);
         }
 
         ~Impl() {

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -284,21 +284,15 @@ namespace {
     
     // Grab the projection matrix for the image based on the viewport.
     auto projection = [camera projectionMatrixForOrientation:orientation viewportSize:viewportSize zNear:frameView.DepthNearZ zFar:frameView.DepthFarZ];
-    
-    // Pull out the xScale, and yScale values from the projection matrix.
-    float xScale = projection.columns[0][0];
-    float yScale = projection.columns[1][1];
-    
-    // Calculate the aspect ratio of the projection.
-    float aspectRatio = yScale / xScale;
 
-    // Calculate FoV and apply it to the frame view.
-    // TODO: Validate if this actually gives the right FoV, it seems to be stretched vertically in Landscape
-    // mode likely due to the image being cropped by the transformation in checkAndUpdateCameraUVs vs being
-    // aspect fitted by projectionMatrixForOrientation.
-    float fov =  atanf(1 / yScale);
-    frameView.FieldOfView.AngleDown = -(frameView.FieldOfView.AngleUp = fov);
-    frameView.FieldOfView.AngleLeft = -(frameView.FieldOfView.AngleRight = fov * aspectRatio);
+    // Update the projection matrix of the view.
+    for(int row = 0; row < 4; row++)
+    {
+        for(int column = 0; column < 4; column++)
+        {
+            ActiveFrameViews[0].ProjectionMatrix[row * 4 + column] = projectionMatrix[row][column];
+        }
+    }
 }
 
 /**

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -281,10 +281,10 @@ namespace {
     auto& frameView = activeFrameViews->at(0);
     auto viewportSize = [self viewportSize];
     auto orientation = [self orientation];
-    
+
     // Grab the projection matrix for the image based on the viewport.
     auto projectionMatrix = [camera projectionMatrixForOrientation:orientation viewportSize:viewportSize zNear:frameView.DepthNearZ zFar:frameView.DepthFarZ];
-    memcpy(frameView.ProjectionMatrix.data(), projectionMatrix.columns, sizeof(float) * 16);
+    memcpy(frameView.ProjectionMatrix.data(), projectionMatrix.columns, sizeof(float) * frameView.ProjectionMatrix.size());
 }
 
 /**

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -207,8 +207,8 @@ namespace {
 
         // Check if our orientation or size has changed and update camera UVs if necessary.
         if ([self checkAndUpdateCameraUVs:frame]) {
-            // If our camera UVs updated, then also update the FoV to match the updated UVs.
-            [self updateFoV:frame.camera];
+            // If our camera UVs updated, then also update the projection matrix to match the updated UVs.
+            [self updateProjectionMatrix:frame.camera];
         }
 
         // Finally update the XR pose based on the current transform from ARKit.
@@ -274,9 +274,9 @@ namespace {
 }
 
 /**
- Finds the FoV of the AR Camera, and applies it to the frameView.
+ Gets the projection matrix of the AR Camera, and applies it to the frameView.
 */
-- (void)updateFoV:(ARCamera*)camera {
+- (void)updateProjectionMatrix:(ARCamera*)camera {
     // Get the viewport size and the orientation of the device.
     auto& frameView = activeFrameViews->at(0);
     auto viewportSize = [self viewportSize];
@@ -290,7 +290,7 @@ namespace {
     {
         for(int column = 0; column < 4; column++)
         {
-            frameView.ProjectionMatrix[row * 4 + column] = projectionMatrix.columns[column][row];
+            frameView.ProjectionMatrix[row * 4 + column] = projectionMatrix.columns[row][column];
         }
     }
 }

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -290,7 +290,7 @@ namespace {
     {
         for(int column = 0; column < 4; column++)
         {
-            frameView.ProjectionMatrix[row * 4 + column] = projectionMatrix.columns[row][column];
+            frameView.ProjectionMatrix[row * 4 + column] = projectionMatrix.columns[column][row];
         }
     }
 }

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -856,6 +856,10 @@ namespace xr
             }
         }
 
+        void PopulateProjectionMatrix(const XrView& cachedView, xr::System::Session::Frame::View& view) {
+            // TODO: Need to populate view.ProjectionMatrix.
+        }
+
         void PopulateView(const XrView& cachedView,
             const xr::System::Session::Impl::Swapchain& colorSwapchain,
             const uint32_t colorSwapchainImageIndex,
@@ -870,10 +874,6 @@ namespace xr
             view.Space.Pose.Orientation.Y = cachedView.pose.orientation.y;
             view.Space.Pose.Orientation.Z = cachedView.pose.orientation.z;
             view.Space.Pose.Orientation.W = cachedView.pose.orientation.w;
-            view.FieldOfView.AngleUp = cachedView.fov.angleUp;
-            view.FieldOfView.AngleDown = cachedView.fov.angleDown;
-            view.FieldOfView.AngleLeft = cachedView.fov.angleLeft;
-            view.FieldOfView.AngleRight = cachedView.fov.angleRight;
             view.ColorTextureFormat = SwapchainFormatToTextureFormat(colorSwapchain.Format);
             view.ColorTexturePointer = colorSwapchain.Images[colorSwapchainImageIndex].texture;
             view.ColorTextureSize.Width = colorSwapchain.Width;
@@ -884,6 +884,8 @@ namespace xr
             view.DepthTextureSize.Height = depthSwapchain.Height;
             view.DepthNearZ = sessionImpl.DepthNearZ;
             view.DepthFarZ = sessionImpl.DepthFarZ;
+
+            PopulateProjectionMatrix(cachedView, view);
         }
 
         void PopulateProjectionView(const XrView& cachedView,

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -856,8 +856,42 @@ namespace xr
             }
         }
 
-        void PopulateProjectionMatrix(const XrView& /*cachedView*/, xr::System::Session::Frame::View& /*view*/) {
-            // TODO: Need to populate view.ProjectionMatrix.
+        void PopulateProjectionMatrix(const XrView& cachedView, xr::System::Session::Frame::View& view) {
+            const float n{sessionImpl.DepthNearZ};
+            const float f{sessionImpl.DepthFarZ};
+
+            const float l{std::tanf(cachedView.fov.angleLeft)  * n};	
+            const float r{std::tanf(cachedView.fov.angleRight) * n};	
+            const float t{std::tanf(cachedView.fov.angleUp)    * n};
+            const float b{std::tanf(cachedView.fov.angleDown)  * n};
+
+            // Taken from BGFX math mtxProj().
+            // See also D3DXMatrixPerspectiveOffCenterRH.
+            const float invDiffRL = 1.f / (r - l);
+		    const float invDiffTB = 1.f / (t - b);
+		    const float ww  =  2.f * n * invDiffRL;
+		    const float hh  =  2.f * n * invDiffTB;
+		    const float xx  = (r + l) * invDiffRL;
+		    const float yy  = (t + b) * invDiffTB;
+
+            // TODO: Set this based on the graphics API in use.
+            // If true, the NDC depth ranges from [-1, 1] (OpenGL/Vulkan)
+            // If false, the NDC depth ranges from [0, 1] (D3D)
+            constexpr bool homogeneousDepth = false;
+
+            // We negate the values za and zc to create a right-handed projection matrix,
+            // since the supplied nearZ and farZ are positive.
+            const float diffFN = f - n;
+		    const float za = -(homogeneousDepth ? (f + n) / diffFN : f / diffFN);
+		    const float zb = -(homogeneousDepth ? (2.f * f * n) / diffFN : n * -za);
+            constexpr float zc = -1.f;
+
+            view.ProjectionMatrix = {
+                ww, 0,  0,  0,
+                0,  hh, 0,  0,
+                xx, yy, za, zc,
+                0,  0,  zb, 0
+            };
         }
 
         void PopulateView(const XrView& cachedView,

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -856,7 +856,7 @@ namespace xr
             }
         }
 
-        void PopulateProjectionMatrix(const XrView& cachedView, xr::System::Session::Frame::View& view) {
+        void PopulateProjectionMatrix(const XrView& /*cachedView*/, xr::System::Session::Frame::View& /*view*/) {
             // TODO: Need to populate view.ProjectionMatrix.
         }
 

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -46,19 +46,19 @@ namespace
 
     std::array<float, 16> CreateProjectionMatrix(const xr::System::Session::Frame::View& view)
     {
-        const float n{view.DepthNearZ};
-        const float f{view.DepthFarZ};
-        const float verticalFoV{view.FieldOfView.AngleUp - view.FieldOfView.AngleDown};
-        const float horizontalFoV{view.FieldOfView.AngleRight - view.FieldOfView.AngleLeft};
+        // Calculate total vertical and horizontal FoV and the aspect ratio.
+        const float verticalFoV{abs(view.FieldOfView.AngleUp) + abs(view.FieldOfView.AngleDown)};
+        const float horizontalFoV{abs(view.FieldOfView.AngleRight) + abs(view.FieldOfView.AngleLeft)};
         const float aspectRatio = static_cast<float>(horizontalFoV / verticalFoV);
 
-        const float t{std::tanf(verticalFoV / 2) * n};
-        const float b{t * -1};
-        const float r{t * aspectRatio};
-        const float l{r * -1};
+        // Calculate the top, bottom, left, and right values for creating the projection matrix.
+        const float top{std::tanf(verticalFoV / 2) * view.DepthNearZ};
+        const float bottom{top * -1};
+        const float right{top * aspectRatio};
+        const float left{right * -1};
 
         std::array<float, 16> bxResult{};
-        bx::mtxProj(bxResult.data(), t, b, l, r, n, f, false, bx::Handness::Right);
+        bx::mtxProj(bxResult.data(), top, bottom, left, right, view.DepthNearZ, view.DepthFarZ, false, bx::Handness::Right);
 
         return bxResult;
     }

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -48,28 +48,17 @@ namespace
     {
         const float n{view.DepthNearZ};
         const float f{view.DepthFarZ};
+        const float verticalFoV{view.FieldOfView.AngleUp - view.FieldOfView.AngleDown};
+        const float horizontalFoV{view.FieldOfView.AngleRight - view.FieldOfView.AngleLeft};
+        const float aspectRatio = static_cast<float>(horizontalFoV / verticalFoV);
 
-        const float r{std::tanf(view.FieldOfView.AngleRight) * n};
-        const float l{std::tanf(view.FieldOfView.AngleLeft) * n};
-        const float t{std::tanf(view.FieldOfView.AngleUp) * n};
-        const float b{std::tanf(view.FieldOfView.AngleDown) * n};
-
-        // Angles for FieldOfView respect the viewport ratio
-        // but tangent is not a linear function and ratio of values(l,r,b,t) computed
-        // in CreateProjectionMatrix do not respect that ratio
-        // so, here, a ratio after tangent is computed
-        // and a second derivative ratio computed to compensate
-        // the aspect ratio delta after tangent calls
-        const float aspectRatio = static_cast<float>(view.ColorTextureSize.Height) / static_cast<float>(view.ColorTextureSize.Width);
-        const float deltax = (r - l);
-        const float deltay = (t - b);
-        const float afterTangentAspectRatio = deltay / deltax;
-        const float compensationRatio = afterTangentAspectRatio / aspectRatio;
-        const float rc{std::tanf(view.FieldOfView.AngleRight * compensationRatio) * n};
-        const float lc{std::tanf(view.FieldOfView.AngleLeft * compensationRatio) * n};
+        const float t{std::tanf(verticalFoV / 2) * n};
+        const float b{t * -1};
+        const float r{t * aspectRatio};
+        const float l{r * -1};
 
         std::array<float, 16> bxResult{};
-        bx::mtxProj(bxResult.data(), t, b, lc, rc, n, f, false, bx::Handness::Right);
+        bx::mtxProj(bxResult.data(), t, b, l, r, n, f, false, bx::Handness::Right);
 
         return bxResult;
     }

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -60,16 +60,16 @@ namespace
         // so, here, a ratio after tangent is computed
         // and a second derivative ratio computed to compensate
         // the aspect ratio delta after tangent calls
-        /*const float aspectRatio = static_cast<float>(view.ColorTextureSize.Width) / static_cast<float>(view.ColorTextureSize.Height);
+        const float aspectRatio = static_cast<float>(view.ColorTextureSize.Height) / static_cast<float>(view.ColorTextureSize.Width);
         const float deltax = (r - l);
         const float deltay = (t - b);
-        const float afterTangentAspectRatio = deltax / deltay;
+        const float afterTangentAspectRatio = deltay / deltax;
         const float compensationRatio = afterTangentAspectRatio / aspectRatio;
-        const float tc{std::tanf(view.FieldOfView.AngleUp * compensationRatio) * n};
-        const float bc{std::tanf(view.FieldOfView.AngleDown * compensationRatio) * n};*/
+        const float rc{std::tanf(view.FieldOfView.AngleRight * compensationRatio) * n};
+        const float lc{std::tanf(view.FieldOfView.AngleLeft * compensationRatio) * n};
 
         std::array<float, 16> bxResult{};
-        bx::mtxProj(bxResult.data(), t, b, l, r, n, f, false, bx::Handness::Right);
+        bx::mtxProj(bxResult.data(), t, b, lc, rc, n, f, false, bx::Handness::Right);
 
         return bxResult;
     }

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -44,12 +44,12 @@ namespace
     };
     // clang-format on
 
-    std::array<float, 16> CreateProjectionMatrix(const xr::System::Session::Frame::View& view)
+    std::array<float, 16> CreateCenteredProjectionMatrix(const xr::System::Session::Frame::View& view)
     {
         // Calculate total vertical and horizontal FoV and the aspect ratio.
-        const float verticalFoV{abs(view.FieldOfView.AngleUp) + abs(view.FieldOfView.AngleDown)};
-        const float horizontalFoV{abs(view.FieldOfView.AngleRight) + abs(view.FieldOfView.AngleLeft)};
-        const float aspectRatio = static_cast<float>(horizontalFoV / verticalFoV);
+        const float verticalFoV{view.FieldOfView.AngleUp - view.FieldOfView.AngleDown};
+        const float horizontalFoV{view.FieldOfView.AngleRight - view.FieldOfView.AngleLeft};
+        const float aspectRatio = {horizontalFoV / verticalFoV};
 
         // Calculate the top, bottom, left, and right values for creating the projection matrix.
         const float top{std::tanf(verticalFoV / 2) * view.DepthNearZ};
@@ -61,6 +61,52 @@ namespace
         bx::mtxProj(bxResult.data(), top, bottom, left, right, view.DepthNearZ, view.DepthFarZ, false, bx::Handness::Right);
 
         return bxResult;
+    }
+
+    std::array<float, 16> CreateOffcenterProjectionMatrix(const xr::System::Session::Frame::View& view)
+    {
+        const float n{view.DepthNearZ};
+        const float f{view.DepthFarZ};
+
+        const float r{std::tanf(view.FieldOfView.AngleRight) * n};
+        const float l{std::tanf(view.FieldOfView.AngleLeft) * n};
+        const float t{std::tanf(view.FieldOfView.AngleUp) * n};
+        const float b{std::tanf(view.FieldOfView.AngleDown) * n};
+
+        // Angles for FieldOfView respect the viewport ratio
+        // but tangent is not a linear function and ratio of values(l,r,b,t) computed
+        // in CreateProjectionMatrix do not respect that ratio
+        // so, here, a ratio after tangent is computed
+        // and a second derivative ratio computed to compensate
+        // the aspect ratio delta after tangent calls
+        const float aspectRatio{static_cast<float>(view.ColorTextureSize.Width) / static_cast<float>(view.ColorTextureSize.Height)};
+        const float deltax = (r - l);
+        const float deltay = (t - b);
+        const float afterTangentAspectRatio = deltax / deltay;
+        const float compensationRatio = afterTangentAspectRatio / aspectRatio;
+        const float tc{std::tanf(view.FieldOfView.AngleUp * compensationRatio) * n};
+        const float bc{std::tanf(view.FieldOfView.AngleDown * compensationRatio) * n};
+
+        std::array<float, 16> bxResult{};
+        bx::mtxProj(bxResult.data(), tc, bc, l, r, n, f, false, bx::Handness::Right);
+
+        return bxResult;
+    }
+
+    std::array<float, 16> CreateProjectionMatrix(const xr::System::Session::Frame::View& view)
+    {
+        const bool isCentered{
+            abs(view.FieldOfView.AngleUp + view.FieldOfView.AngleDown) < .01 &&
+            abs(view.FieldOfView.AngleRight + view.FieldOfView.AngleLeft) < .01};
+
+        if (isCentered)
+        {
+            return CreateCenteredProjectionMatrix(view);
+        }
+        else
+        {
+            return CreateOffcenterProjectionMatrix(view);
+        }
     }
 
     std::array<float, 16> CreateTransformMatrix(const xr::System::Session::Frame::Space& space, bool viewSpace = true)

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -93,11 +93,13 @@ namespace
         return bxResult;
     }
 
+    constexpr float centeredViewAngleEpsilon{0.01};
+
     std::array<float, 16> CreateProjectionMatrix(const xr::System::Session::Frame::View& view)
     {
         const bool isCentered{
-            abs(view.FieldOfView.AngleUp + view.FieldOfView.AngleDown) < .01 &&
-            abs(view.FieldOfView.AngleRight + view.FieldOfView.AngleLeft) < .01};
+            abs(view.FieldOfView.AngleUp + view.FieldOfView.AngleDown) < centeredViewAngleEpsilon &&
+            abs(view.FieldOfView.AngleRight + view.FieldOfView.AngleLeft) < centeredViewAngleEpsilon};
 
         if (isCentered)
         {

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -60,16 +60,16 @@ namespace
         // so, here, a ratio after tangent is computed
         // and a second derivative ratio computed to compensate
         // the aspect ratio delta after tangent calls
-        const float aspectRatio = static_cast<float>(view.ColorTextureSize.Width) / static_cast<float>(view.ColorTextureSize.Height);
+        /*const float aspectRatio = static_cast<float>(view.ColorTextureSize.Width) / static_cast<float>(view.ColorTextureSize.Height);
         const float deltax = (r - l);
         const float deltay = (t - b);
         const float afterTangentAspectRatio = deltax / deltay;
         const float compensationRatio = afterTangentAspectRatio / aspectRatio;
         const float tc{std::tanf(view.FieldOfView.AngleUp * compensationRatio) * n};
-        const float bc{std::tanf(view.FieldOfView.AngleDown * compensationRatio) * n};
+        const float bc{std::tanf(view.FieldOfView.AngleDown * compensationRatio) * n};*/
 
         std::array<float, 16> bxResult{};
-        bx::mtxProj(bxResult.data(), tc, bc, l, r, n, f, false, bx::Handness::Right);
+        bx::mtxProj(bxResult.data(), t, b, l, r, n, f, false, bx::Handness::Right);
 
         return bxResult;
     }

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -44,73 +44,6 @@ namespace
     };
     // clang-format on
 
-    std::array<float, 16> CreateCenteredProjectionMatrix(const xr::System::Session::Frame::View& view)
-    {
-        // Calculate total vertical and horizontal FoV and the aspect ratio.
-        const float verticalFoV{view.FieldOfView.AngleUp - view.FieldOfView.AngleDown};
-        const float horizontalFoV{view.FieldOfView.AngleRight - view.FieldOfView.AngleLeft};
-        const float aspectRatio = {horizontalFoV / verticalFoV};
-
-        // Calculate the top, bottom, left, and right values for creating the projection matrix.
-        const float top{std::tanf(verticalFoV / 2) * view.DepthNearZ};
-        const float bottom{top * -1};
-        const float right{top * aspectRatio};
-        const float left{right * -1};
-
-        std::array<float, 16> bxResult{};
-        bx::mtxProj(bxResult.data(), top, bottom, left, right, view.DepthNearZ, view.DepthFarZ, false, bx::Handness::Right);
-
-        return bxResult;
-    }
-
-    std::array<float, 16> CreateOffcenterProjectionMatrix(const xr::System::Session::Frame::View& view)
-    {
-        const float n{view.DepthNearZ};
-        const float f{view.DepthFarZ};
-
-        const float r{std::tanf(view.FieldOfView.AngleRight) * n};
-        const float l{std::tanf(view.FieldOfView.AngleLeft) * n};
-        const float t{std::tanf(view.FieldOfView.AngleUp) * n};
-        const float b{std::tanf(view.FieldOfView.AngleDown) * n};
-
-        // Angles for FieldOfView respect the viewport ratio
-        // but tangent is not a linear function and ratio of values(l,r,b,t) computed
-        // in CreateProjectionMatrix do not respect that ratio
-        // so, here, a ratio after tangent is computed
-        // and a second derivative ratio computed to compensate
-        // the aspect ratio delta after tangent calls
-        const float aspectRatio{static_cast<float>(view.ColorTextureSize.Width) / static_cast<float>(view.ColorTextureSize.Height)};
-        const float deltax = (r - l);
-        const float deltay = (t - b);
-        const float afterTangentAspectRatio = deltax / deltay;
-        const float compensationRatio = afterTangentAspectRatio / aspectRatio;
-        const float tc{std::tanf(view.FieldOfView.AngleUp * compensationRatio) * n};
-        const float bc{std::tanf(view.FieldOfView.AngleDown * compensationRatio) * n};
-
-        std::array<float, 16> bxResult{};
-        bx::mtxProj(bxResult.data(), tc, bc, l, r, n, f, false, bx::Handness::Right);
-
-        return bxResult;
-    }
-
-    constexpr float centeredViewAngleEpsilon{0.01f};
-
-    std::array<float, 16> CreateProjectionMatrix(const xr::System::Session::Frame::View& view)
-    {
-        const bool isCentered{
-            abs(view.FieldOfView.AngleUp + view.FieldOfView.AngleDown) < centeredViewAngleEpsilon &&
-            abs(view.FieldOfView.AngleRight + view.FieldOfView.AngleLeft) < centeredViewAngleEpsilon};
-
-        if (isCentered)
-        {
-            return CreateCenteredProjectionMatrix(view);
-        }
-        else
-        {
-            return CreateOffcenterProjectionMatrix(view);
-        }
-    }
-
     std::array<float, 16> CreateTransformMatrix(const xr::System::Session::Frame::Space& space, bool viewSpace = true)
     {
         auto& quat = space.Pose.Orientation;
@@ -913,7 +846,7 @@ namespace Babylon
                 for (uint32_t idx = 0; idx < static_cast<uint32_t>(views.size()); ++idx)
                 {
                     const auto& view = views[idx];
-                    m_views[idx]->Update(idx, CreateProjectionMatrix(view), view.Space, view.IsFirstPersonObserver);
+                    m_views[idx]->Update(idx, view.ProjectionMatrix, view.Space, view.IsFirstPersonObserver);
                 }
             }
 

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -93,7 +93,7 @@ namespace
         return bxResult;
     }
 
-    constexpr float centeredViewAngleEpsilon{0.01};
+    constexpr float centeredViewAngleEpsilon{0.01f};
 
     std::array<float, 16> CreateProjectionMatrix(const xr::System::Session::Frame::View& view)
     {


### PR DESCRIPTION
This PR attempts to address #473, which effectively expanded the projection matrix to maintain the aspect ratio, but incorrectly calculated the real FOV.  I think this was occurring because we were applying both the angle FOV values with the aspect ratio from the color texture.

In this PR I'm pushing the generation of projection matrices down to the platform level implementations.  For ARCore and ARKit we are provided with valid projection matrices.  For OpenXR we need to generate them ourselves based off the FoV angles.

Here are some comparisons from my testing attempting to measure a 5' long measuring tape.  In both cases I measured by getting close to the tape and walking along its length then stepping back to a reasonable distance to take a picture.

old:
<img src="https://user-images.githubusercontent.com/27031140/99599500-590ded80-29b0-11eb-876a-9c26f7fc0902.jpg" width="400">
<img src="https://user-images.githubusercontent.com/27031140/99599503-5a3f1a80-29b0-11eb-90f3-886c5a6f33b1.jpg" width="400">
<img src="https://user-images.githubusercontent.com/27031140/99599506-5a3f1a80-29b0-11eb-9b99-9574f7c44d9d.jpg" width="800">
<img src="https://user-images.githubusercontent.com/27031140/99599508-5ad7b100-29b0-11eb-8f50-8e99915e8cd7.jpg" width="800">

new:

<img src="https://user-images.githubusercontent.com/27031140/99599870-1a2c6780-29b1-11eb-8922-d30db8261dc9.jpg" width="400">
<img src="https://user-images.githubusercontent.com/27031140/99599877-1bf62b00-29b1-11eb-9f85-d1752ea07613.jpg" width="400">
<img src="https://user-images.githubusercontent.com/27031140/99599873-1b5d9480-29b1-11eb-9616-9ee9ec1ca000.jpg" width="800">
<img src="https://user-images.githubusercontent.com/27031140/99599872-1ac4fe00-29b1-11eb-9f28-3ca3ad42c8f2.jpg" width="800">
<img src="https://user-images.githubusercontent.com/27031140/99599874-1b5d9480-29b1-11eb-8b84-70b879f91359.jpg" width="800">
