### PR TITLE
Comment out recast.js on windows

### DIFF
--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -306,7 +306,8 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
     Babylon::ScriptLoader loader{*m_runtime};
     loader.Eval("document = {}", "");
     loader.LoadScript("app:///Scripts/ammo.js");
-    loader.LoadScript("app:///Scripts/recast.js");
+    // Commenting out recast.js for now as v8jsi is incompatible with asm.js.
+    // loader.LoadScript("app:///Scripts/recast.js");
     loader.LoadScript("app:///Scripts/babylon.max.js");
     loader.LoadScript("app:///Scripts/babylonjs.loaders.js");
     loader.LoadScript("app:///Scripts/babylonjs.materials.js");

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -150,6 +150,7 @@ namespace
         Babylon::ScriptLoader loader{*runtime};
         loader.Eval("document = {}", "");
         loader.LoadScript("app:///Scripts/ammo.js");
+        // Commenting out recast.js for now because v8jsi is incompatible with asm.js.
         // loader.LoadScript("app:///Scripts/recast.js");
         loader.LoadScript("app:///Scripts/babylon.max.js");
         loader.LoadScript("app:///Scripts/babylonjs.loaders.js");


### PR DESCRIPTION
We need to comment out the lines loading recast.js on Win32 and UWP because v8jsi is currently incompatible with asm.js scripts.

I also forgot to add a comment explaining why we were commenting out the file.