### PR TITLE
add all_load flag for apple targets

### DIFF
--- a/Apps/Playground/CMakeLists.txt
+++ b/Apps/Playground/CMakeLists.txt
@@ -156,8 +156,9 @@ if(APPLE)
             set(CMAKE_Swift_COMPILER_FORCED TRUE)
             set(CMAKE_Swift_LANGUAGE_VERSION 4.0)
             enable_language(Swift)
+        target_link_libraries(Playground PUBLIC "-all_load")
     else()
-        target_link_libraries(Playground PUBLIC "-framework MetalKit")
+        target_link_libraries(Playground PUBLIC "-framework MetalKit" "-all_load")
 
         set_target_properties(Playground PROPERTIES
             MACOSX_BUNDLE true

--- a/Apps/ValidationTests/CMakeLists.txt
+++ b/Apps/ValidationTests/CMakeLists.txt
@@ -91,7 +91,7 @@ target_link_to_dependencies(ValidationTests
     PRIVATE XMLHttpRequest)
 
 if(APPLE)
-    target_link_libraries(ValidationTests PRIVATE "-framework MetalKit")
+    target_link_libraries(ValidationTests PRIVATE "-framework MetalKit" "-all_load")
     if(IOS)
         set_target_properties(ValidationTests PROPERTIES
             MACOSX_BUNDLE true

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -12,9 +12,7 @@
 #include <bimg/decode.h>
 #include <bimg/encode.h>
 
-// STB_IMAGE_RESIZE_IMPLEMENTATION will define implementation in stb_image_resize.h. Many .cpp can include it 
-// but only one can define implementation or linking errors will popup.
-#define STB_IMAGE_RESIZE_IMPLEMENTATION
+// STB_IMAGE_RESIZE_IMPLEMENTATION already defined in bimg
 #include <stb/stb_image_resize.h>
 #include <bx/math.h>
 


### PR DESCRIPTION
Some teams can use this flag for macos/ios build. Adding it to the CI will check that some symbols are defined mutiple times accross the libs.