### PR TITLE
Raise input events after all input state is updated

### DIFF
--- a/Plugins/NativeInput/Source/NativeInput.cpp
+++ b/Plugins/NativeInput/Source/NativeInput.cpp
@@ -71,6 +71,8 @@ namespace Babylon::Plugins
             SetInputState(DeviceType::Touch, pointerId, POINTER_X_INPUT_INDEX, x, deviceInputs, false);
             SetInputState(DeviceType::Touch, pointerId, POINTER_Y_INPUT_INDEX, y, deviceInputs, false);
             SetInputState(DeviceType::Touch, pointerId, inputIndex, 1, deviceInputs, true);
+
+            m_eventDispatcher.tick(arcana::cancellation::none());
         });
     }
 
@@ -80,9 +82,11 @@ namespace Babylon::Plugins
             const uint32_t inputIndex{GetPointerButtonInputIndex(buttonIndex)};
             std::vector<int32_t>& deviceInputs{GetOrCreateInputMap(DeviceType::Touch, pointerId, { inputIndex, POINTER_X_INPUT_INDEX, POINTER_Y_INPUT_INDEX })};
 
-            SetInputState(DeviceType::Touch, pointerId, POINTER_X_INPUT_INDEX, x, deviceInputs, true);
-            SetInputState(DeviceType::Touch, pointerId, POINTER_Y_INPUT_INDEX, y, deviceInputs, true);
+            SetInputState(DeviceType::Touch, pointerId, POINTER_X_INPUT_INDEX, x, deviceInputs, false);
+            SetInputState(DeviceType::Touch, pointerId, POINTER_Y_INPUT_INDEX, y, deviceInputs, false);
             SetInputState(DeviceType::Touch, pointerId, inputIndex, 0, deviceInputs, true);
+
+            m_eventDispatcher.tick(arcana::cancellation::none());
 
             // If all "buttons" are up, then remove the device (e.g. device "disconnected").
             for (size_t index = 0; index < deviceInputs.size(); index++)
@@ -94,6 +98,8 @@ namespace Babylon::Plugins
             }
 
             RemoveInputMap(DeviceType::Touch, pointerId);
+
+            m_eventDispatcher.tick(arcana::cancellation::none());
         });
     }
 
@@ -103,6 +109,8 @@ namespace Babylon::Plugins
             std::vector<int32_t>& deviceInputs{GetOrCreateInputMap(DeviceType::Touch, pointerId, { POINTER_X_INPUT_INDEX, POINTER_Y_INPUT_INDEX })};
             SetInputState(DeviceType::Touch, pointerId, POINTER_X_INPUT_INDEX, x, deviceInputs, true);
             SetInputState(DeviceType::Touch, pointerId, POINTER_Y_INPUT_INDEX, y, deviceInputs, true);
+
+            m_eventDispatcher.tick(arcana::cancellation::none());
         });
     }
 
@@ -152,8 +160,10 @@ namespace Babylon::Plugins
 
         if (newSize != previousSize)
         {
-            m_deviceConnectedCallbacks.apply_to_all([deviceType, deviceSlot](auto& callback) {
-                callback(deviceType, deviceSlot);
+            m_eventDispatcher.queue([this, deviceType, deviceSlot]() {
+                m_deviceConnectedCallbacks.apply_to_all([deviceType, deviceSlot](auto& callback) {
+                    callback(deviceType, deviceSlot);
+                });
             });
         }
 
@@ -166,8 +176,10 @@ namespace Babylon::Plugins
     {
         if (m_inputs.erase({deviceType, deviceSlot}))
         {
-            m_deviceDisconnectedCallbacks.apply_to_all([deviceType, deviceSlot](auto& callback){
-                callback(deviceType, deviceSlot);
+            m_eventDispatcher.queue([this, deviceType, deviceSlot]() {
+                m_deviceDisconnectedCallbacks.apply_to_all([deviceType, deviceSlot](auto& callback){
+                    callback(deviceType, deviceSlot);
+                });
             });
         }
     }
@@ -180,8 +192,10 @@ namespace Babylon::Plugins
             deviceInputs[inputIndex] = inputState;
             if (raiseEvents)
             {
-                m_inputChangedCallbacks.apply_to_all([deviceType, deviceSlot, inputIndex, previousState, inputState](auto& callback) {
-                    callback(deviceType, deviceSlot, inputIndex, previousState, inputState);
+                m_eventDispatcher.queue([this, deviceType, deviceSlot, inputIndex, previousState, inputState]() {
+                    m_inputChangedCallbacks.apply_to_all([deviceType, deviceSlot, inputIndex, previousState, inputState](auto& callback) {
+                        callback(deviceType, deviceSlot, inputIndex, previousState, inputState);
+                    });
                 });
             }
         }

--- a/Plugins/NativeInput/Source/NativeInput.cpp
+++ b/Plugins/NativeInput/Source/NativeInput.cpp
@@ -67,7 +67,7 @@ namespace Babylon::Plugins
             const uint32_t inputIndex{GetPointerButtonInputIndex(buttonIndex)};
             std::vector<int32_t>& deviceInputs{GetOrCreateInputMap(DeviceType::Touch, pointerId, { inputIndex, POINTER_X_INPUT_INDEX, POINTER_Y_INPUT_INDEX })};
 
-            // We need to record the x/y so they can be queried in a pointer down handler, but we don't want to raise x/y change events before raising the pointer down event.
+            // Record the x/y, but don't raise associated events (this matches the behavior in the browser).
             SetInputState(DeviceType::Touch, pointerId, POINTER_X_INPUT_INDEX, x, deviceInputs, false);
             SetInputState(DeviceType::Touch, pointerId, POINTER_Y_INPUT_INDEX, y, deviceInputs, false);
             SetInputState(DeviceType::Touch, pointerId, inputIndex, 1, deviceInputs, true);
@@ -82,6 +82,7 @@ namespace Babylon::Plugins
             const uint32_t inputIndex{GetPointerButtonInputIndex(buttonIndex)};
             std::vector<int32_t>& deviceInputs{GetOrCreateInputMap(DeviceType::Touch, pointerId, { inputIndex, POINTER_X_INPUT_INDEX, POINTER_Y_INPUT_INDEX })};
 
+            // Record the x/y, but don't raise associated events (this matches the behavior in the browser).
             SetInputState(DeviceType::Touch, pointerId, POINTER_X_INPUT_INDEX, x, deviceInputs, false);
             SetInputState(DeviceType::Touch, pointerId, POINTER_Y_INPUT_INDEX, y, deviceInputs, false);
             SetInputState(DeviceType::Touch, pointerId, inputIndex, 0, deviceInputs, true);

--- a/Plugins/NativeInput/Source/NativeInput.h
+++ b/Plugins/NativeInput/Source/NativeInput.h
@@ -3,6 +3,7 @@
 #include <Babylon/JsRuntimeScheduler.h>
 #include <Babylon/Plugins/NativeInput.h>
 #include <arcana/containers/weak_table.h>
+#include <arcana/threading/dispatcher.h>
 
 #include <optional>
 #include <unordered_map>
@@ -60,6 +61,8 @@ namespace Babylon::Plugins
         arcana::weak_table<DeviceStatusChangedCallback> m_deviceConnectedCallbacks{};
         arcana::weak_table<DeviceStatusChangedCallback> m_deviceDisconnectedCallbacks{};
         arcana::weak_table<InputStateChangedCallback> m_inputChangedCallbacks{};
+
+        arcana::manual_dispatcher<64> m_eventDispatcher{};
 
         class DeviceInputSystem;
     };


### PR DESCRIPTION
Prior to this change, when an input state change happened, there would be a sequence of updating state and raising a state change event all interleaved. This causes problems when one of those event handlers tries to query state that isn't updated yet. With this change, group of state get updated, then a batch of state changes are fired together. This makes the API behave the same as in the browser, and fixes https://github.com/BabylonJS/BabylonReactNative/issues/124.