### PR TITLE
Disable vsync on Android

### DIFF
--- a/Core/Graphics/Source/Android/GraphicsPlatform.h
+++ b/Core/Graphics/Source/Android/GraphicsPlatform.h
@@ -5,7 +5,7 @@
 // MSAA is disabled on Android.
 // See issue https://github.com/BabylonJS/BabylonNative/issues/494#issuecomment-731135918
 // for explanation
-#define BGFX_RESET_FLAGS (BGFX_RESET_VSYNC | BGFX_RESET_MAXANISOTROPY)
+#define BGFX_RESET_FLAGS (BGFX_RESET_MAXANISOTROPY)
 
 namespace Babylon
 {


### PR DESCRIPTION
As of recent changes, the actual render loop is managed by the consumer of the Babylon Native API. Currently consumers are *required* to run the render loop on the main thread. Pretty much any way you do that on Android, the main thread is already blocking on vsync, so having bgfx also block on vsync results in a double vsync block that impacts perf. For now, I'm just removing this flag. As soon as @Drigax's changes are in that make `CreateGraphics` take a configuration, we should add vsync to that, because we'll want to be able to choose to enable it when we have a dedicated render thread. But for now, this unblocks performance regressions on Android.