### PR TITLE
Use the NativeEngine TextureData definition to avoid crashes unwrapping Napi::External<NativeEngine::TextureData> for jsi

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1116,12 +1116,6 @@ namespace Babylon
 
     void NativeEngine::CopyTexture(const Napi::CallbackInfo& info)
     {
-        if (!info[0].IsExternal() ||
-            !info[1].IsExternal())
-        {
-            return;
-        }
-
         // This code does not copy texture but overrides texture handle.
         // It will leak texture memory and should be fixed.
         // See task in this list : https://github.com/BabylonJS/BabylonNative/issues/616#issuecomment-831162396

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1116,6 +1116,12 @@ namespace Babylon
 
     void NativeEngine::CopyTexture(const Napi::CallbackInfo& info)
     {
+        if (!info[0].IsExternal() ||
+            !info[1].IsExternal())
+        {
+            return;
+        }
+
         // This code does not copy texture but overrides texture handle.
         // It will leak texture memory and should be fixed.
         // See task in this list : https://github.com/BabylonJS/BabylonNative/issues/616#issuecomment-831162396

--- a/Polyfills/Canvas/CMakeLists.txt
+++ b/Polyfills/Canvas/CMakeLists.txt
@@ -27,7 +27,9 @@ target_link_to_dependencies(Canvas PUBLIC napi
     PRIVATE bgfx
     PRIVATE bimg
     PRIVATE bx
-    PRIVATE GraphicsInternal)
+    PRIVATE GraphicsInternal
+    PRIVATE NativeEngine
+    PRIVATE NativeEngineInternal)
 
 set_property(TARGET Canvas PROPERTY FOLDER Polyfills)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -11,9 +11,9 @@ namespace Babylon::Polyfills::Internal
 {
     static constexpr auto JS_CONSTRUCTOR_NAME = "NativeCanvas";
 
-    struct NativeCanvas::Impl
+    struct NativeCanvas::Impl final
     {
-        std::unique_ptr<Babylon::TextureData> m_textureData;
+        std::unique_ptr<Babylon::TextureData> TextureData;
     };
 
     void NativeCanvas::CreateInstance(Napi::Env env)
@@ -115,12 +115,12 @@ namespace Babylon::Polyfills::Internal
     Napi::Value NativeCanvas::GetCanvasTexture(const Napi::CallbackInfo& info)
     {
         assert(m_frameBufferHandle.idx != bgfx::kInvalidHandle);
-        m_impl->m_textureData = std::make_unique<TextureData>();
-        m_impl->m_textureData->Handle = bgfx::getTexture(m_frameBufferHandle);
-        m_impl->m_textureData->OwnsHandle = false;
-        m_impl->m_textureData->Width = m_width;
-        m_impl->m_textureData->Height = m_height;
-        return Napi::External<TextureData>::New(info.Env(), m_impl->m_textureData.get());
+        m_impl->TextureData = std::make_unique<TextureData>();
+        m_impl->TextureData->Handle = bgfx::getTexture(m_frameBufferHandle);
+        m_impl->TextureData->OwnsHandle = false;
+        m_impl->TextureData->Width = m_width;
+        m_impl->TextureData->Height = m_height;
+        return Napi::External<TextureData>::New(info.Env(), m_impl->TextureData.get());
     }
 
     void NativeCanvas::Dispose(const Napi::CallbackInfo& /*info*/)

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -49,8 +49,14 @@ namespace Babylon::Polyfills::Internal
     void NativeCanvas::LoadTTF(const Napi::CallbackInfo& info)
     {
         std::string fontName = info[0].As<Napi::String>().Utf8Value();
-        const auto buffer = info[1].As<Napi::ArrayBuffer>();
+        if (fontsInfos.find(fontName) != fontsInfos.end())
+        {
+            // If the font is already loaded, we should avoid resetting the data. This can invalidate the font stash and cause graphics crashes.
+            // TODO: we may want to populate fonts on the graphics thread in the future.
+            return;
+        }
 
+        const auto buffer = info[1].As<Napi::ArrayBuffer>();
         fontsInfos[fontName] = std::vector<uint8_t>(buffer.ByteLength());
         memcpy(fontsInfos[fontName].data(), (uint8_t*)buffer.Data(), buffer.ByteLength());
     }

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -117,6 +117,7 @@ namespace Babylon::Polyfills::Internal
         assert(m_frameBufferHandle.idx != bgfx::kInvalidHandle);
         m_impl->m_textureData = std::make_unique<TextureData>();
         m_impl->m_textureData->Handle = bgfx::getTexture(m_frameBufferHandle);
+        m_impl->m_textureData->OwnsHandle = false;
         m_impl->m_textureData->Width = m_width;
         m_impl->m_textureData->Height = m_height;
         return Napi::External<TextureData>::New(info.Env(), m_impl->m_textureData.get());

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include <sstream>
 #include <assert.h>
+#include <NativeEngine.h>
 
 namespace Babylon::Polyfills::Internal
 {
@@ -108,11 +109,12 @@ namespace Babylon::Polyfills::Internal
     Napi::Value NativeCanvas::GetCanvasTexture(const Napi::CallbackInfo& info)
     {
         assert(m_frameBufferHandle.idx != bgfx::kInvalidHandle);
-        m_textureData.Handle = bgfx::getTexture(m_frameBufferHandle);
-        m_textureData.OwnsHandle = false;
-        m_textureData.Width = m_width;
-        m_textureData.Height = m_height;
-        return Napi::External<TextureData>::New(info.Env(), &m_textureData);
+        const auto textureData = new TextureData();
+        textureData->Handle = bgfx::getTexture(m_frameBufferHandle);
+        textureData->OwnsHandle = false;
+        textureData->Width = m_width;
+        textureData->Height = m_height;
+        return Napi::External<TextureData>::New(info.Env(), textureData, [](Napi::Env, TextureData* data) { delete data; });
     }
 
     void NativeCanvas::Dispose(const Napi::CallbackInfo& /*info*/)

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -43,8 +43,7 @@ namespace Babylon::Polyfills::Internal
     Napi::Value NativeCanvas::LoadTTFAsync(const Napi::CallbackInfo& info)
     {
         const auto buffer = info[1].As<Napi::ArrayBuffer>();
-        std::vector<uint8_t> fontBuffer{};
-        fontBuffer.resize(buffer.ByteLength());
+        std::vector<uint8_t> fontBuffer(buffer.ByteLength());
         memcpy(fontBuffer.data(), (uint8_t*)buffer.Data(), buffer.ByteLength());
 
         auto& graphicsImpl{Babylon::GraphicsImpl::GetFromJavaScript(info.Env())};

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -5,16 +5,10 @@
 #include <functional>
 #include <sstream>
 #include <assert.h>
-#include <NativeEngine.h>
 
 namespace Babylon::Polyfills::Internal
 {
     static constexpr auto JS_CONSTRUCTOR_NAME = "NativeCanvas";
-
-    struct NativeCanvas::Impl final
-    {
-        std::unique_ptr<Babylon::TextureData> TextureData;
-    };
 
     void NativeCanvas::CreateInstance(Napi::Env env)
     {
@@ -38,7 +32,6 @@ namespace Babylon::Polyfills::Internal
     NativeCanvas::NativeCanvas(const Napi::CallbackInfo& info)
         : Napi::ObjectWrap<NativeCanvas>{info}
         , m_graphicsImpl{ Babylon::GraphicsImpl::GetFromJavaScript(info.Env()) }
-        , m_impl{std::make_unique<Impl>()}
     {
     }
 
@@ -115,12 +108,11 @@ namespace Babylon::Polyfills::Internal
     Napi::Value NativeCanvas::GetCanvasTexture(const Napi::CallbackInfo& info)
     {
         assert(m_frameBufferHandle.idx != bgfx::kInvalidHandle);
-        m_impl->TextureData = std::make_unique<TextureData>();
-        m_impl->TextureData->Handle = bgfx::getTexture(m_frameBufferHandle);
-        m_impl->TextureData->OwnsHandle = false;
-        m_impl->TextureData->Width = m_width;
-        m_impl->TextureData->Height = m_height;
-        return Napi::External<TextureData>::New(info.Env(), m_impl->TextureData.get());
+        m_textureData.Handle = bgfx::getTexture(m_frameBufferHandle);
+        m_textureData.OwnsHandle = false;
+        m_textureData.Width = m_width;
+        m_textureData.Height = m_height;
+        return Napi::External<TextureData>::New(info.Env(), &m_textureData);
     }
 
     void NativeCanvas::Dispose(const Napi::CallbackInfo& /*info*/)

--- a/Polyfills/Canvas/Source/Canvas.h
+++ b/Polyfills/Canvas/Source/Canvas.h
@@ -2,6 +2,7 @@
 
 #include <Babylon/Polyfills/Canvas.h>
 #include <GraphicsImpl.h>
+#include <NativeEngine.h>
 
 namespace Babylon::Polyfills::Internal
 {
@@ -42,7 +43,6 @@ namespace Babylon::Polyfills::Internal
         Babylon::FrameBuffer* m_frameBuffer{};
         bool m_dirty{};
 
-        struct Impl;
-        std::unique_ptr<Impl> m_impl;
+        Babylon::TextureData m_textureData{};
     };
 }

--- a/Polyfills/Canvas/Source/Canvas.h
+++ b/Polyfills/Canvas/Source/Canvas.h
@@ -2,7 +2,6 @@
 
 #include <Babylon/Polyfills/Canvas.h>
 #include <GraphicsImpl.h>
-#include <NativeEngine.h>
 
 namespace Babylon::Polyfills::Internal
 {
@@ -42,7 +41,5 @@ namespace Babylon::Polyfills::Internal
         bgfx::FrameBufferHandle m_frameBufferHandle{ bgfx::kInvalidHandle };
         Babylon::FrameBuffer* m_frameBuffer{};
         bool m_dirty{};
-
-        Babylon::TextureData m_textureData{};
     };
 }

--- a/Polyfills/Canvas/Source/Canvas.h
+++ b/Polyfills/Canvas/Source/Canvas.h
@@ -41,5 +41,8 @@ namespace Babylon::Polyfills::Internal
         bgfx::FrameBufferHandle m_frameBufferHandle{ bgfx::kInvalidHandle };
         Babylon::FrameBuffer* m_frameBuffer{};
         bool m_dirty{};
+
+        struct Impl;
+        std::unique_ptr<Impl> m_impl;
     };
 }

--- a/Polyfills/Canvas/Source/Canvas.h
+++ b/Polyfills/Canvas/Source/Canvas.h
@@ -22,16 +22,14 @@ namespace Babylon::Polyfills::Internal
         Babylon::FrameBuffer& GetFrameBuffer() { return *m_frameBuffer; }
 
     private:
-
         Napi::Value GetContext(const Napi::CallbackInfo&);
         Napi::Value GetWidth(const Napi::CallbackInfo&);
         void SetWidth(const Napi::CallbackInfo&, const Napi::Value& value);
         Napi::Value GetHeight(const Napi::CallbackInfo&);
         void SetHeight(const Napi::CallbackInfo&, const Napi::Value& value);
         Napi::Value GetCanvasTexture(const Napi::CallbackInfo& info);
-        static void LoadTTF(const Napi::CallbackInfo& info);
+        static Napi::Value LoadTTFAsync(const Napi::CallbackInfo& info);
         void Dispose(const Napi::CallbackInfo& info);
-        
 
         uint32_t m_width{1};
         uint32_t m_height{1};


### PR DESCRIPTION
Defining a second TextureData definition for the Canvas seemed to resolve correctly in BabylonNative. But in BabylonReactNative the jsi wrapper unwrapping the external type threw exceptions. This change updates the Canvas polyfill to consume the TextureData struct defined by NativeEngine. It seems like this is what we should be doing to avoid getting into scenarios where the struct definition changes and we need to update multiple locations.

We also update loadTTF to only load a font once. Once a font is getting used if its updated on the js thread it can cause crashes for the graphics thread.

Note: this change requires having the Canvas polyfill reference internal headers for NativeEngine. It seems like this is already an expected practice. I'm not sure if polyfills are supposed to consume Core/Plugin definitions, but In this scenario we need to.