### PR TITLE
Update to Babylon.js 5.0.0 alpha 34

### DIFF
--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -1,116 +1,42 @@
 {
   "name": "BabylonNative",
   "version": "0.0.1",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "BabylonNative",
-      "version": "0.0.1",
-      "dependencies": {
-        "babylonjs": "5.0.0-alpha.30",
-        "babylonjs-gui": "5.0.0-alpha.30",
-        "babylonjs-loaders": "5.0.0-alpha.30",
-        "babylonjs-materials": "5.0.0-alpha.30",
-        "jsc-android": "^241213.1.0",
-        "v8-android": "^7.8.2"
-      }
-    },
-    "node_modules/babylonjs": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-msvxKLz7ai03j7KWkSQ3XSO9JGIVo9iZz7FIWmE5xOf0NJCjscZmy/egQxx2fnIzcG/mo9ZiIuYrDuiw6uhFvw==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/babylonjs-gltf2interface": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-HO8ezRQ0s4//x4CEACszcVdbotKO0/DzkWJAVbZBGZ/QaMLibYfCQoKCWBP1gIBADIe+cjn3TubM0oIMovDhwQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/babylonjs-gui": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-GZMP9CDmCFbEXbvhTXT/s3N/HmKEaRil9tRTYoTDAha67O+i8VAi8GL7Lx9vf454EuZl1HkMmwiaOQXjFrLy9g==",
-      "dependencies": {
-        "babylonjs": "5.0.0-alpha.30"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/babylonjs-loaders": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-Q8Ui7erYNQSRIFDW3a1sxCWedTspn9Jg1LQAo2N3t5vHNXndenIS+HqzzLjhKsdH5oi7Yn9sLetQA7ricwC5+w==",
-      "dependencies": {
-        "babylonjs": "5.0.0-alpha.30",
-        "babylonjs-gltf2interface": "5.0.0-alpha.30"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/babylonjs-materials": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-zXQ/9Iz1vtqHZsBUhy9u+3ub5MFr7wyAAOR8ZsLb8/+CeYO3tIR63TpCCeTEhXcpn0X8biL2iVtrjKIrGZK+QQ==",
-      "dependencies": {
-        "babylonjs": "5.0.0-alpha.30"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/jsc-android": {
-      "version": "241213.2.0",
-      "resolved": "https://registry.npmjs.org/jsc-android/-/jsc-android-241213.2.0.tgz",
-      "integrity": "sha512-nfddejB9jxFSG+Uewf+zwATFi8F2CZEEgoHLoOj13egiBDoC7zMoxK1c5/Ycf3AGmGuwCgjpn3LWe0f4tKYbjw=="
-    },
-    "node_modules/v8-android": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/v8-android/-/v8-android-7.8.2.tgz",
-      "integrity": "sha512-LZLtehBxj4rLgf3+gWs3ITTmnVvlD3KQubLzFmtdI+l3G9tbi8ckWm6tJv7KQXZu3L/ok5M2bZz1AGnofPiMfQ=="
-    }
-  },
   "dependencies": {
     "babylonjs": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-msvxKLz7ai03j7KWkSQ3XSO9JGIVo9iZz7FIWmE5xOf0NJCjscZmy/egQxx2fnIzcG/mo9ZiIuYrDuiw6uhFvw=="
+      "version": "5.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-5.0.0-alpha.34.tgz",
+      "integrity": "sha512-gxfeo9q3EuI4/Cwl8ioCvQUtk/KrxHWZtobblbnx4pxRzr0h32Cmurl+Iw6oesIbT8cUOmQc9MTCTO1M8pcNig=="
     },
     "babylonjs-gltf2interface": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-HO8ezRQ0s4//x4CEACszcVdbotKO0/DzkWJAVbZBGZ/QaMLibYfCQoKCWBP1gIBADIe+cjn3TubM0oIMovDhwQ=="
+      "version": "5.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-alpha.34.tgz",
+      "integrity": "sha512-BqcvLlTvVsPtQsCp/PtL0uIpNrJ1oas00N7kP1Lk7eDd+PUchIF1gvC/XvPR7QH6WABIvTcbi7Fr931OyIyxsw=="
     },
     "babylonjs-gui": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-GZMP9CDmCFbEXbvhTXT/s3N/HmKEaRil9tRTYoTDAha67O+i8VAi8GL7Lx9vf454EuZl1HkMmwiaOQXjFrLy9g==",
+      "version": "5.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-5.0.0-alpha.34.tgz",
+      "integrity": "sha512-TIqt9FhJUphUWlAedD5FPXcpjBelIYC7NK1Qa6ZXfxcKgW2cqrfJ3A/A3bTeDPdCdMkUEJdu3m1PlFE8lqokiA==",
       "requires": {
-        "babylonjs": "5.0.0-alpha.30"
+        "babylonjs": "5.0.0-alpha.34"
       }
     },
     "babylonjs-loaders": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-Q8Ui7erYNQSRIFDW3a1sxCWedTspn9Jg1LQAo2N3t5vHNXndenIS+HqzzLjhKsdH5oi7Yn9sLetQA7ricwC5+w==",
+      "version": "5.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-5.0.0-alpha.34.tgz",
+      "integrity": "sha512-MjDJXtBygAVUtYr1IhCcdgVR5pjpEzDBxAp5S/dW7M2WUba/9klIFdxKkOZrW6pscrJpwIWqt67+WDe3z4UryA==",
       "requires": {
-        "babylonjs": "5.0.0-alpha.30",
-        "babylonjs-gltf2interface": "5.0.0-alpha.30"
+        "babylonjs": "5.0.0-alpha.34",
+        "babylonjs-gltf2interface": "5.0.0-alpha.34"
       }
     },
     "babylonjs-materials": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-zXQ/9Iz1vtqHZsBUhy9u+3ub5MFr7wyAAOR8ZsLb8/+CeYO3tIR63TpCCeTEhXcpn0X8biL2iVtrjKIrGZK+QQ==",
+      "version": "5.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-5.0.0-alpha.34.tgz",
+      "integrity": "sha512-nXVgPDAl3qm58eQ6q7Ujg3lAPfKeNxV9+e7Vqw3ftPwA1vrxHb7CJ/562TCqGVkR8kKl5lvj/iuvQ5LSnSYDOw==",
       "requires": {
-        "babylonjs": "5.0.0-alpha.30"
+        "babylonjs": "5.0.0-alpha.34"
       }
     },
     "jsc-android": {

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "babylonjs": "5.0.0-alpha.30",
-    "babylonjs-gui": "5.0.0-alpha.30",
-    "babylonjs-loaders": "5.0.0-alpha.30",
-    "babylonjs-materials": "5.0.0-alpha.30",
+    "babylonjs": "5.0.0-alpha.34",
+    "babylonjs-gui": "5.0.0-alpha.34",
+    "babylonjs-loaders": "5.0.0-alpha.34",
+    "babylonjs-materials": "5.0.0-alpha.34",
     "jsc-android": "^241213.1.0",
     "v8-android": "^7.8.2"
   }


### PR DESCRIPTION
The main purpose of this upgrade is to pull in the changes that take advantage of the new NativeOptimizations plugin.

I also downgraded the package lock to version 1 (by using npm 6 instead of 7) to be consistent with Babylon React Native.