### PR TITLE
Fix iOS XR mode crash on device orientation change

### DIFF
--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -718,8 +718,10 @@ namespace xr {
                 {
                     if (ActiveFrameViews[0].DepthTexturePointer != nil) {
                         id<MTLTexture> oldDepthTexture = reinterpret_cast<id<MTLTexture>>(ActiveFrameViews[0].DepthTexturePointer);
-                        [oldDepthTexture setPurgeableState:MTLPurgeableStateEmpty];
-                        [oldDepthTexture release];
+                        deletedTextureAsyncCallback(ActiveFrameViews[0].DepthTexturePointer).then(arcana::inline_scheduler, arcana::cancellation::none(), [oldDepthTexture]() {
+                            [oldDepthTexture setPurgeableState:MTLPurgeableStateEmpty];
+                            [oldDepthTexture release];
+                        });
                         ActiveFrameViews[0].DepthTexturePointer = nil;
                     }
 

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -613,7 +613,7 @@ namespace Babylon
 
                         m_sessionState->TextureToViewConfigurationMap.erase(texturePointer);
                     }
-                });
+                }).then(m_sessionState->GraphicsImpl.AfterRenderScheduler(), arcana::cancellation::none(), []{}); // Ensure continuations run on the render thread if they use inline_scheduler.
             });
 
             // Ending a session outside of calls to EndSessionAsync() is currently not supported.


### PR DESCRIPTION
This fixes #785. There are two small changes:
- In XR.mm use the `deletedTextureAsyncCallback` when cleaning up the depth texture (same as what we were doing for the color texture).
- In NativeXR.cpp switch back to the render thread before completing the `deletedTextureAsyncCallback` async operation so that code that does an inline continuation will execute on the render thread (e.g. where the texture is released).

I tested this in debug/release for both Android/iOS, but no coverage on Windows.