### PR TITLE
Enabling default and microsoft controller bindings side-by-side

### DIFF
--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -733,7 +733,7 @@ namespace xr
                 ActionResources.CONTROLLER_GET_TRIGGER_VALUE_ACTION_LOCALIZED_NAME,
                 ActionResources.CONTROLLER_GET_TRIGGER_VALUE_PATH_SUFFIX,
                 &ActionResources.ControllerGetTriggerValueAction,
-               microsoftControllerBindings
+                microsoftControllerBindings
                 instance);
 
             // Create controller get squeeze click action and suggested bindings

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -733,7 +733,7 @@ namespace xr
                 ActionResources.CONTROLLER_GET_TRIGGER_VALUE_ACTION_LOCALIZED_NAME,
                 ActionResources.CONTROLLER_GET_TRIGGER_VALUE_PATH_SUFFIX,
                 &ActionResources.ControllerGetTriggerValueAction,
-                microsoftControllerBindings
+                microsoftControllerBindings,
                 instance);
 
             // Create controller get squeeze click action and suggested bindings


### PR DESCRIPTION
We were using the MS controller bindings and defaulting to default bindings when they weren't accessible, but this creates a problem. Aim/grip space is only populated when the input device is a MS controller, and other devices, such as hands, do not populate aim/grip space.

Also, if the default profile *was* used, xrSuggestInteractionProfileBindings would hit an error as the list of bindings included invalid bindings for the default profile.