### PR TITLE
Threading fixes

### DIFF
--- a/Core/AppRuntime/Source/AppRuntimeChakra.cpp
+++ b/Core/AppRuntime/Source/AppRuntimeChakra.cpp
@@ -58,10 +58,13 @@ namespace Babylon
 #endif
 
         Napi::Env env = Napi::Attach();
+
         Run(env);
-        Napi::Detach(env);
 
         ThrowIfFailed(JsSetCurrentContext(JS_INVALID_REFERENCE));
         ThrowIfFailed(JsDisposeRuntime(jsRuntime));
+
+        // Detach must come after JsDisposeRuntime since it triggers finalizers which require env.
+        Napi::Detach(env);
     }
 }

--- a/Core/AppRuntime/Source/AppRuntimeJavaScriptCore.cpp
+++ b/Core/AppRuntime/Source/AppRuntimeJavaScriptCore.cpp
@@ -8,8 +8,12 @@ namespace Babylon
     {
         auto globalContext = JSGlobalContextCreateInGroup(nullptr, nullptr);
         Napi::Env env = Napi::Attach(globalContext);
+
         Run(env);
+
         JSGlobalContextRelease(globalContext);
+
+        // Detach must come after JSGlobalContextRelease since it triggers finalizers which require env.
         Napi::Detach(env);
     }
 }

--- a/Dependencies/napi/napi-direct/source/js_native_api_chakra.cc
+++ b/Dependencies/napi/napi-direct/source/js_native_api_chakra.cc
@@ -374,6 +374,7 @@ static napi_status SetErrorCode(napi_env env, JsValueRef error, napi_value code,
 
 napi_status ConcludeDeferred(napi_env env, napi_deferred deferred, const char* property, napi_value result) {
   // We do not check if property is OK, because that's not coming from outside.
+  CHECK_ENV(env);
   CHECK_ARG(env, deferred);
   CHECK_ARG(env, result);
 
@@ -1593,6 +1594,7 @@ napi_status napi_get_value_string_utf16(napi_env env,
 napi_status napi_coerce_to_bool(napi_env env,
                                 napi_value v,
                                 napi_value* result) {
+  CHECK_ENV(env);
   CHECK_ARG(env, result);
   JsValueRef value = reinterpret_cast<JsValueRef>(v);
   CHECK_JSRT(env,
@@ -2355,6 +2357,7 @@ napi_status napi_reject_deferred(napi_env env,
 napi_status napi_is_promise(napi_env env,
                             napi_value promise,
                             bool* is_promise) {
+  CHECK_ENV(env);
   CHECK_ARG(env, promise);
   CHECK_ARG(env, is_promise);
 
@@ -2370,6 +2373,7 @@ napi_status napi_is_promise(napi_env env,
 napi_status napi_run_script(napi_env env,
                             napi_value script,
                             napi_value* result) {
+  CHECK_ENV(env);
   CHECK_ARG(env, script);
   CHECK_ARG(env, result);
 
@@ -2387,6 +2391,7 @@ napi_status napi_run_script(napi_env env,
                             napi_value script,
                             const char* source_url,
                             napi_value* result) {
+  CHECK_ENV(env);
   CHECK_ARG(env, script);
   CHECK_ARG(env, result);
   JsValueRef scriptVar = reinterpret_cast<JsValueRef>(script);
@@ -2411,6 +2416,7 @@ napi_status napi_add_finalizer(napi_env env,
 napi_status napi_adjust_external_memory(napi_env env,
                                         int64_t change_in_bytes,
                                         int64_t* adjusted_value) {
+  CHECK_ENV(env);
   CHECK_ARG(env, adjusted_value);
 
   // TODO(jackhorton): Determine if Chakra needs or is able to do anything here

--- a/Dependencies/napi/napi-direct/source/js_native_api_chakra.h
+++ b/Dependencies/napi/napi-direct/source/js_native_api_chakra.h
@@ -2,25 +2,30 @@
 
 #include <jsrt.h>
 #include <napi/js_native_api_types.h>
+#include <thread>
+#include <cassert>
 
 struct napi_env__ {
   JsSourceContext source_context = JS_SOURCE_CONTEXT_NONE;
   napi_extended_error_info last_error{ nullptr, nullptr, 0, napi_ok };
   JsValueRef has_own_property_function = JS_INVALID_REFERENCE;
+
+  const std::thread::id thread_id{std::this_thread::get_id()};
 };
 
-#define RETURN_STATUS_IF_FALSE(env, condition, status)                  \
-  do {                                                                  \
-    if (!(condition)) {                                                 \
-      return napi_set_last_error((env), (status));                      \
-    }                                                                   \
+#define RETURN_STATUS_IF_FALSE(env, condition, status) \
+  do {                                                 \
+    if (!(condition)) {                                \
+      return napi_set_last_error((env), (status));     \
+    }                                                  \
   } while (0)
 
-#define CHECK_ENV(env)          \
-  do {                          \
-    if ((env) == nullptr) {     \
-      return napi_invalid_arg;  \
-    }                           \
+#define CHECK_ENV(env)                                    \
+  do {                                                    \
+    if ((env) == nullptr) {                               \
+      return napi_invalid_arg;                            \
+    }                                                     \
+    assert(env->thread_id == std::this_thread::get_id()); \
   } while (0)
 
 #define CHECK_ARG(env, arg) \
@@ -32,7 +37,7 @@ struct napi_env__ {
     if (err != JsNoError) return napi_set_last_error(env, err); \
   } while (0)
 
-#define CHECK_JSRT_EXPECTED(env, expr, expected)                 \
+#define CHECK_JSRT_EXPECTED(env, expr, expected)                \
   do {                                                          \
     JsErrorCode err = (expr);                                   \
     if (err == JsErrorInvalidArgument)                          \

--- a/Dependencies/napi/napi-direct/source/js_native_api_javascriptcore.cc
+++ b/Dependencies/napi/napi-direct/source/js_native_api_javascriptcore.cc
@@ -2329,6 +2329,7 @@ napi_status napi_reject_deferred(napi_env env,
 napi_status napi_is_promise(napi_env env,
                             napi_value promise,
                             bool* is_promise) {
+  CHECK_ENV(env);
   CHECK_ARG(env, promise);
   CHECK_ARG(env, is_promise);
 
@@ -2343,6 +2344,7 @@ napi_status napi_is_promise(napi_env env,
 napi_status napi_run_script(napi_env env,
                             napi_value script,
                             napi_value* result) {
+  CHECK_ENV(env);
   CHECK_ARG(env, script);
   CHECK_ARG(env, result);
 
@@ -2362,6 +2364,7 @@ napi_status napi_run_script(napi_env env,
                             napi_value script,
                             const char* source_url,
                             napi_value* result) {
+  CHECK_ENV(env);
   CHECK_ARG(env, script);
   CHECK_ARG(env, result);
 
@@ -2393,6 +2396,7 @@ napi_status napi_add_finalizer(napi_env env,
 napi_status napi_adjust_external_memory(napi_env env,
                                         int64_t change_in_bytes,
                                         int64_t* adjusted_value) {
+  CHECK_ENV(env);
   CHECK_ARG(env, adjusted_value);
 
   // TODO: Determine if JSC needs or is able to do anything here

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1135,7 +1135,7 @@ namespace Babylon
                     CreateCubeTextureFromImages(texture, images, generateMips);
                 });
             })
-            .then(RuntimeScheduler, m_cancelSource, [this, onSuccessRef{Napi::Persistent(onSuccess)}, onErrorRef{Napi::Persistent(onError)}](arcana::expected<void, std::exception_ptr> result) {
+            .then(RuntimeScheduler, m_cancelSource, [onSuccessRef{Napi::Persistent(onSuccess)}, onErrorRef{Napi::Persistent(onError)}](arcana::expected<void, std::exception_ptr> result) {
                 if (result.has_error())
                 {
                     onErrorRef.Call({});
@@ -1180,14 +1180,14 @@ namespace Babylon
                     CreateCubeTextureFromImages(texture, images, true);
                 });
             })
-            .then(RuntimeScheduler, m_cancelSource, [this, onSuccessRef{Napi::Persistent(onSuccess)}, onErrorRef{Napi::Persistent(onError)}](arcana::expected<void, std::exception_ptr> result) {
+            .then(RuntimeScheduler, m_cancelSource, [onSuccessRef{Napi::Persistent(onSuccess)}, onErrorRef{Napi::Persistent(onError)}](arcana::expected<void, std::exception_ptr> result) {
                 if (result.has_error())
                 {
-                    onErrorRef.Call({Napi::Value::From(Env(), true)});
+                    onErrorRef.Call({});
                 }
                 else
                 {
-                    onSuccessRef.Call({Napi::Value::From(Env(), true)});
+                    onSuccessRef.Call({});
                 }
             });
     }

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1069,7 +1069,7 @@ namespace Babylon
         const auto dataSpan = gsl::make_span(static_cast<uint8_t*>(data.ArrayBuffer().Data()) + data.ByteOffset(), data.ByteLength());
 
         arcana::make_task(arcana::threadpool_scheduler, m_cancelSource,
-            [this, dataSpan, dataRef = Napi::Persistent(data), generateMips, invertY]() {
+            [this, dataSpan, generateMips, invertY]() {
                 bimg::ImageContainer* image = bimg::imageParse(&m_allocator, dataSpan.data(), static_cast<uint32_t>(dataSpan.size()));
                 if (image == nullptr)
                 {
@@ -1085,13 +1085,13 @@ namespace Babylon
                 }
                 return image;
             })
-            .then(RuntimeScheduler, arcana::cancellation::none(), [this, texture](bimg::ImageContainer* image) {
+            .then(RuntimeScheduler, arcana::cancellation::none(), [this, texture, dataRef{Napi::Persistent(data)}](bimg::ImageContainer* image) {
                 ScheduleRender();
                 return m_graphicsImpl.GetAfterRenderTask().then(arcana::inline_scheduler, m_cancelSource, [texture, image] {
                     CreateTextureFromImage(texture, image);
                 });
             })
-            .then(RuntimeScheduler, m_cancelSource, [onSuccessRef = Napi::Persistent(onSuccess), onErrorRef = Napi::Persistent(onError)](arcana::expected<void, std::exception_ptr> result) {
+            .then(RuntimeScheduler, m_cancelSource, [onSuccessRef{Napi::Persistent(onSuccess)}, onErrorRef{Napi::Persistent(onError)}](arcana::expected<void, std::exception_ptr> result) {
                 if (result.has_error())
                 {
                     onErrorRef.Call({});
@@ -1111,12 +1111,14 @@ namespace Babylon
         const auto onSuccess = info[3].As<Napi::Function>();
         const auto onError = info[4].As<Napi::Function>();
 
+        std::array<Napi::Reference<Napi::TypedArray>, 6> dataRefs;
         std::array<arcana::task<bimg::ImageContainer*, std::exception_ptr>, 6> tasks;
         for (uint32_t face = 0; face < data.Length(); face++)
         {
             const auto typedArray = data[face].As<Napi::TypedArray>();
             const auto dataSpan = gsl::make_span(static_cast<uint8_t*>(typedArray.ArrayBuffer().Data()) + typedArray.ByteOffset(), typedArray.ByteLength());
-            tasks[face] = arcana::make_task(arcana::threadpool_scheduler, m_cancelSource, [this, dataSpan, dataRef = Napi::Persistent(typedArray), generateMips]() {
+            dataRefs[face] = Napi::Persistent(typedArray);
+            tasks[face] = arcana::make_task(arcana::threadpool_scheduler, m_cancelSource, [this, dataSpan, generateMips]() {
                 bimg::ImageContainer* image = bimg::imageParse(&m_allocator, dataSpan.data(), static_cast<uint32_t>(dataSpan.size()));
                 if (generateMips)
                 {
@@ -1127,19 +1129,20 @@ namespace Babylon
         }
 
         arcana::when_all(gsl::make_span(tasks))
-            .then(RuntimeScheduler, arcana::cancellation::none(), [this, texture, generateMips](std::vector<bimg::ImageContainer*> images) {
+            .then(RuntimeScheduler, arcana::cancellation::none(), [this, texture, generateMips, dataRefs{std::move(dataRefs)}](std::vector<bimg::ImageContainer*> images) {
                 ScheduleRender();
                 return m_graphicsImpl.GetAfterRenderTask().then(arcana::inline_scheduler, m_cancelSource, [texture, generateMips, images = std::move(images)] {
                     CreateCubeTextureFromImages(texture, images, generateMips);
                 });
             })
-            .then(RuntimeScheduler, m_cancelSource, [this, onSuccessRef = Napi::Persistent(onSuccess)]() {
-                onSuccessRef.Call({Napi::Value::From(Env(), true)});
-            })
-            .then(arcana::inline_scheduler, m_cancelSource, [this, onErrorRef = Napi::Persistent(onError)](arcana::expected<void, std::exception_ptr> result) {
+            .then(RuntimeScheduler, m_cancelSource, [this, onSuccessRef{Napi::Persistent(onSuccess)}, onErrorRef{Napi::Persistent(onError)}](arcana::expected<void, std::exception_ptr> result) {
                 if (result.has_error())
                 {
-                    onErrorRef.Call({Napi::Value::From(Env(), true)});
+                    onErrorRef.Call({});
+                }
+                else
+                {
+                    onSuccessRef.Call({});
                 }
             });
     }
@@ -1152,6 +1155,7 @@ namespace Babylon
         const auto onError = info[3].As<Napi::Function>();
 
         const auto numMips = data.Length();
+        std::vector<Napi::Reference<Napi::TypedArray>> dataRefs(6 * numMips);
         std::vector<arcana::task<bimg::ImageContainer*, std::exception_ptr>> tasks(6 * numMips);
         for (uint32_t mip = 0; mip < numMips; mip++)
         {
@@ -1160,7 +1164,8 @@ namespace Babylon
             {
                 const auto typedArray = faceData[face].As<Napi::TypedArray>();
                 const auto dataSpan = gsl::make_span(static_cast<uint8_t*>(typedArray.ArrayBuffer().Data()) + typedArray.ByteOffset(), typedArray.ByteLength());
-                tasks[(face * numMips) + mip] = arcana::make_task(arcana::threadpool_scheduler, m_cancelSource, [this, dataSpan, dataRef = Napi::Persistent(typedArray)]() {
+                dataRefs[(face * numMips) + mip] = Napi::Persistent(typedArray);
+                tasks[(face * numMips) + mip] = arcana::make_task(arcana::threadpool_scheduler, m_cancelSource, [this, dataSpan]() {
                     bimg::ImageContainer* image = bimg::imageParse(&m_allocator, dataSpan.data(), static_cast<uint32_t>(dataSpan.size()));
                     FlipY(image);
                     return image;
@@ -1169,19 +1174,20 @@ namespace Babylon
         }
 
         arcana::when_all(gsl::make_span(tasks))
-            .then(RuntimeScheduler, arcana::cancellation::none(), [this, texture](std::vector<bimg::ImageContainer*> images) {
+            .then(RuntimeScheduler, arcana::cancellation::none(), [this, texture, dataRefs{std::move(dataRefs)}](std::vector<bimg::ImageContainer*> images) {
                 ScheduleRender();
                 return m_graphicsImpl.GetAfterRenderTask().then(arcana::inline_scheduler, m_cancelSource, [texture, images = std::move(images)] {
                     CreateCubeTextureFromImages(texture, images, true);
                 });
             })
-            .then(RuntimeScheduler, m_cancelSource, [this, onSuccessRef = Napi::Persistent(onSuccess)]() {
-                onSuccessRef.Call({Napi::Value::From(Env(), true)});
-            })
-            .then(arcana::inline_scheduler, m_cancelSource, [this, onErrorRef = Napi::Persistent(onError)](arcana::expected<void, std::exception_ptr> result) {
+            .then(RuntimeScheduler, m_cancelSource, [this, onSuccessRef{Napi::Persistent(onSuccess)}, onErrorRef{Napi::Persistent(onError)}](arcana::expected<void, std::exception_ptr> result) {
                 if (result.has_error())
                 {
                     onErrorRef.Call({Napi::Value::From(Env(), true)});
+                }
+                else
+                {
+                    onSuccessRef.Call({Napi::Value::From(Env(), true)});
                 }
             });
     }


### PR DESCRIPTION
As part of #480 we introduced a bug where the NAPI references are not being destructed on the JS thread. This change moves the capture of the NAPI references further down the task chain so that it ends up on a JS thread continuation. This is the result of investigating #510, but I have not confirmed if the issue is fixed yet.

To make sure this type of thing never happens again, this change also adds thread checking logic to each of the NAPI direct implementations (Chakra, V8, JSC). There is more work to do to implement this in NAPI/JSI, but since NAPI direct has the check, it will be much less likely to have a NAPI/JSI specific threading issue.