### PR TITLE
Fix Dynamic texture flag for Canvas

### DIFF
--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -26,6 +26,7 @@ add_subdirectory(bgfx.cmake)
 target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_DEBUG_UNIFORM=0)
 target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_MULTITHREADED=1)
 target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_MAX_VERTEX_STREAMS=32)
+target_compile_definitions(bgfx PRIVATE BGFX_GL_CONFIG_BLIT_EMULATION=1)
 target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_MAX_COMMAND_BUFFER_SIZE=12582912)
 if(APPLE)
     # no Vulkan on Apple but Metal

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -129,13 +129,13 @@ namespace Babylon
 
         void CreateBlitTexture(TextureData* texture)
         {
-            if (texture->Flags & BGFX_TEXTURE_BLIT_DST)
+            if (texture->CreationFlags & BGFX_TEXTURE_BLIT_DST)
             {
                 return;
             }
             bgfx::destroy(texture->Handle);
             texture->Handle = bgfx::createTexture2D((uint16_t)texture->Width, (uint16_t)texture->Height, false, 1, bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_BLIT_DST);
-            texture->Flags |= BGFX_TEXTURE_BLIT_DST;
+            texture->CreationFlags |= BGFX_TEXTURE_BLIT_DST;
         }
 
         void CreateCubeTextureFromImages(TextureData* texture, const std::vector<bimg::ImageContainer*>& images, bool hasMips)

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -42,6 +42,9 @@ namespace Babylon
         uint32_t Width{0};
         uint32_t Height{0};
         uint32_t Flags{0};
+        // CreationFlags contains flags used at texture creation
+        // regarding BLIT support and READBACK
+        uint64_t CreationFlags{0};
         uint8_t AnisotropicLevel{0};
     };
 


### PR DESCRIPTION
Fix bug reported by @Alex-MSFT 
- Enable blit emulation for OpenGL (blit not natively supported on Android Emulator. Good catch Alex!)
- Fix BLIT flag for textures. Texture was recreated each frame and made the blit to fail when updating the canvas each frame.