### PR TITLE
revert m_engineState

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -227,10 +227,7 @@ namespace Babylon
         bool m_requestAnimationFrameCallbacksScheduled{};
 
         bx::DefaultAllocator m_allocator{};
-        // Default webgl context has RGBA and depth write enabled but Depth test and face culling disabled.
-        // https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/cullFace
-        // https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/depthFunc
-        uint64_t m_engineState{BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A | BGFX_STATE_WRITE_Z | BGFX_STATE_MSAA};
+        uint64_t m_engineState{BGFX_STATE_DEFAULT};
 
         template<int size, typename arrayType>
         void SetTypeArrayN(const Napi::CallbackInfo& info);


### PR DESCRIPTION
Default webgl context has culling and depth test disabled. 
But ThinEngine enable them in the constructor. NativeEngine does not and assume those states to be on by default.
One of our partners, using a specific ThinEngine, doesn't do calls to enable and a different behavior arise with NativeEngine.
Until ThinEngine and NativeEngine are using same behavior (making PRs on .js and native will take some days), I prefer to revert this change as it may introduce regressions in some rendering for most of our other partners.