### PR TITLE
Replace input manager with native input

### DIFF
--- a/Apps/Playground/Android/app/CMakeLists.txt
+++ b/Apps/Playground/Android/app/CMakeLists.txt
@@ -59,6 +59,7 @@ target_link_libraries(BabylonNativeJNI
         AndroidExtensions
         AppRuntime
         NativeEngine
+        NativeInput
         NativeXr
         Console
         Window

--- a/Apps/Playground/CMakeLists.txt
+++ b/Apps/Playground/CMakeLists.txt
@@ -111,6 +111,7 @@ target_include_directories(Playground PRIVATE "Source" ".")
 target_link_to_dependencies(Playground
     PRIVATE AppRuntime
     PRIVATE NativeCapture
+    PRIVATE NativeInput
     PRIVATE NativeEngine
     PRIVATE Console
     PRIVATE Window

--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -31,6 +31,7 @@ function CreateSpheresAsync() {
     return Promise.resolve();
 }
 
+// TODO: Remove this completely and just do scene.createDefaultCamera(true, true, true) once this bug is fixed: https://github.com/BabylonJS/BabylonNative/issues/605
 function CreateInputHandling(scene) {
     const deviceSourceManager = new BABYLON.DeviceSourceManager(scene.getEngine());
     let priorX = undefined;

--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -20,7 +20,7 @@ function CreateSpheresAsync() {
     for (var i = 0; i < size; i++) {
         for (var j = 0; j < size; j++) {
             for (var k = 0; k < size; k++) {
-                var sphere = BABYLON.Mesh.CreateSphere("sphere" + i + j + k, 32, 0.9, scene);
+                var sphere = BABYLON.Mesh.CreateSphere("sphere" + i + j + k, 32, 0.9);
                 sphere.position.x = i;
                 sphere.position.y = j;
                 sphere.position.z = k;
@@ -32,22 +32,37 @@ function CreateSpheresAsync() {
 }
 
 function CreateInputHandling(scene) {
-    var inputManager = new InputManager();
-    var priorX = inputManager.pointerX;
-    var priorY = inputManager.pointerY;
-    var x = 0;
-    var y = 0;
-    scene.onBeforeRenderObservable.add(function () {
-        x = inputManager.pointerX;
-        y = inputManager.pointerY;
+    const deviceSourceManager = new BABYLON.DeviceSourceManager(scene.getEngine());
+    let priorX = undefined;
+    let priorY = undefined;
 
-        if (inputManager.isPointerDown) {
-            scene.activeCamera.alpha += 0.01 * (priorX - x);
-            scene.activeCamera.beta += 0.01 * (priorY - y);
+    scene.onBeforeRenderObservable.add(function () {
+        let x = undefined;
+        let y = undefined;
+
+        let pointer = deviceSourceManager.getDeviceSource(BABYLON.DeviceType.Touch);
+        if (pointer === null) {
+            pointer = deviceSourceManager.getDeviceSource(BABYLON.DeviceType.Mouse);
+            if (pointer !== null && pointer.getInput(BABYLON.PointerInput.LeftClick) === 0) {
+                pointer = null;
+            }
         }
 
-        priorX = x;
-        priorY = y;
+        if (pointer !== null) {
+            x = pointer.getInput(BABYLON.PointerInput.Horizontal);
+            y = pointer.getInput(BABYLON.PointerInput.Vertical);
+
+            if (priorX !== undefined && priorY !== undefined) {
+                scene.activeCamera.alpha += 0.01 * (priorX - x);
+                scene.activeCamera.beta += 0.01 * (priorY - y);
+            }
+
+            priorX = x;
+            priorY = y;
+        } else {
+            priorX = undefined;
+            priorY = undefined;
+        }
     });
 }
 

--- a/Apps/Playground/iOS/ViewController.swift
+++ b/Apps/Playground/iOS/ViewController.swift
@@ -57,7 +57,7 @@ class ViewController: UIViewController {
         let appDelegate = UIApplication.shared.delegate as? AppDelegate
         if appDelegate != nil {
             let translation = sender.translation(in:mtkView)
-            appDelegate!._bridge!.setInputs(Int32(translation.x), y:Int32(translation.y), tap:true)
+            appDelegate!._bridge!.setInputs(Int32(translation.x * UIScreen.main.scale), y:Int32(translation.y * UIScreen.main.scale), tap:true)
         }
     }
 }

--- a/Plugins/NativeInput/CMakeLists.txt
+++ b/Plugins/NativeInput/CMakeLists.txt
@@ -11,6 +11,9 @@ if (ANDROID)
 elseif (IOS)
     set(SOURCES ${SOURCES}
         "Source/iOS/NativeInput.cpp")
+elseif (APPLE)
+    set(SOURCES ${SOURCES}
+        "Source/macOS/NativeInput.cpp")
 else()
     set(SOURCES ${SOURCES}
         "Source/Windows/NativeInput.cpp")

--- a/Plugins/NativeInput/Source/macOS/NativeInput.cpp
+++ b/Plugins/NativeInput/Source/macOS/NativeInput.cpp
@@ -1,0 +1,10 @@
+#include "../Shared/NativeInput.h"
+
+namespace Babylon::Plugins
+{
+    bool NativeInput::Impl::HasMouse()
+    {
+        // Assume a mouse is present (or find a way to check this programmatically).
+        return true;
+    }
+}


### PR DESCRIPTION
The `InputManager` in the Babylon Native Playground existed as example code prior to the `NativeInput` plugin. This change aims to replace `InputManager` with `NativeInput`, which reduces confusion and duplication and gives us some test coverage on `NativeInput` (both build and runtime).
- [ ] Android
- [ ] iOS
- [ ] MacOS
- [ ] Win32
- [ ] UWP
- [ ] Linux

I've made the platform agnostic changes (e.g. CMakeLists.txt for Playground and experience.js) as well as the changes for Android, iOS, and MacOS. This is not at all urgent, but I'd appreciate if a few folks could help with the remaining platforms. It should take like 15 mins per platform to make the remaining small changes and test them.
@CedricGuillemet - can you help with Linux at some point?
@bghgary/@syntheticmagus/@chrisfromwork - can you help with Win32/UWP at some point?