### PR TITLE
Added functionality for producing ARKit LiDAR mesh geometry data

### DIFF
--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -179,18 +179,17 @@ CreateBoxAsync().then(function () {
                 }
 
                 // Showing visualization for ARKit LiDAR mesh data
-                if(meshDetection) {
+                if (meshDetection) {
                     var mat = new BABYLON.StandardMaterial("mat", scene);
                     mat.wireframe = true;
                     mat.diffuseColor = BABYLON.Color3.Blue();
                     const xrMeshes = xr.baseExperience.featuresManager.enableFeature(
-                    BABYLON.WebXRFeatureName.MESH_DETECTION,
-                    "latest",
-                    {convertCoordinateSystems: true});
+                        BABYLON.WebXRFeatureName.MESH_DETECTION,
+                        "latest",
+                        {convertCoordinateSystems: true});
                     console.log("Enabled mesh detection.");
-                    const meshes = [];
-                    const meshID = [];
-                    
+                    const meshMap = new Map();
+
                     // adding meshes
                     xrMeshes.onMeshAddedObservable.add(mesh=> {
                         try {
@@ -203,48 +202,43 @@ CreateBoxAsync().then(function () {
                             vertexData.normals = mesh.normals;
                             vertexData.applyToMesh(customMesh, true);
                             customMesh.material = mat;
-                            // add mesh and mesh id to arrays
-                            meshes.splice(mesh.id, 0, (customMesh));
-                            meshID[mesh.id] = mesh.id;
+                            // add mesh and mesh id to map
+                            meshMap.set(mesh.id, customMesh);
                         } catch (ex) {
                             console.error(ex);
                         }
                     });
-                    
+
                     // updating meshes
                     xrMeshes.onMeshUpdatedObservable.add(mesh=> {
-                        try{
+                        try {
                             console.log("Mesh updated.");
-                            if(mesh.id == meshID[mesh.id]) {
+                            if (meshMap.has(mesh.id)) {
                                 var vertexData = new BABYLON.VertexData();
                                 vertexData.positions = mesh.positions;
                                 vertexData.indices = mesh.indices;
                                 vertexData.normals = mesh.normals;
-                                vertexData.applyToMesh(meshes[mesh.id], true);
+                                vertexData.applyToMesh(meshMap.get(mesh.id), true);
                             }
                         } catch (ex) {
                             console.error(ex);
                         }
                     });
-                    
+
                     // removing meshes
                     xrMeshes.onMeshRemovedObservable.add(mesh => {
-                        try{
+                        try {
                             console.log("Mesh removed.");
-                            if(mesh.id == meshID[mesh.id]) {
-                                meshes[mesh.id].positions.dispose();
-                                meshes[mesh.id].normals.dispose();
-                                meshes[mesh.id].indices.dispose();
-                                scene.remove(meshes[mesh.id]);
-                                meshes[mesh.id].dispose();
-                                delete meshID[mesh.id];
+                            if (meshMap.has(mesh.id)) {
+                                meshMap.get(mesh.id).dispose();
+                                meshMap.delete(mesh.id);
                             }
                         } catch (ex) {
                             console.error(ex);
                         }
                     });
                 }
-                
+
                 // Below is an example of how to process feature points.
                 if (xrFeaturePoints) {
                     // First we attach the feature point system feature the XR experience.

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -1032,16 +1032,16 @@ namespace xr {
                 return;
             }
 
-            [sessionDelegate LockMeshes];
-            @try {
-                if (@available(iOS 13.4, *)) {
+            if (@available(iOS 13.4, *)) {
+                [sessionDelegate LockMeshes];
+                @try {
                     // Update all meshes that have been updated since the last frame
                     auto updatedARKitMeshes = [sessionDelegate GetUpdatedMeshes];
                     for (ARMeshAnchor* updatedMesh : *updatedARKitMeshes) {
-                        const auto geometry = updatedMesh.geometry;
-                        const auto faces = geometry.faces;
-                        const auto vertices = geometry.vertices;
-                        const auto normals = geometry.normals;
+                        const auto& geometry = updatedMesh.geometry;
+                        const auto& faces = geometry.faces;
+                        const auto& vertices = geometry.vertices;
+                        const auto& normals = geometry.normals;
                         // get vertices data for vertex buffer
                         meshVertexBuffer.clear();
                         meshVertexBuffer.resize(vertices.count);
@@ -1125,9 +1125,9 @@ namespace xr {
 
                     // Clear the list of removed frames to start building up for the next mesh update.
                     removedARKitMeshes->clear();
+                } @finally {
+                    [sessionDelegate UnlockMeshes];
                 }
-            } @finally {
-                [sessionDelegate UnlockMeshes];
             }
         }
 

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -24,8 +24,7 @@ namespace {
         bool operator()(const ARPlaneAnchor* lhs, const ARPlaneAnchor* rhs) const {
             return lhs.identifier < rhs.identifier;
         }
-
-#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_4)
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
         API_AVAILABLE(ios(13.4))
         bool operator()(const ARMeshAnchor* lhs, const ARMeshAnchor* rhs) const {
             return lhs.identifier < rhs.identifier;
@@ -99,7 +98,7 @@ namespace {
     std::set<ARPlaneAnchor*,ARAnchorComparer> updatedPlanes;
     std::vector<ARPlaneAnchor*> deletedPlanes;
     bool planeDetectionEnabled;
-#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_4)
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
     API_AVAILABLE(ios(13.4))
     std::set<ARMeshAnchor*,ARAnchorComparer> updatedMeshes;
     API_AVAILABLE(ios(13.4))
@@ -147,7 +146,7 @@ namespace {
     return &updatedPlanes;
 }
 
-#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_4)
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
 /**
  Returns the set of all updated meshes since the last time we consumed mesh updates.
  */
@@ -167,19 +166,19 @@ namespace {
     planeDetectionEnabled = enabled;
 }
 
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
 - (bool) TrySetMeshDetectorEnabled:(const bool)enabled {
-#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_4)
     if (@available(iOS 13.4, *)) {
         if([ARWorldTrackingConfiguration supportsSceneReconstruction: ARSceneReconstructionMesh]) {
             meshDetectionEnabled = enabled;
             return true;
         }
     }
-#endif
     return false;
 }
+#endif
 
-#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_4)
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
 /**
  Returns the vector containing all deleted meshes since the last time we consumed mesh updates.
  */
@@ -203,9 +202,10 @@ namespace {
     updatedPlanes = {};
     deletedPlanes = {};
     planeLock = [[NSLock alloc] init];
-
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
     updatedMeshes = {};
     deletedMeshes = {};
+#endif
     meshLock = [[NSLock alloc] init];
     return self;
 }
@@ -414,7 +414,7 @@ namespace {
         [self UnlockPlanes];
     }
 
-#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_4)
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
     if (@available(iOS 13.4, *)) {
         if (meshDetectionEnabled) {
             [self LockMeshes];
@@ -443,7 +443,7 @@ namespace {
         [self UnlockPlanes];
     }
 
-#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_4)
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
     if (@available(iOS 13.4, *)) {
         if (meshDetectionEnabled) {
             [self LockMeshes];
@@ -472,7 +472,7 @@ namespace {
         [self UnlockPlanes];
     }
 
-#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_4)
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
     if (@available(iOS 13.4, *)) {
         if (meshDetectionEnabled) {
             [self LockMeshes];
@@ -649,7 +649,7 @@ namespace xr {
             // Create the ARSession enable plane detection, include scene reconstruction mesh if supported, and disable lighting estimation.
             session = [ARSession new];
             auto configuration = [ARWorldTrackingConfiguration new];
-#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_4)
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
             if (@available(iOS 13.4, *)) {
                 if ([ARWorldTrackingConfiguration supportsSceneReconstruction: ARSceneReconstructionMesh]) {
                     configuration.sceneReconstruction = ARSceneReconstructionMesh;
@@ -1048,6 +1048,7 @@ namespace xr {
             }
         }
 
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
         /**
          Updates existing meshes in place, gets the list of updated/created mesh IDs and removed mesh IDs.
          */
@@ -1055,7 +1056,6 @@ namespace xr {
             if (![sessionDelegate TrySetMeshDetectorEnabled: true]) {
                 return;
             }
-#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_4)
             if (@available(iOS 13.4, *)) {
                 [sessionDelegate LockMeshes];
                 @try {
@@ -1153,8 +1153,8 @@ namespace xr {
                     [sessionDelegate UnlockMeshes];
                 }
             }
-#endif
         }
+#endif
 
         void UpdateFeaturePointCloud() {
             if (!FeaturePointCloudEnabled) {
@@ -1246,10 +1246,12 @@ namespace xr {
             [sessionDelegate SetPlaneDetectionEnabled:enabled];
         }
 
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
         bool TrySetMeshDetectorEnabled(const bool enabled)
         {
             return [sessionDelegate TrySetMeshDetectorEnabled:enabled];
         }
+#endif
 
         bool IsTracking() const {
             // There are three different tracking states as defined in ARKit: https://developer.apple.com/documentation/arkit/artrackingstate
@@ -1454,7 +1456,9 @@ namespace xr {
         Views[0].DepthNearZ = sessionImpl.DepthNearZ;
         Views[0].DepthFarZ = sessionImpl.DepthFarZ;
         m_impl->sessionImpl.UpdatePlanes(UpdatedPlanes, RemovedPlanes);
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
         m_impl->sessionImpl.UpdateMeshes(UpdatedMeshes, RemovedMeshes);
+#endif
         m_impl->sessionImpl.UpdateFeaturePointCloud();
     }
 
@@ -1570,7 +1574,10 @@ namespace xr {
 
     bool System::Session::TrySetMeshDetectorEnabled(const bool enabled)
     {
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
         return m_impl->TrySetMeshDetectorEnabled(enabled);
+#endif
+        return enabled;
     }
 
     bool System::Session::TrySetPreferredMeshDetectorOptions(const GeometryDetectorOptions&)

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -150,7 +150,7 @@ namespace {
 /**
  Returns the set of all updated meshes since the last time we consumed mesh updates.
  */
-- (std::set<ARMeshAnchor*, ARAnchorComparer>*) GetUpdatedMeshes  API_AVAILABLE(ios(13.4)){
+- (std::set<ARMeshAnchor*, ARAnchorComparer>*) GetUpdatedMeshes API_AVAILABLE(ios(13.4)) {
     return &updatedMeshes;
 }
 #endif
@@ -178,11 +178,18 @@ namespace {
 }
 #endif
 
+/**
+ Returns the boolean that keeps track of whether mesh detection is enabled or not.
+ */
+- (bool) GetMeshDetectionEnabled {
+    return meshDetectionEnabled;
+}
+
 #if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
 /**
  Returns the vector containing all deleted meshes since the last time we consumed mesh updates.
  */
-- (std::vector<ARMeshAnchor*>*) GetDeletedMeshes  API_AVAILABLE(ios(13.4)){
+- (std::vector<ARMeshAnchor*>*) GetDeletedMeshes API_AVAILABLE(ios(13.4)) {
     return &deletedMeshes;
 }
 #endif
@@ -1053,7 +1060,7 @@ namespace xr {
          Updates existing meshes in place, gets the list of updated/created mesh IDs and removed mesh IDs.
          */
         void UpdateMeshes(std::vector<Frame::Mesh::Identifier>& updatedMeshes, std::vector<Frame::Mesh::Identifier>& deletedMeshes) {
-            if (![sessionDelegate TrySetMeshDetectorEnabled: true]) {
+            if (![sessionDelegate GetMeshDetectionEnabled]) {
                 return;
             }
             if (@available(iOS 13.4, *)) {
@@ -1328,7 +1335,7 @@ namespace xr {
 
         void UpdateMesh(std::vector<Frame::Mesh::Identifier>& updatedMeshes, Frame::Mesh& mesh, std::vector<Vector3f>& vertexBuffer, std::vector<uint32_t>& indexBuffer, std::vector<Vector3f>& normalsBuffer) {
             // Check if mesh was actually updated
-            BOOL checkIfMeshUpdated = false;
+            bool checkIfMeshUpdated{ false };
             if (mesh.Positions.size() != vertexBuffer.size()) {
                 checkIfMeshUpdated = true;
             } else {

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -203,11 +203,11 @@ namespace {
 }
 
 - (void) LockMeshes {
-    [planeLock lock];
+    [meshLock lock];
 }
 
 - (void) UnlockMeshes {
-    [planeLock unlock];
+    [meshLock unlock];
 }
 
 /**
@@ -422,9 +422,9 @@ namespace {
             }
         }
         
-        [self UnlockPlanes];
-        
+        [self UnlockPlanes];  
     }
+
     if (meshDetectionEnabled) {
         [self LockMeshes];
         for (ARAnchor* updatedAnchor : anchors) {
@@ -440,8 +440,6 @@ namespace {
     return;
 }
 
-
-
 - (void)session:(ARSession *)__unused session didRemoveAnchors:(nonnull NSArray<__kindof ARAnchor *> *)anchors {
     if (planeDetectionEnabled) {
         [self LockPlanes];
@@ -453,6 +451,7 @@ namespace {
         
         [self UnlockPlanes];
     }
+
     if (meshDetectionEnabled) {
         [self LockMeshes];
         for (ARAnchor* removedAnchor : anchors) {
@@ -467,7 +466,6 @@ namespace {
     }
     return;
 }
-
 
 -(void)cleanupTextures {
     if (_cameraTextureY != nil) {

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -1027,7 +1027,7 @@ namespace xr {
         }
 
         /**
-         Updates existing meshes in place,  gets the list of updated/created mesh IDs, and removed mesh IDs.
+         Updates existing meshes in place, gets the list of updated/created mesh IDs and removed mesh IDs.
          */
         void UpdateMeshes(std::vector<Frame::Mesh::Identifier>& updatedMeshes, std::vector<Frame::Mesh::Identifier>& deletedMeshes) {
             if (!meshDetectionEnabled)
@@ -1092,7 +1092,7 @@ namespace xr {
                             meshNormalsBuffer[i].Y = position[1];
                             meshNormalsBuffer[i].Z = position[2];
                         }
-                        // Update the existing mesh if it exists, otherwise create a new mesh, and add it to our list of meshes.
+                        // Update the existing mesh if it exists, otherwise create a new mesh and add it to our list of meshes.
                         auto meshIterator = meshMap.find({[updatedMesh.identifier.UUIDString UTF8String]});
                         if (meshIterator != meshMap.end()) {
                             // if meshID was found, update values
@@ -1307,23 +1307,20 @@ namespace xr {
 
         void UpdateMesh(std::vector<Frame::Mesh::Identifier>& updatedMeshes, Frame::Mesh& mesh, std::vector<Vector3f>& vertexBuffer, std::vector<uint32_t>& indexBuffer, std::vector<Vector3f>& normalsBuffer) {
             // Check if mesh was actually updated
-            BOOL flag = false;
-            
-            if(mesh.Positions.size() != vertexBuffer.size()){ flag = true;
-                
+            BOOL checkIfMeshUpdated = false;
+            if(mesh.Positions.size() != vertexBuffer.size()) {
+                checkIfMeshUpdated = true;
             } else {
-                for (size_t i = 0; i < vertexBuffer.size(); i++)
-                {
+                for (size_t i = 0; i < vertexBuffer.size(); i++) {
                     if (abs(mesh.Positions[i].X - vertexBuffer[i].X) > 0.02f
                         || abs(mesh.Positions[i].Y - vertexBuffer[i].Y) > 0.02f
                         || abs(mesh.Positions[i].Z - vertexBuffer[i].Z) > 0.02f) {
-                        
-                        flag = true;
+                        checkIfMeshUpdated = true;
                     }
                 }
             }
             
-            if(flag) {
+            if(checkIfMeshUpdated) {
                 // Store the new mesh information
                 mesh.Positions.resize(vertexBuffer.size());
                 mesh.Positions.swap(vertexBuffer);

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -1581,10 +1581,12 @@ namespace xr {
 
     bool System::Session::TrySetMeshDetectorEnabled(const bool enabled)
     {
+        if (enabled) {
 #if (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400)
         return m_impl->TrySetMeshDetectorEnabled(enabled);
 #endif
-        return enabled;
+        }
+        return false;
     }
 
     bool System::Session::TrySetPreferredMeshDetectorOptions(const GeometryDetectorOptions&)


### PR DESCRIPTION
Functionality for producing ARKit LiDAR mesh geometry data was added. ARKit uses the LiDAR scanner to create a polygonal model of the physical environment. This data will allow the user to more accurately locate points on real-world surfaces. 

- Available on devices with a LiDAR scanner that support scene reconstruction, running iOS 13.4 or later.