### PR TITLE
Fix slash direction

### DIFF
--- a/Plugins/NativeInput/Source/Android/NativeInput.cpp
+++ b/Plugins/NativeInput/Source/Android/NativeInput.cpp
@@ -1,4 +1,4 @@
-#include "..\Shared\NativeInput.h"
+#include "../Shared/NativeInput.h"
 
 namespace Babylon::Plugins
 {

--- a/Plugins/NativeInput/Source/iOS/NativeInput.cpp
+++ b/Plugins/NativeInput/Source/iOS/NativeInput.cpp
@@ -1,4 +1,4 @@
-#include "..\Shared\NativeInput.h"
+#include "../Shared/NativeInput.h"
 
 namespace Babylon::Plugins
 {


### PR DESCRIPTION
BabylonNative PR ci doesn't build NativeInput, but BabylonReactNative is seeing android and ios build failures due to slash direction