### PR TITLE
Only creating gamepad data when gamepad information is available

### DIFF
--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -154,7 +154,7 @@ namespace xr
                     {
                         bool Pressed{ false };
                         bool Touched{ false };
-                        double Value{0};
+                        float Value{0};
                     };
 
                     std::array<float, DEFAULT_CONTROLLER_AXES> Axes;

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -1446,7 +1446,7 @@ namespace xr
                 // Get gamepad data 
                 {
                     const auto& controllerInfo = sessionImpl.ControllerInfo;
-                    auto gamepadObject = InputSources[idx].GamepadObject;
+                    auto& gamepadObject = InputSources[idx].GamepadObject;
 
                     // Update gamepad data
                     if ((m_impl->TryUpdateControllerFloatAction(actionResources.ControllerGetTriggerValueAction, session, gamepadObject.Buttons[controllerInfo.TRIGGER_BUTTON].Value)) &&


### PR DESCRIPTION
Since the action profile's availability is separate from whether we use it, this change only creates a gamepad component on the input source if gamepad data is available.