### PR TITLE
Fix texture binding related exceptions caused by resize

### DIFF
--- a/Core/Graphics/Source/Graphics.cpp
+++ b/Core/Graphics/Source/Graphics.cpp
@@ -156,6 +156,8 @@ namespace Babylon
             {
                 bgfx::setPlatformData(m_state.Bgfx.InitState.platformData);
                 auto& res = m_state.Bgfx.InitState.resolution;
+                
+                // Ensure bgfx rebinds all texture information.
                 bgfx::discard(BGFX_DISCARD_ALL);
                 bgfx::reset(res.width, res.height, BGFX_RESET_FLAGS);
                 bgfx::setViewRect(0, 0, 0, static_cast<uint16_t>(res.width), static_cast<uint16_t>(res.height));

--- a/Core/Graphics/Source/Graphics.cpp
+++ b/Core/Graphics/Source/Graphics.cpp
@@ -156,6 +156,7 @@ namespace Babylon
             {
                 bgfx::setPlatformData(m_state.Bgfx.InitState.platformData);
                 auto& res = m_state.Bgfx.InitState.resolution;
+                bgfx::discard(BGFX_DISCARD_ALL);
                 bgfx::reset(res.width, res.height, BGFX_RESET_FLAGS);
                 bgfx::setViewRect(0, 0, 0, static_cast<uint16_t>(res.width), static_cast<uint16_t>(res.height));
 


### PR DESCRIPTION
Add an explicit bgfx::discard() call on resize to ensure that the internal state of bgfx has been reset.
fixes #581 