### PR TITLE
Check Stencil/Depth RT

### DIFF
--- a/Core/Graphics/Source/FrameBuffer.cpp
+++ b/Core/Graphics/Source/FrameBuffer.cpp
@@ -24,12 +24,14 @@ namespace Babylon
         }
     }
 
-    FrameBuffer::FrameBuffer(GraphicsImpl& impl, bgfx::FrameBufferHandle handle, uint16_t width, uint16_t height, bool defaultBackBuffer)
+    FrameBuffer::FrameBuffer(GraphicsImpl& impl, bgfx::FrameBufferHandle handle, uint16_t width, uint16_t height, bool defaultBackBuffer, bool hasDepth, bool hasStencil)
         : m_impl{impl}
         , m_handle{handle}
         , m_width{width}
         , m_height{height}
         , m_defaultBackBuffer{defaultBackBuffer}
+        , m_hasDepth(hasDepth)
+        , m_hasStencil(hasStencil)
     {
     }
 
@@ -130,7 +132,7 @@ namespace Babylon
 
     void FrameBuffer::SetStencil(bgfx::Encoder& encoder, uint32_t stencilState)
     {
-        encoder.setStencil(stencilState);
+        encoder.setStencil(m_hasStencil ? stencilState : 0);
     }
 
     bool ViewPort::Equals(const ViewPort& other) const

--- a/Core/Graphics/Source/FrameBuffer.h
+++ b/Core/Graphics/Source/FrameBuffer.h
@@ -20,7 +20,7 @@ namespace Babylon
     class FrameBuffer
     {
     public:
-        FrameBuffer(GraphicsImpl& impl, bgfx::FrameBufferHandle handle, uint16_t width, uint16_t height, bool defaultBackBuffer);
+        FrameBuffer(GraphicsImpl& impl, bgfx::FrameBufferHandle handle, uint16_t width, uint16_t height, bool defaultBackBuffer, bool hasDepth, bool hasStencil);
         ~FrameBuffer();
 
         FrameBuffer(const FrameBuffer&) = delete;
@@ -40,6 +40,9 @@ namespace Babylon
         void SetStencil(bgfx::Encoder& encoder, uint32_t stencilState);
         void Blit(bgfx::Encoder& encoder, bgfx::TextureHandle _dst, uint16_t _dstX, uint16_t _dstY, bgfx::TextureHandle _src, uint16_t _srcX = 0, uint16_t _srcY = 0, uint16_t _width = UINT16_MAX, uint16_t _height = UINT16_MAX);
 
+        bool HasDepth() const { return m_hasDepth; }
+        bool HasStencil() const { return m_hasStencil; }
+
     private:
 
         GraphicsImpl& m_impl;
@@ -47,6 +50,8 @@ namespace Babylon
         const uint16_t m_width;
         const uint16_t m_height;
         const bool m_defaultBackBuffer;
+        const bool m_hasDepth;
+        const bool m_hasStencil;
 
         bgfx::ViewId m_viewId{};
         ViewPort m_viewPort{};

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -686,6 +686,8 @@ namespace Babylon
                                 frameBufferHandle,
                                 static_cast<uint16_t>(viewConfig.ViewTextureSize.Width),
                                 static_cast<uint16_t>(viewConfig.ViewTextureSize.Height),
+                                true,
+                                true,
                                 true);
 
                             // WebXR, at least in its current implementation, specifies an implicit default clear to black.

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -100,7 +100,7 @@ namespace Babylon::Polyfills::Internal
         {
             auto handle = bgfx::createFrameBuffer(static_cast<uint16_t>(m_width), static_cast<uint16_t>(m_height), bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT);
             assert(handle.idx != bgfx::kInvalidHandle);
-            m_frameBuffer = std::make_unique<FrameBuffer>(m_graphicsImpl, handle, static_cast<uint16_t>(m_width), static_cast<uint16_t>(m_height), false);
+            m_frameBuffer = std::make_unique<FrameBuffer>(m_graphicsImpl, handle, static_cast<uint16_t>(m_width), static_cast<uint16_t>(m_height), false, false, false);
             m_dirty = false;
             return true;
         }


### PR DESCRIPTION
With Metal, having a stencil operation or depth write on a RenderTarget that does not have a Depth/stencil buffer will pop up an error with Metal Validation Layer. (I guess it will be the same with Vulkan)

So, keeping track of depth/stencil capability for the frame buffer and enable/disable feature accordingly.