### PR TITLE
Prefer non-stencil depth for WMR

### DIFF
--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -13,7 +13,8 @@ namespace xr
     {
         RGBA8_SRGB,
         BGRA8_SRGB,
-        D24S8
+        D24S8,
+        D16
     };
 
     enum class SessionType

--- a/Dependencies/xr/Source/OpenXR/Windows/XrPlatform.h
+++ b/Dependencies/xr/Source/OpenXR/Windows/XrPlatform.h
@@ -36,8 +36,9 @@ namespace xr
         DXGI_FORMAT_R8G8B8A8_UNORM_SRGB
     };
 
-    constexpr std::array<SwapchainFormat, 1> SUPPORTED_DEPTH_FORMATS
+    constexpr std::array<SwapchainFormat, 2> SUPPORTED_DEPTH_FORMATS
     {
+        DXGI_FORMAT_D16_UNORM,
         DXGI_FORMAT_D24_UNORM_S8_UINT
     };
 
@@ -51,6 +52,8 @@ namespace xr
             return xr::TextureFormat::RGBA8_SRGB;
         case DXGI_FORMAT_D24_UNORM_S8_UINT:
             return xr::TextureFormat::D24S8;
+        case DXGI_FORMAT_D16_UNORM:
+            return xr::TextureFormat::D16;
         default:
             throw std::runtime_error{ "Unsupported texture format" };
         }

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -31,6 +31,8 @@ namespace
             // Depth Formats
             case xr::TextureFormat::D24S8:
                 return bgfx::TextureFormat::D24S8;
+            case xr::TextureFormat::D16:
+                return bgfx::TextureFormat::D16;
 
             default:
                 throw std::runtime_error{"Unsupported texture format"};


### PR DESCRIPTION
This is the first small change to improve XR rendering performance on Windows Mixed Reality devices.

We need to use the [recommended backbuffer formats](https://docs.microsoft.com/en-us/windows/mixed-reality/develop/native/openxr-best-practices#select-a-swapchain-format) for rendering, which means a depth buffer format without any stencil bits. This will get us closer to using the "PassThru" OpenXR compositor mode (right now we're using "TexMapping"), which will basically evaporate the Post CPU/GPU portion of the frame times listed below.


An important callout here is that there currently isn't any way for a WebXR user to specify what format they want the runtime to use when creating its swapchains. We also currently have no way of specifying backbuffer formats for NativeEngine (including simply enabling or disabling the stencil buffer) because [BGFX always creates a depth/stencil buffer of format D24_S8](https://github.com/bkaradzic/bgfx/blob/master/src/renderer_d3d11.cpp#L2239) if no depth buffer is provided in the platform data. If people have any suggestions or feel that this is an issue worth discussing I can file an issue, but it doesn't really seem to be top-of-mind for WebXR.


**Note the following frame timings have nothing to do with the new depth format, I'm just illustrating that the error is now "None"**

Before:
<img src="https://user-images.githubusercontent.com/4724014/119063946-13e26c80-b98f-11eb-919e-39442bd0b8f6.jpg" width=480/>
After:
<img src="https://user-images.githubusercontent.com/4724014/119063879-f1505380-b98e-11eb-8fdd-a36c3cd56923.jpg" width=480/>

fixes #704 

