### PR TITLE
Use transparent clear color on HoloLens

### DIFF
--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -241,7 +241,7 @@ CreateBoxAsync().then(function () {
                     if (hololens) {
                         // Pass through, head mounted displays (HoloLens 2) require autoClear and a black clear color
                         xrSessionManager.scene.autoClear = true;
-                        xrSessionManager.scene.clearColor = BABYLON.Color4.FromColor3(Color3.Black());
+                        xrSessionManager.scene.clearColor = new BABYLON.Color4(0, 0, 0, 0);
                     }
                 });
             });


### PR DESCRIPTION
We were creating a Color4 from a Color3, and the Color4(Color3) constructor assigns alpha to 1.0, causing the background to be semi-opaque in mixed reality captures.

fixes #652