### PR TITLE
Replace C++ GoogleTest tests with JS tests using Mocha and Chai

### DIFF
--- a/Apps/UnitTests/CMakeLists.txt
+++ b/Apps/UnitTests/CMakeLists.txt
@@ -3,22 +3,42 @@ if((NOT WIN32) OR WINDOWS_STORE)
     message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}")
 endif()
 
-include(FetchContent)
-FetchContent_Declare(
-  googletest
-  # Specify the commit you depend on and update it regularly.
-  URL https://github.com/google/googletest/archive/23ef29555ef4789f555f1ba8c51b4c52975f0907.zip
-)
-# Downloads the google test source and binaries and places them in in /build/<platform>/_deps
-FetchContent_MakeAvailable(googletest)
+set(SCRIPTS
+    "Scripts/tests.js")
 
-add_executable(UnitTests "UnitTests.cpp")
+set(BABYLON_SCRIPTS
+    "../node_modules/babylonjs-loaders/babylonjs.loaders.js"
+    "../node_modules/babylonjs-loaders/babylonjs.loaders.js.map"
+    "../node_modules/babylonjs/babylon.max.js"
+    "../node_modules/babylonjs/babylon.max.js.map"
+    "../node_modules/babylonjs-materials/babylonjs.materials.js"
+    "../node_modules/babylonjs-materials/babylonjs.materials.js.map"
+    "../node_modules/babylonjs-gui/babylon.gui.js"
+    "../node_modules/babylonjs-gui/babylon.gui.js.map")
+
+add_executable(UnitTests ${SCRIPTS} ${BABYLON_SCRIPTS} "UnitTests.cpp")
 
 target_link_libraries(UnitTests
-    gtest_main
-    UrlLib)
+    UrlLib
+    AppRuntime
+    XMLHttpRequest
+    NativeEngine
+    ScriptLoader
+    Console
+    Window
+    )
 
 add_test(NAME UnitTests COMMAND UnitTests)
 
+foreach(SCRIPT ${SCRIPTS} ${BABYLON_SCRIPTS})
+    get_filename_component(SCRIPT_NAME "${SCRIPT}" NAME)
+    add_custom_command(
+        OUTPUT "${CMAKE_CFG_INTDIR}/Scripts/${SCRIPT_NAME}"
+        COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/${SCRIPT}" "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/Scripts/${SCRIPT_NAME}"
+        COMMENT "Copying ${SCRIPT_NAME}"
+        MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/${SCRIPT}")
+endforeach()
+
 set_property(TARGET UnitTests PROPERTY FOLDER Apps)
-set_property(TARGET gtest gtest_main gmock gmock_main PROPERTY FOLDER "Dependencies/GoogleTest")
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SCRIPTS})
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/../node_modules PREFIX Scripts FILES ${BABYLON_SCRIPTS})

--- a/Apps/UnitTests/CMakeLists.txt
+++ b/Apps/UnitTests/CMakeLists.txt
@@ -7,14 +7,8 @@ set(SCRIPTS
     "Scripts/tests.js")
 
 set(BABYLON_SCRIPTS
-    "../node_modules/babylonjs-loaders/babylonjs.loaders.js"
-    "../node_modules/babylonjs-loaders/babylonjs.loaders.js.map"
     "../node_modules/babylonjs/babylon.max.js"
-    "../node_modules/babylonjs/babylon.max.js.map"
-    "../node_modules/babylonjs-materials/babylonjs.materials.js"
-    "../node_modules/babylonjs-materials/babylonjs.materials.js.map"
-    "../node_modules/babylonjs-gui/babylon.gui.js"
-    "../node_modules/babylonjs-gui/babylon.gui.js.map")
+    "../node_modules/babylonjs/babylon.max.js.map")
 
 add_executable(UnitTests ${SCRIPTS} ${BABYLON_SCRIPTS} "UnitTests.cpp")
 
@@ -25,8 +19,7 @@ target_link_libraries(UnitTests
     NativeEngine
     ScriptLoader
     Console
-    Window
-    )
+    Window)
 
 add_test(NAME UnitTests COMMAND UnitTests)
 

--- a/Apps/UnitTests/Scripts/tests.js
+++ b/Apps/UnitTests/Scripts/tests.js
@@ -2,24 +2,24 @@
 function BabylonReporter(runner) {
     const stats = runner.stats;
 
-    runner.on("pass", function (test) {
+    runner.on("pass", test => {
         console.log(`Passed: ${test.fullTitle()}`);
     });
 
-    runner.on("fail", function (test, err) {
+    runner.on("fail", (test, err) => {
         console.log(`Failed: ${test.fullTitle()} with error: ${err.message}`);
     });
 
-    runner.on("end", function () {
+    runner.on("end", () => {
         console.log(`Total passed: ${stats.passes}/${stats.tests} tests`);
     });
 }
 
 mocha.setup({ ui: "bdd", reporter: BabylonReporter });
 
-function makeXHR(method, url) {
+function createRequest(method, url) {
     return new Promise( (resolve, reject) => {
-        var xhr = new XMLHttpRequest();
+        const xhr = new XMLHttpRequest();
         xhr.open(method, url);
         xhr.addEventListener("loadend", () => resolve(xhr));
         xhr.send();
@@ -31,21 +31,21 @@ const expect = chai.expect;
 describe("XMLHTTPRequest", function () {
     this.timeout(0);
     it("should have readyState=4 when load ends", async function () {
-        const xhr = await makeXHR("GET", "https://babylonjs.com");
+        const xhr = await createRequest("GET", "https://babylonjs.com");
         expect(xhr.readyState).to.equal(4);
     })
     it("should have status=200 for a valid page", async function () {
-        const xhr = await makeXHR("GET", "https://babylonjs.com");
+        const xhr = await createRequest("GET", "https://babylonjs.com");
         expect(xhr.status).to.equal(200);
     })
     it("should have status=404 for a page that does not exist", async function () {
-        const xhr = await makeXHR("GET", "https://babylonjs.com/invalid");
+        const xhr = await createRequest("GET", "https://babylonjs.com/invalid");
         expect(xhr.status).to.equal(404);
     })
 
 });
 
 
-mocha.run(function (failures) {
+mocha.run( failures => {
     // TODO: set exit code if any tests failed
 });

--- a/Apps/UnitTests/Scripts/tests.js
+++ b/Apps/UnitTests/Scripts/tests.js
@@ -2,20 +2,20 @@
 function BabylonReporter(runner) {
     const stats = runner.stats;
 
-    runner.on('pass', function (test) {
+    runner.on("pass", function (test) {
         console.log(`Passed: ${test.fullTitle()}`);
     });
 
-    runner.on('fail', function (test, err) {
+    runner.on("fail", function (test, err) {
         console.log(`Failed: ${test.fullTitle()} with error: ${err.message}`);
     });
 
-    runner.on('end', function () {
+    runner.on("end", function () {
         console.log(`Total passed: ${stats.passes}/${stats.tests} tests`);
     });
 }
 
-mocha.setup({ ui: 'bdd', reporter: BabylonReporter });
+mocha.setup({ ui: "bdd", reporter: BabylonReporter });
 
 function makeXHR(method, url) {
     return new Promise( (resolve, reject) => {
@@ -28,18 +28,18 @@ function makeXHR(method, url) {
 
 const expect = chai.expect;
 
-describe('XMLHTTPRequest', function () {
+describe("XMLHTTPRequest", function () {
     this.timeout(0);
-    it('should have readyState=4 when load ends', async function () {
+    it("should have readyState=4 when load ends", async function () {
         const xhr = await makeXHR("GET", "https://babylonjs.com");
         expect(xhr.readyState).to.equal(4);
     })
-    it('should have status=200 for a valid page', async function () {
+    it("should have status=200 for a valid page", async function () {
         const xhr = await makeXHR("GET", "https://babylonjs.com");
         expect(xhr.status).to.equal(200);
     })
-    it('should have status=404 for a page that does not exist', async function () {
-        const xhr = await makeXHR('GET', 'https://babylonjs.com/invalid');
+    it("should have status=404 for a page that does not exist", async function () {
+        const xhr = await makeXHR("GET", "https://babylonjs.com/invalid");
         expect(xhr.status).to.equal(404);
     })
 

--- a/Apps/UnitTests/Scripts/tests.js
+++ b/Apps/UnitTests/Scripts/tests.js
@@ -18,7 +18,7 @@ function BabylonReporter(runner) {
 mocha.setup({ ui: "bdd", reporter: BabylonReporter });
 
 function createRequest(method, url) {
-    return new Promise( (resolve, reject) => {
+    return new Promise((resolve, reject) => {
         const xhr = new XMLHttpRequest();
         xhr.open(method, url);
         xhr.addEventListener("loadend", () => resolve(xhr));
@@ -46,6 +46,6 @@ describe("XMLHTTPRequest", function () {
 });
 
 
-mocha.run( failures => {
+mocha.run(failures => {
     // TODO: set exit code if any tests failed
 });

--- a/Apps/UnitTests/Scripts/tests.js
+++ b/Apps/UnitTests/Scripts/tests.js
@@ -1,0 +1,51 @@
+﻿// TODO: use premade reporter (once Console Polyfill is fixed)
+function BabylonReporter(runner) {
+    const stats = runner.stats;
+
+    runner.on('pass', function (test) {
+        console.log(`Passed: ${test.fullTitle()}`);
+    });
+
+    runner.on('fail', function (test, err) {
+        console.log(`Failed: ${test.fullTitle()} with error: ${err.message}`);
+    });
+
+    runner.on('end', function () {
+        console.log(`Total passed: ${stats.passes}/${stats.tests} tests`);
+    });
+}
+
+mocha.setup({ ui: 'bdd', reporter: BabylonReporter });
+
+function makeXHR(method, url) {
+    return new Promise( (resolve, reject) => {
+        var xhr = new XMLHttpRequest();
+        xhr.open(method, url);
+        xhr.addEventListener("loadend", () => resolve(xhr));
+        xhr.send();
+    });
+}
+
+const expect = chai.expect;
+
+describe('XMLHTTPRequest', function () {
+    this.timeout(0);
+    it('should have readyState=4 when load ends', async function () {
+        const xhr = await makeXHR("GET", "https://babylonjs.com");
+        expect(xhr.readyState).to.equal(4);
+    })
+    it('should have status=200 for a valid page', async function () {
+        const xhr = await makeXHR("GET", "https://babylonjs.com");
+        expect(xhr.status).to.equal(200);
+    })
+    it('should have status=404 for a page that does not exist', async function () {
+        const xhr = await makeXHR('GET', 'https://babylonjs.com/invalid');
+        expect(xhr.status).to.equal(404);
+    })
+
+});
+
+
+mocha.run(function (failures) {
+    // TODO: set exit code if any tests failed
+});

--- a/Apps/UnitTests/UnitTests.cpp
+++ b/Apps/UnitTests/UnitTests.cpp
@@ -37,9 +37,6 @@ int main()
     loader.Eval("window.clearTimeout = () => {};", ""); // TODO: implement clear timeout, required for Mocha timeouts to work correctly
     loader.Eval("location = {href: ''};", "");          // Required for Mocha.js as we do not have a location in Babylon Native
     loader.LoadScript("app:///Scripts/babylon.max.js");
-    loader.LoadScript("app:///Scripts/babylonjs.loaders.js");
-    loader.LoadScript("app:///Scripts/babylonjs.materials.js");
-    loader.LoadScript("app:///Scripts/babylon.gui.js");
     loader.LoadScript("https://unpkg.com/chai/chai.js");
     loader.LoadScript("https://unpkg.com/mocha/mocha.js");
     loader.LoadScript("app:///Scripts/tests.js");

--- a/Apps/UnitTests/UnitTests.cpp
+++ b/Apps/UnitTests/UnitTests.cpp
@@ -1,27 +1,48 @@
 #pragma once
-#include "gtest/gtest.h"
 #include <UrlLib/UrlLib.h>
 #include <arcana/threading/task.h>
+#include <future>
+#include <Babylon/AppRuntime.h>
+#include <Babylon/Graphics.h>
+#include <Babylon/Polyfills/XMLHttpRequest.h>
+#include <Babylon/Polyfills/Console.h>
+#include <Babylon/Polyfills/Window.h>
+#include <Babylon/Plugins/NativeEngine.h>
+#include <Babylon/ScriptLoader.h>
+#include <chrono>
+#include <thread>
 
-namespace Babylon
+std::unique_ptr<Babylon::AppRuntime> runtime{};
+std::unique_ptr<Babylon::Graphics> graphics{};
+
+int main()
 {
-    // Waits for an arcana task to complete before continuing
-    void WaitForCompletion(arcana::task<void, std::exception_ptr> task) {
-        // The boolean flag is a temporary hack that should be replaced by proper synchronization code
-        bool done{false};
-        task.then(arcana::inline_scheduler, arcana::cancellation::none(), [&done](arcana::expected<void, std::exception_ptr> result) {
-            done = true;
-        });
-        while (!done);
-    }
+    Babylon::ContextConfiguration graphicsConfig{};
+    graphics = Babylon::Graphics::CreateGraphics(graphicsConfig);
 
-    TEST(URLLibTest, EmptyUrl)
-    {
-        UrlLib::UrlRequest req;
-        req.Open(UrlLib::UrlMethod::Get, "");
-        WaitForCompletion(req.SendAsync());
-        ASSERT_EQ(req.ResponseType(), UrlLib::UrlResponseType::String);
-        ASSERT_EQ(req.ResponseString(), "");
-        ASSERT_EQ(req.StatusCode(), UrlLib::UrlStatusCode::None);
-    }
+    runtime = std::make_unique<Babylon::AppRuntime>();
+    runtime->Dispatch([](Napi::Env env) {
+        graphics->AddToJavaScript(env);
+
+        Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+        Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
+            printf("%s", message);
+            fflush(stdout);
+        });
+        Babylon::Polyfills::Window::Initialize(env);
+        Babylon::Plugins::NativeEngine::Initialize(env);
+    });
+    Babylon::ScriptLoader loader{*runtime};
+    loader.Eval("global = {};", ""); // Required for Chai.js as we do not have global in Babylon Native
+    loader.Eval("window.clearTimeout = () => {};", ""); // TODO: implement clear timeout, required for Mocha timeouts to work correctly
+    loader.Eval("location = {href: ''};", "");          // Required for Mocha.js as we do not have a location in Babylon Native
+    loader.LoadScript("app:///Scripts/babylon.max.js");
+    loader.LoadScript("app:///Scripts/babylonjs.loaders.js");
+    loader.LoadScript("app:///Scripts/babylonjs.materials.js");
+    loader.LoadScript("app:///Scripts/babylon.gui.js");
+    loader.LoadScript("https://unpkg.com/chai/chai.js");
+    loader.LoadScript("https://unpkg.com/mocha/mocha.js");
+    loader.LoadScript("app:///Scripts/tests.js");
+    // TODO: add mechanism to wait until an exit code is received from tests.js
+    std::this_thread::sleep_for(std::chrono::seconds(1000000));
 }


### PR DESCRIPTION
Removes GoogleTest dependency and C++ tests for UrlLib. In their place, adds basic Javascript tests for XMLHTTPRequest using Mocha.js and Chai.js.

Includes several hacks that should be cleaned up, marked with TODOs.

Creates base framework for #802.