### PR TITLE
Fix Missing Canvas Init VT iOS

### DIFF
--- a/Apps/ValidationTests/iOS/LibNativeBridge.mm
+++ b/Apps/ValidationTests/iOS/LibNativeBridge.mm
@@ -5,6 +5,7 @@
 #import <Babylon/ScriptLoader.h>
 #import <Babylon/Plugins/NativeEngine.h>
 #import <Babylon/Plugins/NativeXr.h>
+#import <Babylon/Polyfills/Canvas.h>
 #import <Babylon/Polyfills/Window.h>
 #import <Babylon/Polyfills/XMLHttpRequest.h>
 #import <UIKit/UIKit.h>
@@ -48,6 +49,7 @@ std::unique_ptr<Babylon::AppRuntime> runtime{};
     {
         Babylon::Polyfills::Window::Initialize(env);
         Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+        Babylon::Polyfills::Canvas::Initialize(env);
 
         graphics->AddToJavaScript(env);
         Babylon::Plugins::NativeEngine::Initialize(env);
@@ -59,9 +61,6 @@ std::unique_ptr<Babylon::AppRuntime> runtime{};
     });
 
     Babylon::ScriptLoader loader{ *runtime };
-    loader.Eval("document = {}", "");
-    loader.LoadScript("app:///Scripts/ammo.js");
-    loader.LoadScript("app:///Scripts/recast.js");
     loader.LoadScript("app:///Scripts/babylon.max.js");
     loader.LoadScript("app:///Scripts/babylonjs.loaders.js");
     loader.LoadScript("app:///Scripts/babylonjs.materials.js");


### PR DESCRIPTION
Missing Canvas init for iOS ValidationTests