### PR TITLE
Fixing behavior bug resulting from FrameBuffers being owned by JavaSc…

### DIFF
--- a/Core/Graphics/Source/FrameBuffer.cpp
+++ b/Core/Graphics/Source/FrameBuffer.cpp
@@ -37,7 +37,7 @@ namespace Babylon
 
     FrameBuffer::~FrameBuffer()
     {
-        assert(!bgfx::isValid(m_handle));
+        Dispose();
     }
 
     bgfx::FrameBufferHandle FrameBuffer::Handle() const

--- a/Core/Graphics/Source/FrameBuffer.cpp
+++ b/Core/Graphics/Source/FrameBuffer.cpp
@@ -37,10 +37,7 @@ namespace Babylon
 
     FrameBuffer::~FrameBuffer()
     {
-        if (bgfx::isValid(m_handle))
-        {
-            bgfx::destroy(m_handle);
-        }
+        assert(!bgfx::isValid(m_handle));
     }
 
     bgfx::FrameBufferHandle FrameBuffer::Handle() const
@@ -61,6 +58,15 @@ namespace Babylon
     bool FrameBuffer::DefaultBackBuffer() const
     {
         return m_defaultBackBuffer;
+    }
+
+    void FrameBuffer::Dispose()
+    {
+        if (bgfx::isValid(m_handle))
+        {
+            bgfx::destroy(m_handle);
+        }
+        m_handle = BGFX_INVALID_HANDLE;
     }
 
     void FrameBuffer::Bind(bgfx::Encoder& encoder)

--- a/Core/Graphics/Source/FrameBuffer.h
+++ b/Core/Graphics/Source/FrameBuffer.h
@@ -31,6 +31,8 @@ namespace Babylon
         uint16_t Height() const;
         bool DefaultBackBuffer() const;
 
+        void Dispose();
+
         void Bind(bgfx::Encoder& encoder);
         void Unbind(bgfx::Encoder& encoder);
 

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1459,8 +1459,10 @@ namespace Babylon
         return Napi::External<FrameBuffer>::New(info.Env(), frameBuffer, [](Napi::Env, FrameBuffer* frameBuffer) { delete frameBuffer; });
     }
 
-    void NativeEngine::DeleteFrameBuffer(const Napi::CallbackInfo&)
+    void NativeEngine::DeleteFrameBuffer(const Napi::CallbackInfo& info)
     {
+        auto frameBuffer{info[0].As<Napi::External<FrameBuffer>>().Data()};
+        frameBuffer->Dispose();
     }
 
     void NativeEngine::BindFrameBuffer(const Napi::CallbackInfo& info)


### PR DESCRIPTION
…ript, which could allow underlying native framebuffers to be more long-lived than intended. This could result in crashes if the texture underneath the framebuffer was externally-owned because that texture could die before JavaScript garbage collected its ownership, which would leave bgfx holding onto an active pointer to a dead underlying texture. Fixed this by adding a dispose so that the native framebuffer is explicitly cleaned up, decoupling its lifespan from JS garbage collection.

Fixes #852.