### PR TITLE
Add dom static lib to polyfill DOMPointReadOnly for WebXR APIs

### DIFF
--- a/Apps/Playground/Android/app/CMakeLists.txt
+++ b/Apps/Playground/Android/app/CMakeLists.txt
@@ -63,7 +63,8 @@ target_link_libraries(BabylonNativeJNI
         Console
         Window
         ScriptLoader
-        XMLHttpRequest)
+        XMLHttpRequest
+        DOM)
 
 configure_file(
     "${ANDROID_NDK}/sources/cxx-stl/llvm-libc++/libs/${ANDROID_ABI}/libc++_shared.so"

--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -92,6 +92,7 @@ extern "C"
 
                 Babylon::Polyfills::Window::Initialize(env);
                 Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+                Babylon::Polyfills::DOM::Initialize(env);
 
                 InputManager<Babylon::AppRuntime>::Initialize(env, *g_inputBuffer);
             });

--- a/Apps/Playground/CMakeLists.txt
+++ b/Apps/Playground/CMakeLists.txt
@@ -115,6 +115,7 @@ target_link_to_dependencies(Playground
     PRIVATE Window
     PRIVATE ScriptLoader
     PRIVATE XMLHttpRequest
+    PRIVATE DOM
     ${ADDITIONAL_LIBRARIES}
     ${BABYLON_NATIVE_PLAYGROUND_EXTENSION_LIBRARIES})
 

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -158,6 +158,7 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
 
         Babylon::Polyfills::Window::Initialize(env);
         Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+        Babylon::Polyfills::DOM::Initialize(env);
 
         // Initialize NativeEngine plugin.
         m_graphics->AddToJavaScript(env);

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -111,6 +111,7 @@ namespace
 
             Babylon::Polyfills::Window::Initialize(env);
             Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+            Babylon::Polyfills::DOM::Initialize(env);
 
             // Initialize NativeEngine plugin.
             graphics->AddToJavaScript(env);

--- a/Apps/Playground/X11/App.cpp
+++ b/Apps/Playground/X11/App.cpp
@@ -68,6 +68,7 @@ namespace
 
             Babylon::Polyfills::Window::Initialize(env);
             Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+            Babylon::Polyfills::DOM::Initialize(env);
 
             // Initialize NativeEngine plugin.
             graphics->AddToJavaScript(env);

--- a/Apps/Playground/iOS/LibNativeBridge.mm
+++ b/Apps/Playground/iOS/LibNativeBridge.mm
@@ -43,6 +43,7 @@ std::unique_ptr<InputManager<Babylon::AppRuntime>::InputBuffer> inputBuffer{};
     {
         Babylon::Polyfills::Window::Initialize(env);
         Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+        Babylon::Polyfills::DOM::Initialize(env);
         
         graphics->AddToJavaScript(env);
         Babylon::Plugins::NativeEngine::Initialize(env);

--- a/Apps/Playground/macOS/ViewController.mm
+++ b/Apps/Playground/macOS/ViewController.mm
@@ -76,6 +76,7 @@ std::unique_ptr<InputManager<Babylon::AppRuntime>::InputBuffer> inputBuffer{};
     {
         Babylon::Polyfills::Window::Initialize(env);
         Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+        Babylon::Polyfills::DOM::Initialize(env);
 
         graphics->AddToJavaScript(env);
         Babylon::Plugins::NativeEngine::Initialize(env, false); // render on UI Thread

--- a/Apps/ValidationTests/Android/app/CMakeLists.txt
+++ b/Apps/ValidationTests/Android/app/CMakeLists.txt
@@ -64,7 +64,8 @@ target_link_libraries(BabylonNativeJNI
         Window
         ScriptLoader
         bgfx
-        XMLHttpRequest)
+        XMLHttpRequest
+        DOM)
 
 configure_file(
     "${ANDROID_NDK}/sources/cxx-stl/llvm-libc++/libs/${ANDROID_ABI}/libc++_shared.so"

--- a/Apps/ValidationTests/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/ValidationTests/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -88,6 +88,7 @@ extern "C"
 
                 Babylon::Polyfills::Window::Initialize(env);
                 Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+                Babylon::Polfyills::DOM::Initialize(env);
                 Babylon::TestUtils::CreateInstance(env, window);
             });
 

--- a/Apps/ValidationTests/CMakeLists.txt
+++ b/Apps/ValidationTests/CMakeLists.txt
@@ -89,7 +89,8 @@ target_link_to_dependencies(ValidationTests
     PRIVATE Window
     PRIVATE ScriptLoader
     ${ADDITIONAL_LIBRARIES}
-    PRIVATE XMLHttpRequest)
+    PRIVATE XMLHttpRequest
+    PRIVATE DOM)
 
 if(APPLE)
     target_link_libraries(ValidationTests PRIVATE "-framework MetalKit")

--- a/Apps/ValidationTests/Win32/App.cpp
+++ b/Apps/ValidationTests/Win32/App.cpp
@@ -111,6 +111,7 @@ namespace
 
                 Babylon::Polyfills::Window::Initialize(env);
                 Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+                Babylon::Polyfills::DOM::Initialize(env);
 
                 Babylon::Polyfills::Window::Initialize(env);
 

--- a/Apps/ValidationTests/X11/App.cpp
+++ b/Apps/ValidationTests/X11/App.cpp
@@ -79,6 +79,7 @@ namespace
 
             Babylon::Polyfills::Window::Initialize(env);
             Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+            Babylon::Polyfills::DOM::Initialize(env);
             
             // Initialize NativeEngine plugin.
             graphics->AddToJavaScript(env);

--- a/Apps/ValidationTests/iOS/LibNativeBridge.mm
+++ b/Apps/ValidationTests/iOS/LibNativeBridge.mm
@@ -44,6 +44,7 @@ std::unique_ptr<Babylon::AppRuntime> runtime{};
     {
         Babylon::Polyfills::Window::Initialize(env);
         Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+        Babylon::Polyfills::DOM::Initialize(env);
         
         graphics->AddToJavaScript(env);
         Babylon::Plugins::NativeEngine::Initialize(env);

--- a/Apps/ValidationTests/macOS/ViewController.mm
+++ b/Apps/ValidationTests/macOS/ViewController.mm
@@ -73,6 +73,7 @@ std::unique_ptr<Babylon::AppRuntime> runtime{};
     {
         Babylon::Polyfills::Window::Initialize(env);
         Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+        Babylon::Polyfills::DOM::Initialize(env);
 
         graphics->AddToJavaScript(env);
         Babylon::Plugins::NativeEngine::Initialize(env, false); // render on UI Thread

--- a/Polyfills/CMakeLists.txt
+++ b/Polyfills/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Console)
 add_subdirectory(Window)
 add_subdirectory(XMLHttpRequest)
+add_subdirectory(DOM)

--- a/Polyfills/DOM/CMakeLists.txt
+++ b/Polyfills/DOM/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(SOURCES
+    "Include/Babylon/Polyfills/DOM.h"
+    "Source/DOM.cpp")
+
+add_library(DOM ${SOURCES})
+warnings_as_errors(DOM)
+
+target_include_directories(DOM PUBLIC "Include")
+
+target_link_to_dependencies(DOM PUBLIC napi)
+
+set_property(TARGET DOM PROPERTY FOLDER Polyfills)
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Polyfills/DOM/Include/Babylon/Polyfills/DOM.h
+++ b/Polyfills/DOM/Include/Babylon/Polyfills/DOM.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <napi/env.h>
+
+namespace Babylon::Polyfills::DOM
+{
+    void Initialize(Napi::Env env);
+}

--- a/Polyfills/DOM/Source/DOM.cpp
+++ b/Polyfills/DOM/Source/DOM.cpp
@@ -1,0 +1,69 @@
+#include <Babylon/Polyfills/DOM.h>
+
+namespace Babylon::Polyfills::DOM
+{
+    class DOMPointReadOnly final : public Napi::ObjectWrap<DOMPointReadOnly>
+    {
+        static constexpr auto JS_CLASS_NAME = "DOMPointReadOnly";
+
+    public:
+        static void Initialize(Napi::Env env) {
+            Napi::HandleScope scope{ env };
+
+            Napi::Function func = DefineClass(
+                env,
+                JS_CLASS_NAME,
+                {
+                    InstanceAccessor("x", &DOMPointReadOnly::GetX, nullptr),
+                    InstanceAccessor("y", &DOMPointReadOnly::GetY, nullptr),
+                    InstanceAccessor("z", &DOMPointReadOnly::GetZ, nullptr),
+                    InstanceAccessor("w", &DOMPointReadOnly::GetW, nullptr)
+                });
+
+            env.Global().Set(JS_CLASS_NAME, func);
+        }
+
+        DOMPointReadOnly(const Napi::CallbackInfo& info) : Napi::ObjectWrap<DOMPointReadOnly>{info}
+        {
+            _x = info[0].As<Napi::Number>();
+            _y = info[1].As<Napi::Number>();
+
+            if (info.Length() > 2)
+            {
+                _z = info[2].As<Napi::Number>();
+            }
+
+            if (info.Length() > 3)
+            {
+                _w = info[3].As<Napi::Number>();
+            }
+        }
+
+    private:
+        float _x{ 0 };
+        float _y{ 0 };
+        float _z{ 0 };
+        float _w{ 1 };
+
+        Napi::Value GetX(const Napi::CallbackInfo& info) {
+            return Napi::Number::From(info.Env(), _x);
+        }
+
+        Napi::Value GetY(const Napi::CallbackInfo& info) {
+            return Napi::Number::From(info.Env(), _y);
+        }
+
+        Napi::Value GetZ(const Napi::CallbackInfo& info) {
+            return Napi::Number::From(info.Env(), _z);
+        }
+
+        Napi::Value GetW(const Napi::CallbackInfo& info) {
+            return Napi::Number::From(info.Env(), _w);
+        }
+    };
+
+    void Initialize(Napi::Env env)
+    {
+        DOMPointReadOnly::Initialize(env);
+    }
+}


### PR DESCRIPTION
We have some WebXR definitions that require constructing and handing around DOMPointReadOnlys. This change introduces an incomplete polyfill for DOMPointReadOnly that allows us to unblock WebXR world geometry scenarios in BabylonNative