### PR TITLE
discard texture bindings because of mismatch in shaders

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1421,7 +1421,7 @@ namespace Babylon
             bgfx::setState(m_engineState | fillModeState);
         }
 
-        bgfx::submit(m_frameBufferManager.GetBound().ViewId, m_currentProgram->Program, 0, BGFX_DISCARD_INSTANCE_DATA | BGFX_DISCARD_STATE | BGFX_DISCARD_TRANSFORM);
+        bgfx::submit(m_frameBufferManager.GetBound().ViewId, m_currentProgram->Program, 0, BGFX_DISCARD_INSTANCE_DATA | BGFX_DISCARD_STATE | BGFX_DISCARD_TRANSFORM | BGFX_DISCARD_BINDINGS);
     }
 
     void NativeEngine::Draw(const Napi::CallbackInfo& info)


### PR DESCRIPTION
Reported failing Nightly Build.
Texture binding was not discarded and subsequent drawcall shaders failed with d3d11.