### PR TITLE
Improve immersive xr fast refresh scenarios for BabylonReactNative/OpenXR

### DIFF
--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -54,6 +54,14 @@ namespace xr
         std::unique_ptr<XrSupportedExtensions> Extensions;
         xr::SceneUnderstanding SceneUnderstanding{};
         bool IsSessionRunning{ false };
+
+        void Reset()
+        {
+            Session.Reset();
+            SceneSpace.Reset();
+            State = XrSessionState::XR_SESSION_STATE_UNKNOWN;
+            IsSessionRunning = false;
+        }
     };
 
     XrSessionContext::XrSessionContext()
@@ -126,6 +134,11 @@ namespace xr
     const SceneUnderstanding& XrSessionContext::SceneUnderstanding() const
     {
         return ContextImpl->SceneUnderstanding;
+    }
+
+    void XrRegistry::Reset()
+    {
+        globalXrSessionContext = nullptr;
     }
 
     const XrSessionContext& XrRegistry::Context()
@@ -465,6 +478,9 @@ namespace xr
 
                 HandData.HandsInitialized = false;
             }
+
+            // Reset OpenXR Context to release session handle and exit immersive mode
+            XrRegistry::Reset();
         }
 
         std::unique_ptr<System::Session::Frame> GetNextFrame(bool& shouldEndSession, bool& shouldRestartSession)

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -54,14 +54,6 @@ namespace xr
         std::unique_ptr<XrSupportedExtensions> Extensions;
         xr::SceneUnderstanding SceneUnderstanding{};
         bool IsSessionRunning{ false };
-
-        void Reset()
-        {
-            Session.Reset();
-            SceneSpace.Reset();
-            State = XrSessionState::XR_SESSION_STATE_UNKNOWN;
-            IsSessionRunning = false;
-        }
     };
 
     XrSessionContext::XrSessionContext()

--- a/Dependencies/xr/Source/OpenXR/XrRegistry.h
+++ b/Dependencies/xr/Source/OpenXR/XrRegistry.h
@@ -36,5 +36,6 @@ namespace xr
         static const XrSessionContext& Context();
         static uintptr_t GetNativeXrContext();
         static std::string GetNativeXrContextType();
+        static void Reset();
     };
 }

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -428,6 +428,8 @@ namespace Babylon
         m_frameBufferToJsTextureMap.clear();
         m_textureToFrameBufferMap.clear();
         m_activeTextures.clear();
+        m_scheduleFrameCallbacks.clear();
+        m_createRenderTexture.Reset();
 
         return m_frameTask.then(m_graphicsImpl.AfterRenderScheduler(), arcana::cancellation::none(), [this, thisRef{shared_from_this()}](const arcana::expected<void, std::exception_ptr>&) {
             assert(m_session != nullptr);


### PR DESCRIPTION
Right now we never drop out of immersive mode when ending an xr session because we never release the session handle. This change releases the session handle when destroying the session after releasing hand tracking extension resources.

Note:
1. There are still issues related to NativeEngine texture creation that can cause crashes during reload.
2. OpenXR does not currently activate the original view when dropping out of immersive xr mode. Developers/users will have to touch the view on a HoloLens to get it to start rendering again. I have synced internally with the microsoft OpenXR team and they are looking into fixing this issue.