### PR TITLE
Handle non-string uniforms

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -686,13 +686,7 @@ namespace Babylon
         auto uniforms = Napi::Array::New(info.Env(), length);
         for (uint32_t index = 0; index < length; ++index)
         {
-            if (!names[index].IsString())
-            {
-                uniforms[index] = info.Env().Null();
-                continue;
-            }
-
-            const auto name = names[index].As<Napi::String>().Utf8Value();
+            const auto name = names[index].IsString() ? names[index].As<Napi::String>().Utf8Value() : "";
 
             auto vertexFound = program->VertexUniformInfos.find(name);
             auto fragmentFound = program->FragmentUniformInfos.find(name);

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -686,6 +686,12 @@ namespace Babylon
         auto uniforms = Napi::Array::New(info.Env(), length);
         for (uint32_t index = 0; index < length; ++index)
         {
+            if (!names[index].IsString())
+            {
+                uniforms[index] = info.Env().Null();
+                continue;
+            }
+
             const auto name = names[index].As<Napi::String>().Utf8Value();
 
             auto vertexFound = program->VertexUniformInfos.find(name);


### PR DESCRIPTION
I made a silly mistake when creating a custom shader where my uniforms array looked like this:
```javascript
var uniforms = [
    "world", "viewProjection", "cameraPosition",
    , "_Radius_", "_Line_Width_", "_Absolute_Sizes_", "_Filter_Width_"
];
```
Causing the array to have a `,,` entry, and causing `NativeEngine::GetUniforms` to crash. This didn't cause an issue in Babylon.js, so I figured it would be good for us to handle the error case gracefully as well.

Alternatively, we could throw an error telling the user to check their uniforms array (since it's highly unlikely that they wanted to pass a non-string), but that would be different behavior from BJS.