### PR TITLE
Fix Win32 crash unmaximized

### DIFF
--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -317,13 +317,16 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
             }
             else if ((wParam & 0xFFF0) == SC_RESTORE)
             {
-                minimized = false;
-
-                runtime->Resume();
-
-                if (graphics)
+                if (minimized)
                 {
-                    graphics->StartRenderingCurrentFrame();
+                    runtime->Resume();
+
+                    minimized = false;
+
+                    if (graphics)
+                    {
+                        graphics->StartRenderingCurrentFrame();
+                    }
                 }
             }
             DefWindowProc(hWnd, message, wParam, lParam);

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -94,7 +94,7 @@ namespace
         Uninitialize();
 
         RECT rect;
-        if (!GetWindowRect(hWnd, &rect))
+        if (!GetClientRect(hWnd, &rect))
         {
             return;
         }


### PR DESCRIPTION
Fixes #817 

SC_RESTORE event happens when un-maximizing. Previously this event assumed it was only called when app was minimized.
Checking it was minimized before otherwise does nothing.
WM_SIZE event occurs anyway.