### PR TITLE
Draw AR camera to babylon render texture

### DIFF
--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -222,14 +222,6 @@ namespace xr
                 return gsl::finally([previousDepthMask]() { glDepthMask(previousDepthMask); });
             }
 
-            auto BlendFunc(GLenum blendFuncName, GLenum blendFuncSFactor, GLenum blendFuncTFactor)
-            {
-                GLint previousBlendFuncTFactor;
-                glGetIntegerv(blendFuncName, &previousBlendFuncTFactor);
-                glBlendFunc(blendFuncSFactor, blendFuncTFactor);
-                return gsl::finally([blendFuncSFactor, previousBlendFuncTFactor]() { glBlendFunc(blendFuncSFactor, static_cast<GLenum>(previousBlendFuncTFactor)); });
-            }
-
             auto BindSampler(GLenum unit, GLuint id)
             {
                 glActiveTexture(unit);
@@ -557,7 +549,6 @@ namespace xr
                 auto depthTestTransaction{ GLTransactions::SetCapability(GL_DEPTH_TEST, false) };
                 auto blendTransaction{ GLTransactions::SetCapability(GL_BLEND, false) };
                 auto depthMaskTransaction{ GLTransactions::DepthMask(GL_FALSE) };
-                auto blendFuncTransaction{ GLTransactions::BlendFunc(GL_BLEND_SRC_ALPHA, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA) };
 
                 glUseProgram(cameraShaderProgramId);
 
@@ -611,7 +602,6 @@ namespace xr
                 auto depthTestTransaction{ GLTransactions::SetCapability(GL_DEPTH_TEST, false) };
                 auto blendTransaction{ GLTransactions::SetCapability(GL_BLEND, false) };
                 auto depthMaskTransaction{ GLTransactions::DepthMask(GL_FALSE) };
-                auto blendFuncTransaction{ GLTransactions::BlendFunc(GL_BLEND_SRC_ALPHA, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA) };
 
                 glViewport(0, 0, ActiveFrameViews[0].ColorTextureSize.Width, ActiveFrameViews[0].ColorTextureSize.Height);
                 glUseProgram(babylonShaderProgramId);

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -536,9 +536,7 @@ namespace xr
 
             ArCamera_release(camera);
 
-            // Suppress rendering if the camera did not produce the first frame yet.
-            // This is to avoid drawing possible leftover data from previous sessions if
-            // the texture is reused.
+            // Draw the camera texture to the Babylon render texture, but only if the session has started providing AR frames.
             int64_t frameTimestamp{};
             ArFrame_getTimestamp(session, frame, &frameTimestamp);
             if (frameTimestamp)
@@ -590,9 +588,7 @@ namespace xr
 
         void DrawFrame()
         {
-            // Suppress rendering if the camera did not produce the first frame yet.
-            // This is to avoid drawing possible leftover data from previous sessions if
-            // the texture is reused.
+            // Draw the Babylon render texture to the display, but only if the session has started providing AR frames.
             int64_t frameTimestamp{};
             ArFrame_getTimestamp(session, frame, &frameTimestamp);
             if (frameTimestamp)

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -728,7 +728,7 @@ namespace xr {
             }
 
             @autoreleasepool {
-                // Clear the color and depth texture before handing it off to Babylon
+                // Draw the camera texture to the color texture and clear the depth texture before handing them off to Babylon.
                 id<MTLCommandBuffer> commandBuffer = [commandQueue commandBuffer];
                 commandBuffer.label = @"DrawCameraToBabylonTextureCommandBuffer";
                 MTLRenderPassDescriptor *renderPassDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -808,7 +808,7 @@ namespace xr {
                 id<CAMetalDrawable> drawable = [metalLayer nextDrawable];
                 MTLRenderPassDescriptor *renderPassDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
 
-                if(renderPassDescriptor != nil) {
+                if (renderPassDescriptor != nil) {
                     renderPassDescriptor.colorAttachments[0].texture = drawable.texture;
                     renderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionDontCare;
 

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -429,7 +429,13 @@ namespace {
 @end
 namespace xr {
     namespace {
-        const char* shaderSource = R"(
+        // This shader is used to render *either* the camera texture or the final composited texture.
+        // It could be split into two shaders, but this is a bit simpler since they use the same structs
+        // and have some common logic.
+        // The shader is used in two passes:
+        // 1. Render the camera texture to the color render texture (see GetNextFrame).
+        // 2. Render the composited texture to the screen (see DrawFrame).
+        constexpr char shaderSource[] = R"(
             #include <metal_stdlib>
             #include <simd/simd.h>
 


### PR DESCRIPTION
This change is the first part of the solution to #562.

Prior to this change, we would clear the render texture, have Babylon render to it, then in a custom shader compose the Babylon render texture on top of the camera texture. The problem with this is that BGFX never sees the camera texture, and so there is no way from the context of Babylon Native to get an rgba byte buffer of what is being displayed to the screen in XR mode.

With this change, for both ARCore and ARKit, we now draw the camera texture onto the render texture that Babylon draws to, and then we just present that final texture to the screen. This way the render texture that Babylon Native (and therefore BGFX) is dealing with has the camera texture.

I did a little bit of white space and uniform initialization cleanup as well, so the change looks bigger than it really is. Sorry!