### PR TITLE
GCC10 + Latest SPIRV-cross

### DIFF
--- a/Apps/ValidationTests/iOS/LibNativeBridge.h
+++ b/Apps/ValidationTests/iOS/LibNativeBridge.h
@@ -11,6 +11,6 @@
 
 - (void)init:(MTKView*)inView width:(int)inWidth height:(int)inHeight;
 - (void)resize:(int)inWidth height:(int)inHeight;
+- (void)render;
 
 @end
-

--- a/Apps/ValidationTests/iOS/LibNativeBridge.mm
+++ b/Apps/ValidationTests/iOS/LibNativeBridge.mm
@@ -39,6 +39,7 @@ std::unique_ptr<Babylon::AppRuntime> runtime{};
     graphicsConfig.Width = static_cast<size_t>(width);
     graphicsConfig.Height = static_cast<size_t>(height);
     graphics = Babylon::Graphics::CreateGraphics(graphicsConfig);
+    graphics->StartRenderingCurrentFrame();
     graphics->SetDiagnosticOutput([](const char* outputString) { printf("%s", outputString); fflush(stdout); });
 
     runtime = std::make_unique<Babylon::AppRuntime>();
@@ -73,6 +74,15 @@ std::unique_ptr<Babylon::AppRuntime> runtime{};
     if (graphics)
     {
         graphics->UpdateSize(static_cast<size_t>(inWidth), static_cast<size_t>(inHeight));
+    }
+}
+
+- (void)render
+{
+    if (graphics)
+    {
+        graphics->FinishRenderingCurrentFrame();
+        graphics->StartRenderingCurrentFrame();
     }
 }
 

--- a/Apps/ValidationTests/iOS/ViewController.swift
+++ b/Apps/ValidationTests/iOS/ViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import MetalKit
 
-class ViewController: UIViewController {
+class ViewController: UIViewController, MTKViewDelegate {
     
     var mtkView: MTKView!
     
@@ -14,6 +14,7 @@ class ViewController: UIViewController {
         let appDelegate = UIApplication.shared.delegate as? AppDelegate
         if appDelegate != nil {
             mtkView = MTKView()
+            mtkView.delegate = self
             mtkView.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview(mtkView)
             view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "|[mtkView]|", options: [], metrics: nil, views: ["mtkView" : mtkView]))
@@ -21,13 +22,12 @@ class ViewController: UIViewController {
             
             let device = MTLCreateSystemDefaultDevice()!
             mtkView.device = device
-            
+
             mtkView.colorPixelFormat = .bgra8Unorm_srgb
             mtkView.depthStencilPixelFormat = .depth32Float
 
             let width = 600
             let height = 400
-            
             
             appDelegate!._bridge!.init(mtkView, width:Int32(width), height:Int32(height))
         }
@@ -41,6 +41,17 @@ class ViewController: UIViewController {
         }
         if appDelegate != nil {
             appDelegate!._bridge!.resize(Int32(600), height: Int32(400))
+        }
+    }
+    
+    func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
+        // no resize here. keep the 600x400 size for validation tests.
+    }
+
+    func draw(in view: MTKView) {
+        let appDelegate = UIApplication.shared.delegate as? AppDelegate
+        if appDelegate != nil {
+            appDelegate!._bridge!.render()
         }
     }
 }

--- a/Plugins/NativeEngine/Source/ShaderCompilerCommon.cpp
+++ b/Plugins/NativeEngine/Source/ShaderCompilerCommon.cpp
@@ -172,7 +172,7 @@ namespace Babylon::ShaderCompilerCommon
             const auto& compiler = *vertexShaderInfo.Compiler;
             const spirv_cross::ShaderResources resources = compiler.get_shader_resources();
             auto uniformsInfo = CollectNonSamplerUniforms(*vertexShaderInfo.Parser, compiler);
-#if (BGFX_CONFIG_RENDERER_METAL)
+#if __APPLE__
             // with metal, we bind images and not samplers
             const spirv_cross::SmallVector<spirv_cross::Resource>& samplers = resources.separate_images;
 #else

--- a/Plugins/NativeEngine/Source/ShaderCompilerMetal.cpp
+++ b/Plugins/NativeEngine/Source/ShaderCompilerMetal.cpp
@@ -36,26 +36,15 @@ namespace Babylon
 
             auto compiler = std::make_unique<spirv_cross::CompilerMSL>(parser->get_parsed_ir());
 
+            // Enable decoration for texture binding
+            spirv_cross::CompilerMSL::Options opts{};
+            opts.enable_decoration_binding = true;
+            compiler->set_msl_options(opts);
+
             auto resources = compiler->get_shader_resources();
             for (auto& resource : resources.uniform_buffers)
             {
                 compiler->set_name(resource.id, "_mtl_u");
-            }
-
-            // Disable location for varying stage to force compiler to do it with variable names
-            if (stage == EShLangVertex)
-            {
-                for (auto& output : resources.stage_outputs)
-                {
-                    compiler->set_decoration(output.id, spv::DecorationLocation, -1);
-                }
-            }
-            else
-            {
-              for (auto& input : resources.stage_inputs)
-                {
-                    compiler->set_decoration(input.id, spv::DecorationLocation, -1);
-                }
             }
 
             // rename textures without the 'texture' suffix so it's bindable from .js

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,13 +81,12 @@ jobs:
       CC: gcc-9
       CXX: g++-9
 
-# Enable this job once SPIRV-cross has been updated see issue https://github.com/BabylonJS/BabylonNative/issues/679
-#  - template: .github/jobs/linux.yml
-#    parameters:
-#      name: Ubuntu_GCC10
-#      vmImage: 'ubuntu-latest'
-#      CC: gcc-10
-#      CXX: g++-10
+  - template: .github/jobs/linux.yml
+    parameters:
+      name: Ubuntu_GCC10
+      vmImage: 'ubuntu-latest'
+      CC: gcc-10
+      CXX: g++-10
 
 # Android
   - template: .github/jobs/android.yml


### PR DESCRIPTION
- enable decoration bindings for Metal texture association
- update SPIRV
- update iOS validation tests
- enable GCC10 build on AzurePipelines fixes #679 