### PR TITLE
Workaround ARCore double rendering issue

### DIFF
--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -604,10 +604,16 @@ namespace xr
                 // Draw the quad
                 glDrawArrays(GL_TRIANGLE_STRIP, 0, VERTEX_COUNT);
 
-                // Present to the screen
-                // NOTE: For a yet to be determined reason, bgfx is also doing an eglSwapBuffers when running in the regular Android Babylon Native Playground playground app.
-                //       The "double" eglSwapBuffers causes rendering issues, so until we figure out this issue, comment out this line while testing in the regular playground app.
-                eglSwapBuffers(eglGetCurrentDisplay(), eglGetCurrentSurface(EGL_DRAW));
+                // TODO: This is a hacky work around for https://github.com/BabylonJS/BabylonNative/issues/568
+                //       Remove this code once we actually resolve that issue.
+                if (hasTracked)
+                {
+                    // Present to the screen
+                    // NOTE: For a yet to be determined reason, bgfx is also doing an eglSwapBuffers when running in the regular Android Babylon Native Playground playground app.
+                    //       The "double" eglSwapBuffers causes rendering issues, so until we figure out this issue, comment out this line while testing in the regular playground app.
+                    eglSwapBuffers(eglGetCurrentDisplay(), eglGetCurrentSurface(EGL_DRAW));
+                }
+                hasTracked |= IsTracking();
 
                 glUseProgram(0);
             }
@@ -967,6 +973,7 @@ namespace xr
     private:
         bool isInitialized{false};
         bool sessionEnded{false};
+        bool hasTracked{false};
         std::vector<ArTrackable*> frameTrackables{};
         std::vector<ArAnchor*> arCoreAnchors{};
         std::vector<float> planePolygonBuffer{};


### PR DESCRIPTION
See https://github.com/BabylonJS/BabylonNative/issues/568 for a description of the problem.

This is a really gross 🤮  workaround, but a real fix will take more time and is probably dependent on the frame buffer management fixes that @bghgary is working on. This workaround will at least unblock consumers needing to update Babylon React Native to the latest.