### PR TITLE
Simplify memory management xr lib on iOS

### DIFF
--- a/Core/AppRuntime/Include/Babylon/AppRuntime.h
+++ b/Core/AppRuntime/Include/Babylon/AppRuntime.h
@@ -36,6 +36,7 @@ namespace Babylon
         void RunPlatformTier();
         void RunEnvironmentTier(const char* executablePath = ".");
         void Run(Napi::Env);
+        void Execute(std::function<void()> callback);
 
         static void DefaultUnhandledExceptionHandler(std::exception_ptr ptr);
 

--- a/Core/AppRuntime/Source/AppRuntime.cpp
+++ b/Core/AppRuntime/Source/AppRuntime.cpp
@@ -37,6 +37,8 @@ namespace Babylon
 
     void AppRuntime::Dispatch(std::function<void(Napi::Env)> func)
     {
-        m_workQueue->Append(std::move(func));
+        m_workQueue->Append([this, func{std::move(func)}] (Napi::Env env) {
+            Execute({[env, func{std::move(func)}] { func(env); }});
+        });
     }
 }

--- a/Core/AppRuntime/Source/AppRuntimeAndroid.cpp
+++ b/Core/AppRuntime/Source/AppRuntimeAndroid.cpp
@@ -23,4 +23,9 @@ namespace Babylon
             __android_log_write(ANDROID_LOG_ERROR, "BabylonNative", ss.str().data());
         }
     }
+
+    void AppRuntime::Execute(std::function<void()> callback)
+    {
+        callback();
+    }
 }

--- a/Core/AppRuntime/Source/AppRuntimeApple.mm
+++ b/Core/AppRuntime/Source/AppRuntimeApple.mm
@@ -21,4 +21,12 @@ namespace Babylon
             NSLog(@"Uncaught Error: %s", error.what());
         }
     }
+
+    void AppRuntime::Execute(std::function<void()> callback)
+    {
+        @autoreleasepool
+        {
+            callback();
+        }
+    }
 }

--- a/Core/AppRuntime/Source/AppRuntimeUWP.cpp
+++ b/Core/AppRuntime/Source/AppRuntimeUWP.cpp
@@ -25,4 +25,9 @@ namespace Babylon
             OutputDebugStringA(ss.str().data());
         }
     }
+
+    void AppRuntime::Execute(std::function<void()> callback)
+    {
+        callback();
+    }
 }

--- a/Core/AppRuntime/Source/AppRuntimeUnix.cpp
+++ b/Core/AppRuntime/Source/AppRuntimeUnix.cpp
@@ -21,4 +21,9 @@ namespace Babylon
             std::cerr << "Uncaught Error: " << error.Message() << std::endl;
         }
     }
+
+    void AppRuntime::Execute(std::function<void()> callback)
+    {
+        callback();
+    }
 }

--- a/Core/AppRuntime/Source/AppRuntimeWin32.cpp
+++ b/Core/AppRuntime/Source/AppRuntimeWin32.cpp
@@ -42,4 +42,9 @@ namespace Babylon
             OutputDebugStringA(ss.str().data());
         }
     }
+
+    void AppRuntime::Execute(std::function<void()> callback)
+    {
+        callback();
+    }
 }

--- a/Dependencies/xr/CMakeLists.txt
+++ b/Dependencies/xr/CMakeLists.txt
@@ -40,6 +40,12 @@ add_library(xrInternal INTERFACE)
 
 target_compile_definitions(xr PRIVATE _CRT_SECURE_NO_WARNINGS)
 
+if (APPLE)
+    set_target_properties(xr PROPERTIES
+        XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES
+    )
+endif()
+
 if (ANDROID)
     add_library(arcore SHARED IMPORTED)
     set_target_properties(arcore PROPERTIES IMPORTED_LOCATION

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -574,13 +574,13 @@ namespace xr {
 
         ~Impl() {
             if (ActiveFrameViews[0].ColorTexturePointer != nil) {
-                id<MTLTexture> oldColorTexture = (__bridge id<MTLTexture>)ActiveFrameViews[0].ColorTexturePointer;
+                id<MTLTexture> oldColorTexture = (__bridge_transfer id<MTLTexture>)ActiveFrameViews[0].ColorTexturePointer;
                 [oldColorTexture setPurgeableState:MTLPurgeableStateEmpty];
                 ActiveFrameViews[0].ColorTexturePointer = nil;
             }
 
             if (ActiveFrameViews[0].DepthTexturePointer != nil) {
-                id<MTLTexture> oldDepthTexture = (__bridge id<MTLTexture>)ActiveFrameViews[0].DepthTexturePointer;
+                id<MTLTexture> oldDepthTexture = (__bridge_transfer id<MTLTexture>)ActiveFrameViews[0].DepthTexturePointer;
                 [oldDepthTexture setPurgeableState:MTLPurgeableStateEmpty];
                 ActiveFrameViews[0].DepthTexturePointer = nil;
             }
@@ -840,7 +840,7 @@ namespace xr {
             auto anchor = [[ARAnchor alloc] initWithTransform:poseTransform];
             [session addAnchor:anchor];
             nativeAnchors.push_back(anchor);
-            return { pose, (__bridge_retained NativeAnchorPtr)anchor };
+            return { pose, (__bridge NativeAnchorPtr)anchor };
         }
 
         /**
@@ -865,7 +865,7 @@ namespace xr {
             // If this anchor has not already been deleted, then remove it from the current AR session,
             // and clean up its state in memory.
             if (anchor.NativeAnchor != nil) {
-                auto arAnchor = (__bridge_transfer ARAnchor*)anchor.NativeAnchor;
+                auto arAnchor = (__bridge ARAnchor*)anchor.NativeAnchor;
                 anchor.NativeAnchor = nil;
 
                 CleanupAnchor(arAnchor);


### PR DESCRIPTION
We've hit memory management issues several times in the xr lib on iOS:
- Memory leaks from missing calls to `release`
- Memory leaks from missing @autoreleasepools
- Crashes from releasing objects too early

With this change, I'm simplifying the memory management in two main ways:
- Enable ARC (automatic reference counting) for the iOS compilation of the xr lib
- Wrap each "tick" of the JS work queue in a @autoreleasepool (this is analogous to what happens on the UI thread, and also to what happens on the JS thread in react native - this fixes #527)

With ARC enabled, I *mostly* just had to remove all the explicit calls to `retain`, `release`, and `dealloc`. The one complicated part is the bridge casting. When ownership is transferred to or from ARC, a bridge cast is needed. There are three types of bridge cast used in these changes:
**`__bridge`** - this is used to cast to/from `void*` and does not affect the ref count.
**`__bridge_retained`** - this is used to cast to `void*` when we need to keep the object alive (essentially increments the ref count).
**`__bridge_transfer`** - this is used to cast from `void*` when we that pointer no longer needs to keep the object alive (essentially does not increment the ref count when casting back to the Foundation object that ARC understands).

For the @autoreleasepool, I needed to add an extra hook in `AppRuntime` for this, and it is a no-op for most platforms. This is not used in Babylon React Native, but I did test this in the regular Babylon Native playground to make sure memory is cleaned up as expected.