### PR TITLE
Ensure XR async lifecycle operations are sequential

### DIFF
--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -380,6 +380,8 @@ namespace Babylon
             std::mutex m_sessionStateChangedCallbackMutex{};
             std::function<void(bool)> m_sessionStateChangedCallback{};
             void* m_windowPtr{};
+            std::optional<arcana::task<void, std::exception_ptr>> m_beginTask{};
+            arcana::task<void, std::exception_ptr> m_endTask{arcana::task_from_result<std::exception_ptr>()};
 
             struct SessionState final
             {
@@ -400,7 +402,7 @@ namespace Babylon
                 arcana::cancellation_source CancellationSource{};
                 bool FrameScheduled{false};
                 std::vector<std::function<void(const xr::System::Session::Frame&)>> ScheduleFrameCallbacks{};
-                arcana::task<void, std::exception_ptr> FrameTask{};
+                arcana::task<void, std::exception_ptr> FrameTask{arcana::task_from_result<std::exception_ptr>()};
             };
 
             std::unique_ptr<SessionState> m_sessionState{};
@@ -447,9 +449,15 @@ namespace Babylon
 
         arcana::task<void, std::exception_ptr> NativeXr::Impl::BeginSessionAsync()
         {
+            if (m_beginTask)
+            {
+                return arcana::task_from_error<void>(std::make_exception_ptr(std::runtime_error{"There is already an immersive XR session either currently active or in the process of being set up. There can only be one immersive VR session at a time."}));
+            }
+
             Graphics::Impl& graphicsImpl{Graphics::Impl::GetFromJavaScript(m_env)};
 
-            return arcana::make_task(graphicsImpl.AfterRenderScheduler(), arcana::cancellation::none(),
+            // Don't try to start a session while it is still ending.
+            m_beginTask.emplace(m_endTask.then(graphicsImpl.AfterRenderScheduler(), arcana::cancellation::none(),
                 [this, thisRef{shared_from_this()}, &graphicsImpl]() {
                     assert(m_sessionState == nullptr);
 
@@ -468,18 +476,27 @@ namespace Babylon
                             m_sessionState->Session = std::move(session);
                             NotifySessionStateChanged(true);
                         });
-                });
+                }));
+
+            return m_beginTask.value();
         }
 
         arcana::task<void, std::exception_ptr> NativeXr::Impl::EndSessionAsync()
         {
+            assert(m_beginTask);
+            assert(m_sessionState != nullptr);
+
             m_sessionState->CancellationSource.cancel();
 
             m_sessionState->FrameBufferToJsTextureMap.clear();
             m_sessionState->TextureToFrameBufferMap.clear();
             m_sessionState->ActiveTextures.clear();
 
-            return m_sessionState->FrameTask.then(m_sessionState->GraphicsImpl.AfterRenderScheduler(), arcana::cancellation::none(), [this, thisRef{shared_from_this()}](const arcana::expected<void, std::exception_ptr>&) {
+            // Don't try to end the session while it is still starting.
+            m_endTask = m_beginTask->then(arcana::inline_scheduler, arcana::cancellation::none(), [this, thisRef{shared_from_this()}] {
+                // Also don't try to end the session while a frame is in progress.
+                return m_sessionState->FrameTask;
+            }).then(m_sessionState->GraphicsImpl.AfterRenderScheduler(), arcana::cancellation::none(), [this, thisRef{shared_from_this()}](const arcana::expected<void, std::exception_ptr>&) {
                 assert(m_sessionState != nullptr);
                 assert(m_sessionState->Session != nullptr);
                 assert(m_sessionState->Frame == nullptr);
@@ -496,8 +513,11 @@ namespace Babylon
                 } while (!shouldEndSession);
 
                 m_sessionState.reset();
+                m_beginTask.reset();
                 NotifySessionStateChanged(false);
             });
+
+            return m_endTask;
         }
 
         void NativeXr::Impl::ScheduleFrame(std::function<void(const xr::System::Session::Frame&)>&& callback)


### PR DESCRIPTION
This change addresses the following problems in NativeXR:
- If `BeginSession` is called multiple times, it dies with a failed assertion. According to the WebXR spec, it should return a promise in a rejected state. It specifically wants a `DOMException` but Babylon.js catches any exception and logs it to the console as a warning. So the change for this is to track when we have an active XR session and return a faulted task if `BeginSession` is called again.
- If `EndSession` is called before `BeginSession` completes, it dies with a failed assertion. The WebXR spec does not indicate what should happen in this case, so the behavior I implemented is to have `EndSession` await completion of `BeginSession` before executing.
- If `BeginSession` is called before a previous `EndSession` completes, it does with a failed assertion. The WebXR spec does not indicate what should happen in this case, so the behavior I implemented is to have `BeginSession` await completion of the previous `EndSession` before executing.

The WebXR spec seems to imply that `EndSession` should just return the promise for ending the session, and it does not specify any exceptions should be thrown from `EndSession`, so I think this means it *should* just return the same promise. I did not implement this because Babylon.js prevents it from happening. We can revisit it in the future if needed.