### PR TITLE
Expose AR Feature Points on iOS

### DIFF
--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -983,7 +983,7 @@ namespace xr {
                 return;
             }
 
-            ARPointCloud *pointCloud = currentFrame.rawFeaturePoints;
+            ARPointCloud* pointCloud = currentFrame.rawFeaturePoints;
 
             FeaturePointCloud.resize(pointCloud.count);
             for (NSUInteger i = 0; i < pointCloud.count; i++) {

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -751,7 +751,7 @@ namespace xr {
                         renderPassDescriptor.depthAttachment.texture = reinterpret_cast<id<MTLTexture>>(ActiveFrameViews[0].DepthTexturePointer);
                         renderPassDescriptor.depthAttachment.loadAction = MTLLoadActionClear;
                         renderPassDescriptor.depthAttachment.clearDepth = 1.0f;
- 
+
                         // Create and end the render encoder.
                         id<MTLRenderCommandEncoder> renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:renderPassDescriptor];
                         renderEncoder.label = @"DrawCameraToBabylonTextureEncoder";

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -751,11 +751,11 @@ namespace xr {
                         renderPassDescriptor.depthAttachment.texture = reinterpret_cast<id<MTLTexture>>(ActiveFrameViews[0].DepthTexturePointer);
                         renderPassDescriptor.depthAttachment.loadAction = MTLLoadActionClear;
                         renderPassDescriptor.depthAttachment.clearDepth = 1.0f;
-                        
+ 
                         // Create and end the render encoder.
                         id<MTLRenderCommandEncoder> renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:renderPassDescriptor];
                         renderEncoder.label = @"DrawCameraToBabylonTextureEncoder";
-                        
+
                         // Set the shader pipeline.
                         [renderEncoder setRenderPipelineState:pipelineState];
 


### PR DESCRIPTION
This PR contains logic that surfaces feature points from ARKit on iOS. This replicates the logic that @Alex-MSFT added for ARCore back in August: https://github.com/BabylonJS/BabylonNative/pull/353.

This'll allow the applications consuming this logic to get the same experience with feature points on iOS as they currently have on Android, and furthers the feature parity across platforms. 