### PR TITLE
Don't set folder property on asio library

### DIFF
--- a/Dependencies/v8inspector/CMakeLists.txt
+++ b/Dependencies/v8inspector/CMakeLists.txt
@@ -1,7 +1,6 @@
 # ------------------------------- asio -------------------------------
 add_library(asio INTERFACE)
 target_include_directories(asio INTERFACE "Dependencies/asio/asio/include")
-set_property(TARGET asio PROPERTY FOLDER Dependencies)
 
 # ------------------------------ llhttp ------------------------------
 # Install node to use npm


### PR DESCRIPTION
asio is a header-only library included as an INTERFACE target, and CMake doesn't allow the FOLDER property to get set on INTERFACE's, so we'll just remove the line.

fixes #747 