### PR TITLE
Fix ARCore rendering regression

### DIFF
--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -404,18 +404,6 @@ namespace xr
                 }
 
                 eglGetConfigAttrib(display, config, EGL_NATIVE_VISUAL_ID, &format);
-
-                EGLint contextAttributes[]
-                {
-                    EGL_CONTEXT_MAJOR_VERSION_KHR, 3,
-                    EGL_CONTEXT_MINOR_VERSION_KHR, 0,
-
-                    EGL_NONE
-                };
-
-                context = EGLContextPtr(eglCreateContext(display, config, parentContext, contextAttributes), [display{display}](EGLContext context) {
-                    eglDestroyContext(display, context);
-                });
             }
 
             // Generate a texture id for the camera texture (ARCore will allocate the texture itself)
@@ -657,7 +645,8 @@ namespace xr
             ArFrame_getTimestamp(session, frame, &frameTimestamp);
             if (frameTimestamp && surface.get())
             {
-                auto surfaceTransaction{ GLTransactions::MakeCurrent(eglGetDisplay(EGL_DEFAULT_DISPLAY), surface.get(), surface.get(), context.get()) };
+                //auto surfaceTransaction{ GLTransactions::MakeCurrent(eglGetDisplay(EGL_DEFAULT_DISPLAY), surface.get(), surface.get(), context.get()) };
+                auto surfaceTransaction{ GLTransactions::MakeCurrent(eglGetDisplay(EGL_DEFAULT_DISPLAY), surface.get(), surface.get(), parentContext) };
 
                 auto bindFrameBufferTransaction{ GLTransactions::BindFrameBuffer(0) };
                 auto cullFaceTransaction{ GLTransactions::SetCapability(GL_CULL_FACE, false) };
@@ -1059,7 +1048,7 @@ namespace xr
         EGLConfig config{};
         EGLint format{};
         EGLContext parentContext{};
-        EGLContextPtr context;
+        //EGLContextPtr context;
         EGLSurfacePtr surface;
 
         GLuint cameraShaderProgramId{};


### PR DESCRIPTION
This change fixes #647. For some reason, creating a parent `EGLContext` (with the bgfx `EGLContext` as a child) doesn't work correctly on some devices (maybe a driver issue?). We don't really *need* this parent context though, it was just a defensive measure to try to ensure we don't pollute the `EGLContext` "owned" by bgfx. For now, I'm just removing this as it seems to fix the issue.