### PR TITLE
Revert "Don't try to create new XR textures if no window (#746)"

### DIFF
--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -609,12 +609,6 @@ namespace Babylon
 
         void NativeXr::Impl::BeginUpdate()
         {
-            // Don't try to create new textures if the window is no longer available.
-            if (m_windowPtr == nullptr)
-            {
-                return;
-            }
-
             m_sessionState->ActiveTextures.reserve(m_sessionState->Frame->Views.size());
             for (const auto& view : m_sessionState->Frame->Views)
             {


### PR DESCRIPTION
This reverts commit e2e409d6038c3d5e9f3c286c88f1741432230f84.

Fixes regression #755