### PR TITLE
Native resource handles + command buffer

### DIFF
--- a/Core/Graphics/Source/FrameBuffer.cpp
+++ b/Core/Graphics/Source/FrameBuffer.cpp
@@ -37,7 +37,11 @@ namespace Babylon
 
     FrameBuffer::~FrameBuffer()
     {
-        Dispose();
+        if (bgfx::isValid(m_handle))
+        {
+            bgfx::destroy(m_handle);
+        }
+        m_handle = BGFX_INVALID_HANDLE;
     }
 
     bgfx::FrameBufferHandle FrameBuffer::Handle() const
@@ -58,15 +62,6 @@ namespace Babylon
     bool FrameBuffer::DefaultBackBuffer() const
     {
         return m_defaultBackBuffer;
-    }
-
-    void FrameBuffer::Dispose()
-    {
-        if (bgfx::isValid(m_handle))
-        {
-            bgfx::destroy(m_handle);
-        }
-        m_handle = BGFX_INVALID_HANDLE;
     }
 
     void FrameBuffer::Bind(bgfx::Encoder& encoder)

--- a/Core/Graphics/Source/FrameBuffer.h
+++ b/Core/Graphics/Source/FrameBuffer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ResourceManagement.h"
 #include <bgfx/bgfx.h>
 #include <optional>
 
@@ -17,7 +18,7 @@ namespace Babylon
         bool Equals(const ViewPort& other) const;
     };
 
-    class FrameBuffer
+    class FrameBuffer final : public NativeResource<FrameBuffer>
     {
     public:
         FrameBuffer(GraphicsImpl& impl, bgfx::FrameBufferHandle handle, uint16_t width, uint16_t height, bool defaultBackBuffer, bool hasDepth, bool hasStencil);
@@ -30,8 +31,6 @@ namespace Babylon
         uint16_t Width() const;
         uint16_t Height() const;
         bool DefaultBackBuffer() const;
-
-        void Dispose();
 
         void Bind(bgfx::Encoder& encoder);
         void Unbind(bgfx::Encoder& encoder);

--- a/Core/Graphics/Source/ResourceManagement.h
+++ b/Core/Graphics/Source/ResourceManagement.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <unordered_map>
 
 namespace Babylon
@@ -37,13 +38,13 @@ namespace Babylon
     public:
         static T& Get(uint32_t handle)
         {
-            return s_resources.Get(handle);
+            return *s_resources.Get(handle);
         }
 
         template<typename... Args>
         static uint32_t Create(Args&&... args)
         {
-            return s_resources.Add({std::forward<Args>(args)...});
+            return s_resources.Add(std::make_unique<T>(std::forward<Args>(args)...));
         }
 
         static void Delete(uint32_t handle)
@@ -52,6 +53,6 @@ namespace Babylon
         }
 
     private:
-        inline static ResourceTable<T> s_resources{};
+        inline static ResourceTable<std::unique_ptr<T>> s_resources{};
     };
 }

--- a/Core/Graphics/Source/ResourceManagement.h
+++ b/Core/Graphics/Source/ResourceManagement.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <unordered_map>
+
+namespace Babylon
+{
+    template<typename T>
+    class ResourceTable final
+    {
+    public:
+        uint32_t Add(T resource)
+        {
+            const uint32_t resourceHandle{m_nextResourceId};
+            m_resources.insert({resourceHandle, std::move(resource)});
+            m_nextResourceId++;
+            return resourceHandle;
+        }
+
+        T& Get(uint32_t resourceHandle)
+        {
+            return m_resources.at(resourceHandle);
+        }
+
+        void Remove(uint32_t resourceHandle)
+        {
+            m_resources.erase(resourceHandle);
+        }
+
+    private:
+        uint32_t m_nextResourceId{1};
+        std::unordered_map<uint32_t, T> m_resources{};
+    };
+
+    template<typename T>
+    struct NativeResource
+    {
+    public:
+        static T& Get(uint32_t handle)
+        {
+            return s_resources.Get(handle);
+        }
+
+        template<typename... Args>
+        static uint32_t Create(Args&&... args)
+        {
+            return s_resources.Add({std::forward<Args>(args)...});
+        }
+
+        static void Delete(uint32_t handle)
+        {
+            s_resources.Remove(handle);
+        }
+
+    private:
+        inline static ResourceTable<T> s_resources{};
+    };
+}

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -705,18 +705,37 @@ namespace xr {
             id<MTLFunction> vertexFunction = [lib newFunctionWithName:@"vertexShader"];
             id<MTLFunction> fragmentFunction = [lib newFunctionWithName:@"fragmentShader"];
 
-            // Configure a pipeline descriptor that is used to create a pipeline state.
-            MTLRenderPipelineDescriptor *pipelineStateDescriptor = [[MTLRenderPipelineDescriptor alloc] init];
-            pipelineStateDescriptor.label = @"XR Pipeline";
-            pipelineStateDescriptor.vertexFunction = vertexFunction;
-            pipelineStateDescriptor.fragmentFunction = fragmentFunction;
-            pipelineStateDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+            // Create a pipeline state for drawing the camera texture to the render target texture.
+            {
 
-            // build pipeline
-            NSError* error;
-            pipelineState = [metalDevice newRenderPipelineStateWithDescriptor:pipelineStateDescriptor error:&error];
-            if (!pipelineState) {
-                NSLog(@"Failed to create pipeline state: %@", error);
+                MTLRenderPipelineDescriptor *pipelineStateDescriptor = [[MTLRenderPipelineDescriptor alloc] init];
+                pipelineStateDescriptor.label = @"XR Camera Pipeline";
+                pipelineStateDescriptor.vertexFunction = vertexFunction;
+                pipelineStateDescriptor.fragmentFunction = fragmentFunction;
+                pipelineStateDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+                pipelineStateDescriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
+                pipelineStateDescriptor.stencilAttachmentPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
+
+                NSError* error;
+                cameraPipelineState = [metalDevice newRenderPipelineStateWithDescriptor:pipelineStateDescriptor error:&error];
+                if (!cameraPipelineState) {
+                    NSLog(@"Failed to create camera pipeline state: %@", error);
+                }
+            }
+
+            // Create a pipeline state for drawing the final composited texture to the screen.
+            {
+                MTLRenderPipelineDescriptor *pipelineStateDescriptor = [[MTLRenderPipelineDescriptor alloc] init];
+                pipelineStateDescriptor.label = @"XR Screen Pipeline";
+                pipelineStateDescriptor.vertexFunction = vertexFunction;
+                pipelineStateDescriptor.fragmentFunction = fragmentFunction;
+                pipelineStateDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+
+                NSError* error;
+                screenPipelineState = [metalDevice newRenderPipelineStateWithDescriptor:pipelineStateDescriptor error:&error];
+                if (!screenPipelineState) {
+                    NSLog(@"Failed to create screen pipeline state: %@", error);
+                }
             }
 
             commandQueue = [metalDevice newCommandQueue];
@@ -853,7 +872,7 @@ namespace xr {
 
             // Draw the camera texture to the color texture and clear the depth texture before handing them off to Babylon.
             id<MTLCommandBuffer> commandBuffer = [commandQueue commandBuffer];
-            commandBuffer.label = @"DrawCameraToBabylonTextureCommandBuffer";
+            commandBuffer.label = @"XRCameraCommandBuffer";
             MTLRenderPassDescriptor *renderPassDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
 
             id<MTLTexture> cameraTextureY = nil;
@@ -865,27 +884,27 @@ namespace xr {
 
             @try {
                 if(renderPassDescriptor != nil) {
-                    // Attach the color texture, on which we'll draw the camera texture.
+                    // Attach the color texture, on which we'll draw the camera texture (so no need to clear on load).
                     renderPassDescriptor.colorAttachments[0].texture = (__bridge id<MTLTexture>)ActiveFrameViews[0].ColorTexturePointer;
                     renderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionDontCare;
                     renderPassDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
 
-                    // Clear the depth texture
+                    // Attach the depth texture, which should be cleared on load.
                     renderPassDescriptor.depthAttachment.texture = (__bridge id<MTLTexture>)ActiveFrameViews[0].DepthTexturePointer;
                     renderPassDescriptor.depthAttachment.loadAction = MTLLoadActionClear;
                     renderPassDescriptor.depthAttachment.storeAction = MTLStoreActionStore;
 
-                    // Clear the stencil texture
+                    // Attach the stencil texture, which should be cleared on load.
                     renderPassDescriptor.stencilAttachment.texture = (__bridge id<MTLTexture>)ActiveFrameViews[0].DepthTexturePointer;
                     renderPassDescriptor.stencilAttachment.loadAction = MTLLoadActionClear;
                     renderPassDescriptor.stencilAttachment.storeAction = MTLStoreActionStore;
 
                     // Create and end the render encoder.
                     id<MTLRenderCommandEncoder> renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:renderPassDescriptor];
-                    renderEncoder.label = @"DrawCameraToBabylonTextureEncoder";
+                    renderEncoder.label = @"XRCameraEncoder";
 
                     // Set the shader pipeline.
-                    [renderEncoder setRenderPipelineState:pipelineState];
+                    [renderEncoder setRenderPipelineState:cameraPipelineState];
 
                     // Set the vertex data.
                     [renderEncoder setVertexBytes:vertices length:sizeof(vertices) atIndex:0];
@@ -926,7 +945,7 @@ namespace xr {
             if (metalLayer) {
                 // Create a new command buffer for each render pass to the current drawable.
                 id<MTLCommandBuffer> commandBuffer = [commandQueue commandBuffer];
-                commandBuffer.label = @"XRDisplayCommandBuffer";
+                commandBuffer.label = @"XRScreenCommandBuffer";
 
                 id<CAMetalDrawable> drawable = [metalLayer nextDrawable];
                 MTLRenderPassDescriptor *renderPassDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
@@ -937,13 +956,13 @@ namespace xr {
 
                     // Create a render command encoder.
                     id<MTLRenderCommandEncoder> renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:renderPassDescriptor];
-                    renderEncoder.label = @"XRDisplayEncoder";
+                    renderEncoder.label = @"XRScreenEncoder";
 
                     // Set the region of the drawable to draw into.
                     [renderEncoder setViewport:(MTLViewport){0.0, 0.0, static_cast<double>(viewportSize.x), static_cast<double>(viewportSize.y), 0.0, 1.0 }];
 
                     // Set the shader pipeline.
-                    [renderEncoder setRenderPipelineState:pipelineState];
+                    [renderEncoder setRenderPipelineState:screenPipelineState];
 
                     // Set the vertex data.
                     [renderEncoder setVertexBytes:vertices length:sizeof(vertices) atIndex:0];
@@ -1328,7 +1347,8 @@ namespace xr {
         CAMetalLayer* metalLayer{};
 #pragma clang diagnostic pop
         SessionDelegate* sessionDelegate{};
-        id<MTLRenderPipelineState> pipelineState{};
+        id<MTLRenderPipelineState> cameraPipelineState{};
+        id<MTLRenderPipelineState> screenPipelineState{};
         vector_uint2 viewportSize{};
         id<MTLCommandQueue> commandQueue;
         std::vector<ARAnchor*> nativeAnchors{};

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -707,7 +707,6 @@ namespace xr {
 
             // Create a pipeline state for drawing the camera texture to the render target texture.
             {
-
                 MTLRenderPipelineDescriptor *pipelineStateDescriptor = [[MTLRenderPipelineDescriptor alloc] init];
                 pipelineStateDescriptor.label = @"XR Camera Pipeline";
                 pipelineStateDescriptor.vertexFunction = vertexFunction;

--- a/Plugins/NativeCamera/Source/NativeCamera.cpp
+++ b/Plugins/NativeCamera/Source/NativeCamera.cpp
@@ -115,6 +115,7 @@ namespace Babylon
 
             void UpdateVideoTexture(const Napi::CallbackInfo& info)
             {
+                // TODO
                 const auto texture = info[0].As<Napi::External<TextureData>>().Data();
                 auto videoObject = NativeVideo::Unwrap(info[1].As<Napi::Object>());
 

--- a/Plugins/NativeCamera/Source/NativeCamera.cpp
+++ b/Plugins/NativeCamera/Source/NativeCamera.cpp
@@ -115,7 +115,7 @@ namespace Babylon
 
             void UpdateVideoTexture(const Napi::CallbackInfo& info)
             {
-                // TODO
+                // TODO (ryantrem)
                 const auto texture = info[0].As<Napi::External<TextureData>>().Data();
                 auto videoObject = NativeVideo::Unwrap(info[1].As<Napi::Object>());
 

--- a/Plugins/NativeCapture/Source/NativeCapture.cpp
+++ b/Plugins/NativeCapture/Source/NativeCapture.cpp
@@ -169,6 +169,7 @@ namespace Babylon::Plugins::Internal
             }
             else if (info.Length() > 0 && !info[0].IsNull() && !info[0].IsUndefined())
             {
+                // TODO (ryantrem)
                 if (!info[0].IsExternal())
                 {
                     throw Napi::Error::New(info.Env(), "Argument passed to NativeCapture constructor must be a Napi::External containing a native FrameBuffer.");

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -182,13 +182,34 @@ namespace Babylon
         }
     }
 
+    IndexBufferData::IndexBufferData(IndexBufferData&& other)
+    {
+        m_handle = other.m_handle;
+
+        constexpr auto nonDynamic = [](auto& handle) {
+            // TODO: Fix this const cast
+            const_cast<bgfx::IndexBufferHandle&>(handle).idx = bgfx::kInvalidHandle;
+        };
+        constexpr auto dynamic = [](auto& handle) {
+            // TODO: Fix this const cast
+            const_cast<bgfx::DynamicIndexBufferHandle&>(handle).idx = bgfx::kInvalidHandle;
+        };
+        other.DoForHandleTypes(nonDynamic, dynamic);
+    }
+
     IndexBufferData::~IndexBufferData()
     {
         constexpr auto nonDynamic = [](auto handle) {
-            bgfx::destroy(handle);
+            if (handle.idx != bgfx::kInvalidHandle)
+            {
+                bgfx::destroy(handle);
+            }
         };
         constexpr auto dynamic = [](auto handle) {
-            bgfx::destroy(handle);
+            if (handle.idx != bgfx::kInvalidHandle)
+            {
+                bgfx::destroy(handle);
+            }
         };
         DoForHandleTypes(nonDynamic, dynamic);
     }

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -182,21 +182,6 @@ namespace Babylon
         }
     }
 
-    IndexBufferData::IndexBufferData(IndexBufferData&& other)
-    {
-        m_handle = other.m_handle;
-
-        constexpr auto nonDynamic = [](auto& handle) {
-            // TODO: Fix this const cast
-            const_cast<bgfx::IndexBufferHandle&>(handle).idx = bgfx::kInvalidHandle;
-        };
-        constexpr auto dynamic = [](auto& handle) {
-            // TODO: Fix this const cast
-            const_cast<bgfx::DynamicIndexBufferHandle&>(handle).idx = bgfx::kInvalidHandle;
-        };
-        other.DoForHandleTypes(nonDynamic, dynamic);
-    }
-
     IndexBufferData::~IndexBufferData()
     {
         constexpr auto nonDynamic = [](auto handle) {
@@ -238,7 +223,7 @@ namespace Babylon
         DoForHandleTypes(nonDynamic, dynamic);
     }
 
-    class VertexBufferData final : VariantHandleHolder<bgfx::VertexBufferHandle, bgfx::DynamicVertexBufferHandle>
+    class VertexBufferData final : protected VariantHandleHolder<bgfx::VertexBufferHandle, bgfx::DynamicVertexBufferHandle>
     {
     public:
         VertexBufferData(const Napi::Uint8Array& bytes, bool dynamic)

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -638,26 +638,27 @@ namespace Babylon
 
         const uint16_t flags = data.TypedArrayType() == napi_typedarray_type::napi_uint16_array ? 0 : BGFX_BUFFER_INDEX32;
 
-        return Napi::External<IndexBufferData>::New(info.Env(), new IndexBufferData(data, flags, dynamic));
+        return Napi::Value::From(info.Env(), m_indexBuffers.Add(new IndexBufferData(data, flags, dynamic)));
     }
 
     void NativeEngine::DeleteIndexBuffer(const Napi::CallbackInfo& info)
     {
-        IndexBufferData* indexBufferData = info[0].As<Napi::External<IndexBufferData>>().Data();
+        const IndexBufferData* indexBufferData = m_indexBuffers.Get(info[1].ToNumber().Uint32Value());
+        m_indexBuffers.Remove(info[0].ToNumber().Uint32Value());
         delete indexBufferData;
     }
 
     void NativeEngine::RecordIndexBuffer(const Napi::CallbackInfo& info)
     {
         VertexArray& vertexArray = m_vertexArrays.Get(info[0].ToNumber().Uint32Value());
-        const IndexBufferData* indexBufferData = info[1].As<Napi::External<IndexBufferData>>().Data();
+        const IndexBufferData* indexBufferData = m_indexBuffers.Get(info[1].ToNumber().Uint32Value());
 
         vertexArray.indexBuffer.Data = indexBufferData;
     }
 
     void NativeEngine::UpdateDynamicIndexBuffer(const Napi::CallbackInfo& info)
     {
-        IndexBufferData& indexBufferData = *(info[0].As<Napi::External<IndexBufferData>>().Data());
+        IndexBufferData& indexBufferData = *m_indexBuffers.Get(info[0].ToNumber().Uint32Value());
 
         const Napi::TypedArray data = info[1].As<Napi::TypedArray>();
         const uint32_t startingIdx = info[2].As<Napi::Number>().Uint32Value();

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -627,25 +627,25 @@ namespace Babylon
 
         const uint16_t flags = data.TypedArrayType() == napi_typedarray_type::napi_uint16_array ? 0 : BGFX_BUFFER_INDEX32;
 
-        return Napi::Value::From(info.Env(), m_indexBuffers.Add({data, flags, dynamic}));
+        return Napi::Value::From(info.Env(), IndexBufferData::Create(data, flags, dynamic));
     }
 
     void NativeEngine::DeleteIndexBuffer(const Napi::CallbackInfo& info)
     {
-        m_indexBuffers.Remove(info[0].ToNumber().Uint32Value());
+        IndexBufferData::Delete(info[0].ToNumber().Uint32Value());
     }
 
     void NativeEngine::RecordIndexBuffer(const Napi::CallbackInfo& info)
     {
         VertexArray& vertexArray = m_vertexArrays.Get(info[0].ToNumber().Uint32Value());
-        const IndexBufferData& indexBufferData = m_indexBuffers.Get(info[1].ToNumber().Uint32Value());
+        const IndexBufferData& indexBufferData = IndexBufferData::Get(info[1].ToNumber().Uint32Value());
 
         vertexArray.indexBuffer.Data = &indexBufferData;
     }
 
     void NativeEngine::UpdateDynamicIndexBuffer(const Napi::CallbackInfo& info)
     {
-        IndexBufferData& indexBufferData = m_indexBuffers.Get(info[0].ToNumber().Uint32Value());
+        IndexBufferData& indexBufferData = IndexBufferData::Get(info[0].ToNumber().Uint32Value());
 
         const Napi::TypedArray data = info[1].As<Napi::TypedArray>();
         const uint32_t startingIdx = info[2].As<Napi::Number>().Uint32Value();

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1472,13 +1472,14 @@ namespace Babylon
         texture->OwnsHandle = false;
 
         auto* frameBuffer = new FrameBuffer(m_graphicsImpl, frameBufferHandle, width, height, false, generateDepth, generateStencilBuffer);
-        return Napi::External<FrameBuffer>::New(info.Env(), frameBuffer, [](Napi::Env, FrameBuffer* frameBuffer) { delete frameBuffer; });
+        return Napi::External<FrameBuffer>::New(info.Env(), frameBuffer);
     }
 
+    // TODO: This doesn't get called when an Engine instance is disposed.
     void NativeEngine::DeleteFrameBuffer(const Napi::CallbackInfo& info)
     {
         auto frameBuffer{info[0].As<Napi::External<FrameBuffer>>().Data()};
-        frameBuffer->Dispose();
+        delete frameBuffer;
     }
 
     void NativeEngine::BindFrameBuffer(const Napi::CallbackInfo& info)

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -450,7 +450,7 @@ namespace Babylon
                 InstanceMethod("setTextureSampling", &NativeEngine::SetTextureSampling),
                 InstanceMethod("setTextureWrapMode", &NativeEngine::SetTextureWrapMode),
                 InstanceMethod("setTextureAnisotropicLevel", &NativeEngine::SetTextureAnisotropicLevel),
-                InstanceMethod("setTexture", &NativeEngine::SetTexture),
+                //InstanceMethod("setTexture", &NativeEngine::SetTexture),
                 InstanceMethod("setTexture2", &NativeEngine::SetTexture2),
                 InstanceMethod("setTexture3", &NativeEngine::SetTexture3),
                 InstanceMethod("deleteTexture", &NativeEngine::DeleteTexture),
@@ -566,6 +566,7 @@ namespace Babylon
                 InstanceValue("STENCIL_OP_PASS_Z_INVERT", Napi::Number::From(env, BGFX_STENCIL_OP_PASS_Z_INVERT)),
 
                 InstanceValue("COMMAND_SETMATRICES", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetMatrices))),
+                InstanceValue("COMMAND_SETTEXTURE", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetTexture)))
             });
         // clang-format on
 
@@ -1416,14 +1417,27 @@ namespace Babylon
         }
     }
 
-    void NativeEngine::SetTexture(const Napi::CallbackInfo& info)
+//    void NativeEngine::SetTexture(const Napi::CallbackInfo& info)
+//    {
+//        bgfx::Encoder* encoder{GetUpdateToken().GetEncoder()};
+//
+//        const auto& uniformInfo = m_uniformInfos.Get(info[0].ToNumber().Uint32Value());
+//        const auto texture = &TextureData::Get(info[1].ToNumber().Uint32Value());
+//
+//        encoder->setTexture(uniformInfo.Stage, uniformInfo.Handle, texture->Handle, texture->Flags);
+//    }
+
+    void NativeEngine::SetTexture(CommandBufferDecoder& decoder)
     {
         bgfx::Encoder* encoder{GetUpdateToken().GetEncoder()};
 
-        const auto& uniformInfo = m_uniformInfos.Get(info[0].ToNumber().Uint32Value());
-        const auto texture = &TextureData::Get(info[1].ToNumber().Uint32Value());
+        const auto uniformHandle{decoder.DecodeCommandArgAsUInt32()};
+        const auto textureHandle{decoder.DecodeCommandArgAsUInt32()};
 
-        encoder->setTexture(uniformInfo.Stage, uniformInfo.Handle, texture->Handle, texture->Flags);
+        const auto& uniformInfo{m_uniformInfos.Get(uniformHandle)};
+        const auto& texture{TextureData::Get(textureHandle)};
+
+        encoder->setTexture(uniformInfo.Stage, uniformInfo.Handle, texture.Handle, texture.Flags);
     }
 
     void NativeEngine::SetTexture2(const Napi::CallbackInfo&) {}

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -444,7 +444,7 @@ namespace Babylon
                 InstanceMethod("createImageBitmap", &NativeEngine::CreateImageBitmap),
                 InstanceMethod("resizeImageBitmap", &NativeEngine::ResizeImageBitmap),
                 InstanceMethod("getFrameBufferData", &NativeEngine::GetFrameBufferData),
-                InstanceMethod("setStencil", &NativeEngine::SetStencil),
+                //InstanceMethod("setStencil", &NativeEngine::SetStencil),
                 InstanceMethod("setCommandBuffer", &NativeEngine::SetCommandBuffer),
                 InstanceMethod("setCommandUint32Buffer", &NativeEngine::SetCommandUint32Buffer),
                 InstanceMethod("setCommandFloat32Buffer", &NativeEngine::SetCommandFloat32Buffer),
@@ -550,7 +550,8 @@ namespace Babylon
                 InstanceValue("COMMAND_SETFLOAT4", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetFloat4))),
                 InstanceValue("COMMAND_SETTEXTUREWRAPMODE", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetTextureWrapMode))),
                 InstanceValue("COMMAND_DRAWINDEXED", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::DrawIndexed))),
-                InstanceValue("COMMAND_CLEAR", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::Clear)))
+                InstanceValue("COMMAND_CLEAR", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::Clear))),
+                InstanceValue("COMMAND_SETSTENCIL", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetStencil)))
             });
         // clang-format on
 
@@ -1876,15 +1877,42 @@ namespace Babylon
         });
     }
 
-    void NativeEngine::SetStencil(const Napi::CallbackInfo& info)
+//    void NativeEngine::SetStencil(const Napi::CallbackInfo& info)
+//    {
+//        const auto writeMask{info[0].As<Napi::Number>().Uint32Value()};
+//        const auto stencilOpFail{info[1].As<Napi::Number>().Uint32Value()};
+//        const auto depthOpFail{info[2].As<Napi::Number>().Uint32Value()};
+//        const auto depthOpPass{info[3].As<Napi::Number>().Uint32Value()};
+//        const auto func{info[4].As<Napi::Number>().Uint32Value()};
+//        const auto ref{info[5].As<Napi::Number>().Uint32Value()};
+//
+//        m_stencilState = BGFX_STENCIL_FUNC_RMASK(0xFF); //  always 0xFF
+//        m_stencilState |= stencilOpFail;
+//        m_stencilState |= depthOpFail;
+//        // bgfx write mask is always 0xFF, to not change stencil value when writemask is 0
+//        // its value is kept unchanged.
+//        // https://github.com/bkaradzic/bgfx/blob/2c21f68998595fa388e25cb6527e82254d0e9bff/src/renderer_d3d11.cpp#L2874
+//        if (writeMask == 0)
+//        {
+//            m_stencilState |= BGFX_STENCIL_OP_PASS_Z_KEEP;
+//        }
+//        else
+//        {
+//            m_stencilState |= depthOpPass;
+//        }
+//        m_stencilState |= func;
+//        m_stencilState |= BGFX_STENCIL_FUNC_REF(ref);
+//    }
+
+    void NativeEngine::SetStencil(CommandBufferDecoder& decoder)
     {
-        const auto writeMask{info[0].As<Napi::Number>().Uint32Value()};
-        const auto stencilOpFail{info[1].As<Napi::Number>().Uint32Value()};
-        const auto depthOpFail{info[2].As<Napi::Number>().Uint32Value()};
-        const auto depthOpPass{info[3].As<Napi::Number>().Uint32Value()};
-        const auto func{info[4].As<Napi::Number>().Uint32Value()};
-        const auto ref{info[5].As<Napi::Number>().Uint32Value()};
-        
+        const auto writeMask{decoder.DecodeCommandArgAsUInt32()};
+        const auto stencilOpFail{decoder.DecodeCommandArgAsUInt32()};
+        const auto depthOpFail{decoder.DecodeCommandArgAsUInt32()};
+        const auto depthOpPass{decoder.DecodeCommandArgAsUInt32()};
+        const auto func{decoder.DecodeCommandArgAsUInt32()};
+        const auto ref{decoder.DecodeCommandArgAsUInt32()};
+
         m_stencilState = BGFX_STENCIL_FUNC_RMASK(0xFF); //  always 0xFF
         m_stencilState |= stencilOpFail;
         m_stencilState |= depthOpFail;

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -470,6 +470,9 @@ namespace Babylon
                 InstanceMethod("resizeImageBitmap", &NativeEngine::ResizeImageBitmap),
                 InstanceMethod("getFrameBufferData", &NativeEngine::GetFrameBufferData),
                 InstanceMethod("setStencil", &NativeEngine::SetStencil),
+                InstanceMethod("setCommandBuffer", &NativeEngine::SetCommandBuffer),
+                InstanceMethod("setCommandUint32Buffer", &NativeEngine::SetCommandUint32Buffer),
+                InstanceMethod("setCommandFloat32Buffer", &NativeEngine::SetCommandFloat32Buffer),
                 InstanceMethod("submitCommandBuffer", &NativeEngine::SubmitCommandBuffer),
 
                 InstanceValue("TEXTURE_NEAREST_NEAREST", Napi::Number::From(env, TextureSampling::NEAREST_NEAREST)),
@@ -1761,17 +1764,29 @@ namespace Babylon
         m_stencilState |= BGFX_STENCIL_FUNC_REF(ref);
     }
 
+    void NativeEngine::SetCommandBuffer(const Napi::CallbackInfo& info)
+    {
+        m_commandBuffer = Napi::Persistent(info[0].As<Napi::Uint8Array>());
+    }
+
+    void NativeEngine::SetCommandUint32Buffer(const Napi::CallbackInfo& info)
+    {
+        m_commandUint32Buffer = Napi::Persistent(info[0].As<Napi::Uint32Array>());
+    }
+
+    void NativeEngine::SetCommandFloat32Buffer(const Napi::CallbackInfo& info)
+    {
+        m_commandFloat32Buffer = Napi::Persistent(info[0].As<Napi::Float32Array>());
+    }
+
     void NativeEngine::SubmitCommandBuffer(const Napi::CallbackInfo& info)
     {
         const auto commandCount{info[0].ToNumber().Uint32Value()};
-        const auto commandBuffer{info[1].As<Napi::Uint8Array>()};
-        const auto uint32Buffer{info[2].As<Napi::Uint32Array>()};
-        const auto float32Buffer{info[3].As<Napi::Float32Array>()};
 
         CommandBufferDecoder commandBufferDecoder{
-            gsl::make_span(commandBuffer.Data(), commandCount),
-            gsl::make_span(uint32Buffer.Data(), uint32Buffer.ElementLength()),
-            gsl::make_span(float32Buffer.Data(), float32Buffer.ElementLength())
+            gsl::make_span(m_commandBuffer.Value().Data(), commandCount),
+            gsl::make_span(m_commandUint32Buffer.Value().Data(), m_commandUint32Buffer.Value().ElementLength()),
+            gsl::make_span(m_commandFloat32Buffer.Value().Data(), m_commandFloat32Buffer.Value().ElementLength())
         };
 
         uint8_t command{};

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1130,12 +1130,12 @@ namespace Babylon
 
     Napi::Value NativeEngine::CreateTexture(const Napi::CallbackInfo& info)
     {
-        return Napi::Value::From(info.Env(), m_textures.Add({}));
+        return Napi::Value::From(info.Env(), TextureData::Create());
     }
 
     void NativeEngine::LoadTexture(const Napi::CallbackInfo& info)
     {
-        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
+        const auto texture = &TextureData::Get(info[0].ToNumber().Uint32Value());
         const auto data = info[1].As<Napi::TypedArray>();
         const auto generateMips = info[2].As<Napi::Boolean>().Value();
         auto invertY = info[3].As<Napi::Boolean>().Value();
@@ -1194,8 +1194,8 @@ namespace Babylon
 
     void NativeEngine::CopyTexture(const Napi::CallbackInfo& info)
     {
-        const auto textureDestination = &m_textures.Get(info[0].ToNumber().Uint32Value());
-        const auto textureSource = &m_textures.Get(info[1].ToNumber().Uint32Value());
+        const auto textureDestination = &TextureData::Get(info[0].ToNumber().Uint32Value());
+        const auto textureSource = &TextureData::Get(info[1].ToNumber().Uint32Value());
         const auto handleSource{textureSource->Handle};
         // Make sure destination texture is valid for BLIT and is not created from static datas.
         CreateBlitTexture(textureDestination);
@@ -1224,7 +1224,7 @@ namespace Babylon
 
     void NativeEngine::LoadRawTexture(const Napi::CallbackInfo& info)
     {
-        const auto texture{&m_textures.Get(info[0].ToNumber().Uint32Value())};
+        const auto texture{&TextureData::Get(info[0].ToNumber().Uint32Value())};
         const auto data{info[1].As<Napi::TypedArray>()};
         const auto width{static_cast<uint16_t>(info[2].As<Napi::Number>().Uint32Value())};
         const auto height{static_cast<uint16_t>(info[3].As<Napi::Number>().Uint32Value())};
@@ -1260,7 +1260,7 @@ namespace Babylon
 
     void NativeEngine::LoadCubeTexture(const Napi::CallbackInfo& info)
     {
-        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
+        const auto texture = &TextureData::Get(info[0].ToNumber().Uint32Value());
         const auto data = info[1].As<Napi::Array>();
         const auto generateMips = info[2].As<Napi::Boolean>().Value();
         const auto onSuccess = info[3].As<Napi::Function>();
@@ -1305,7 +1305,7 @@ namespace Babylon
 
     void NativeEngine::LoadCubeTextureWithMips(const Napi::CallbackInfo& info)
     {
-        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
+        const auto texture = &TextureData::Get(info[0].ToNumber().Uint32Value());
         const auto data = info[1].As<Napi::Array>();
         const auto onSuccess = info[2].As<Napi::Function>();
         const auto onError = info[3].As<Napi::Function>();
@@ -1348,19 +1348,19 @@ namespace Babylon
 
     Napi::Value NativeEngine::GetTextureWidth(const Napi::CallbackInfo& info)
     {
-        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
+        const auto texture = &TextureData::Get(info[0].ToNumber().Uint32Value());
         return Napi::Value::From(info.Env(), texture->Width);
     }
 
     Napi::Value NativeEngine::GetTextureHeight(const Napi::CallbackInfo& info)
     {
-        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
+        const auto texture = &TextureData::Get(info[0].ToNumber().Uint32Value());
         return Napi::Value::From(info.Env(), texture->Height);
     }
 
     void NativeEngine::SetTextureSampling(const Napi::CallbackInfo& info)
     {
-        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
+        const auto texture = &TextureData::Get(info[0].ToNumber().Uint32Value());
         auto filter = static_cast<uint32_t>(info[1].As<Napi::Number>().Uint32Value());
 
         texture->Flags &= ~(BGFX_SAMPLER_MIN_MASK | BGFX_SAMPLER_MAG_MASK | BGFX_SAMPLER_MIP_MASK);
@@ -1377,7 +1377,7 @@ namespace Babylon
 
     void NativeEngine::SetTextureWrapMode(const Napi::CallbackInfo& info)
     {
-        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
+        const auto texture = &TextureData::Get(info[0].ToNumber().Uint32Value());
         auto addressModeU = static_cast<uint32_t>(info[1].As<Napi::Number>().Uint32Value());
         auto addressModeV = static_cast<uint32_t>(info[2].As<Napi::Number>().Uint32Value());
         auto addressModeW = static_cast<uint32_t>(info[3].As<Napi::Number>().Uint32Value());
@@ -1392,7 +1392,7 @@ namespace Babylon
 
     void NativeEngine::SetTextureAnisotropicLevel(const Napi::CallbackInfo& info)
     {
-        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
+        const auto texture = &TextureData::Get(info[0].ToNumber().Uint32Value());
         const auto value = info[1].As<Napi::Number>().Uint32Value();
 
         texture->AnisotropicLevel = static_cast<uint8_t>(value);
@@ -1410,7 +1410,7 @@ namespace Babylon
         bgfx::Encoder* encoder{GetUpdateToken().GetEncoder()};
 
         const auto& uniformInfo = m_uniformInfos.Get(info[0].ToNumber().Uint32Value());
-        const auto texture = &m_textures.Get(info[1].ToNumber().Uint32Value());
+        const auto texture = &TextureData::Get(info[1].ToNumber().Uint32Value());
 
         encoder->setTexture(uniformInfo.Stage, uniformInfo.Handle, texture->Handle, texture->Flags);
     }
@@ -1420,14 +1420,14 @@ namespace Babylon
 
     void NativeEngine::DeleteTexture(const Napi::CallbackInfo& info)
     {
-        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
+        const auto texture = &TextureData::Get(info[0].ToNumber().Uint32Value());
         m_graphicsImpl.RemoveTexture(texture->Handle);
-        delete texture;
+//        delete texture;
     }
 
     Napi::Value NativeEngine::CreateFrameBuffer(const Napi::CallbackInfo& info)
     {
-        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
+        const auto texture = &TextureData::Get(info[0].ToNumber().Uint32Value());
         uint16_t width{static_cast<uint16_t>(info[1].As<Napi::Number>().Uint32Value())};
         uint16_t height{static_cast<uint16_t>(info[2].As<Napi::Number>().Uint32Value())};
         bgfx::TextureFormat::Enum format{static_cast<bgfx::TextureFormat::Enum>(info[3].As<Napi::Number>().Uint32Value())};

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -615,22 +615,19 @@ namespace Babylon
 
     Napi::Value NativeEngine::CreateVertexArray(const Napi::CallbackInfo& info)
     {
-        const auto nativeHandle = m_nextVertexArrayHandle;
-        m_vertexArrays.insert({nativeHandle, std::make_unique<VertexArray>()});
-        m_nextVertexArrayHandle++;
-        return Napi::Value::From(info.Env(), nativeHandle);
+        return Napi::Value::From(info.Env(), m_vertexArrays.Add({}));
     }
 
     void NativeEngine::DeleteVertexArray(const Napi::CallbackInfo& info)
     {
-        m_vertexArrays.erase(static_cast<size_t>(info[0].ToNumber().Int64Value()));
+        m_vertexArrays.Remove(info[0].ToNumber().Uint32Value());
         // TODO: should we clear the m_boundVertexArray if it gets deleted?
         //assert(vertexArray != m_boundVertexArray);
     }
 
     void NativeEngine::BindVertexArray(const Napi::CallbackInfo& info)
     {
-        const VertexArray& vertexArray = *(m_vertexArrays.at(static_cast<size_t>(info[0].ToNumber().Int64Value())));
+        const VertexArray& vertexArray = m_vertexArrays.Get(info[0].ToNumber().Uint32Value());
         m_boundVertexArray = &vertexArray;
     }
 
@@ -652,7 +649,7 @@ namespace Babylon
 
     void NativeEngine::RecordIndexBuffer(const Napi::CallbackInfo& info)
     {
-        VertexArray& vertexArray = *(m_vertexArrays.at(static_cast<size_t>(info[0].ToNumber().Int64Value())));
+        VertexArray& vertexArray = m_vertexArrays.Get(info[0].ToNumber().Uint32Value());
         const IndexBufferData* indexBufferData = info[1].As<Napi::External<IndexBufferData>>().Data();
 
         vertexArray.indexBuffer.Data = indexBufferData;
@@ -684,7 +681,7 @@ namespace Babylon
 
     void NativeEngine::RecordVertexBuffer(const Napi::CallbackInfo& info)
     {
-        VertexArray& vertexArray = *(m_vertexArrays.at(static_cast<size_t>(info[0].ToNumber().Int64Value())));
+        VertexArray& vertexArray = m_vertexArrays.Get(info[0].ToNumber().Uint32Value());
         VertexBufferData* vertexBufferData = info[1].As<Napi::External<VertexBufferData>>().Data();
 
         const uint32_t location = info[2].As<Napi::Number>().Uint32Value();

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -376,7 +376,7 @@ namespace Babylon
                 InstanceMethod("requestAnimationFrame", &NativeEngine::RequestAnimationFrame),
                 InstanceMethod("createVertexArray", &NativeEngine::CreateVertexArray),
                 InstanceMethod("deleteVertexArray", &NativeEngine::DeleteVertexArray),
-                InstanceMethod("bindVertexArray", &NativeEngine::BindVertexArray),
+                //InstanceMethod("bindVertexArray", &NativeEngine::BindVertexArray),
                 InstanceMethod("createIndexBuffer", &NativeEngine::CreateIndexBuffer),
                 InstanceMethod("deleteIndexBuffer", &NativeEngine::DeleteIndexBuffer),
                 InstanceMethod("recordIndexBuffer", &NativeEngine::RecordIndexBuffer),
@@ -541,7 +541,8 @@ namespace Babylon
                 InstanceValue("STENCIL_OP_PASS_Z_INVERT", Napi::Number::From(env, BGFX_STENCIL_OP_PASS_Z_INVERT)),
 
                 InstanceValue("COMMAND_SETMATRICES", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetMatrices))),
-                InstanceValue("COMMAND_SETTEXTURE", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetTexture)))
+                InstanceValue("COMMAND_SETTEXTURE", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetTexture))),
+                InstanceValue("COMMAND_BINDVERTEXARRAY", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::BindVertexArray)))
             });
         // clang-format on
 
@@ -611,9 +612,15 @@ namespace Babylon
         //assert(vertexArray != m_boundVertexArray);
     }
 
-    void NativeEngine::BindVertexArray(const Napi::CallbackInfo& info)
+//    void NativeEngine::BindVertexArray(const Napi::CallbackInfo& info)
+//    {
+//        const VertexArray& vertexArray = VertexArray::Get(info[0].ToNumber().Uint32Value());
+//        m_boundVertexArray = &vertexArray;
+//    }
+
+    void NativeEngine::BindVertexArray(CommandBufferDecoder& decoder)
     {
-        const VertexArray& vertexArray = VertexArray::Get(info[0].ToNumber().Uint32Value());
+        const VertexArray& vertexArray = VertexArray::Get(decoder.DecodeCommandArgAsUInt32());
         m_boundVertexArray = &vertexArray;
     }
 

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -643,9 +643,9 @@ namespace Babylon
         return Napi::Value::From(info.Env(), IndexBufferData::Create(data, flags, dynamic));
     }
 
-    void NativeEngine::DeleteIndexBuffer(const Napi::CallbackInfo& info)
+    void NativeEngine::DeleteIndexBuffer(const Napi::CallbackInfo& /*info*/)
     {
-        IndexBufferData::Delete(info[0].ToNumber().Uint32Value());
+        //IndexBufferData::Delete(info[0].ToNumber().Uint32Value());
     }
 
     void NativeEngine::RecordIndexBuffer(const Napi::CallbackInfo& info)
@@ -674,9 +674,9 @@ namespace Babylon
         return Napi::Value::From(info.Env(), VertexBufferData::Create(data, dynamic));
     }
 
-    void NativeEngine::DeleteVertexBuffer(const Napi::CallbackInfo& info)
+    void NativeEngine::DeleteVertexBuffer(const Napi::CallbackInfo& /*info*/)
     {
-        VertexBufferData::Delete(info[0].ToNumber().Uint32Value());
+        //VertexBufferData::Delete(info[0].ToNumber().Uint32Value());
     }
 
     void NativeEngine::RecordVertexBuffer(const Napi::CallbackInfo& info)

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1123,12 +1123,12 @@ namespace Babylon
 
     Napi::Value NativeEngine::CreateTexture(const Napi::CallbackInfo& info)
     {
-        return Napi::External<TextureData>::New(info.Env(), new TextureData());
+        return Napi::Value::From(info.Env(), m_textures.Add({}));
     }
 
     void NativeEngine::LoadTexture(const Napi::CallbackInfo& info)
     {
-        const auto texture = info[0].As<Napi::External<TextureData>>().Data();
+        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
         const auto data = info[1].As<Napi::TypedArray>();
         const auto generateMips = info[2].As<Napi::Boolean>().Value();
         auto invertY = info[3].As<Napi::Boolean>().Value();
@@ -1187,8 +1187,8 @@ namespace Babylon
 
     void NativeEngine::CopyTexture(const Napi::CallbackInfo& info)
     {
-        const auto textureDestination = info[0].As<Napi::External<TextureData>>().Data();
-        const auto textureSource = info[1].As<Napi::External<TextureData>>().Data();
+        const auto textureDestination = &m_textures.Get(info[0].ToNumber().Uint32Value());
+        const auto textureSource = &m_textures.Get(info[1].ToNumber().Uint32Value());
         const auto handleSource{textureSource->Handle};
         // Make sure destination texture is valid for BLIT and is not created from static datas.
         CreateBlitTexture(textureDestination);
@@ -1217,7 +1217,7 @@ namespace Babylon
 
     void NativeEngine::LoadRawTexture(const Napi::CallbackInfo& info)
     {
-        const auto texture{info[0].As<Napi::External<TextureData>>().Data()};
+        const auto texture{&m_textures.Get(info[0].ToNumber().Uint32Value())};
         const auto data{info[1].As<Napi::TypedArray>()};
         const auto width{static_cast<uint16_t>(info[2].As<Napi::Number>().Uint32Value())};
         const auto height{static_cast<uint16_t>(info[3].As<Napi::Number>().Uint32Value())};
@@ -1253,7 +1253,7 @@ namespace Babylon
 
     void NativeEngine::LoadCubeTexture(const Napi::CallbackInfo& info)
     {
-        const auto texture = info[0].As<Napi::External<TextureData>>().Data();
+        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
         const auto data = info[1].As<Napi::Array>();
         const auto generateMips = info[2].As<Napi::Boolean>().Value();
         const auto onSuccess = info[3].As<Napi::Function>();
@@ -1298,7 +1298,7 @@ namespace Babylon
 
     void NativeEngine::LoadCubeTextureWithMips(const Napi::CallbackInfo& info)
     {
-        const auto texture = info[0].As<Napi::External<TextureData>>().Data();
+        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
         const auto data = info[1].As<Napi::Array>();
         const auto onSuccess = info[2].As<Napi::Function>();
         const auto onError = info[3].As<Napi::Function>();
@@ -1341,19 +1341,19 @@ namespace Babylon
 
     Napi::Value NativeEngine::GetTextureWidth(const Napi::CallbackInfo& info)
     {
-        const auto texture = info[0].As<Napi::External<TextureData>>().Data();
+        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
         return Napi::Value::From(info.Env(), texture->Width);
     }
 
     Napi::Value NativeEngine::GetTextureHeight(const Napi::CallbackInfo& info)
     {
-        const auto texture = info[0].As<Napi::External<TextureData>>().Data();
+        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
         return Napi::Value::From(info.Env(), texture->Height);
     }
 
     void NativeEngine::SetTextureSampling(const Napi::CallbackInfo& info)
     {
-        const auto texture = info[0].As<Napi::External<TextureData>>().Data();
+        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
         auto filter = static_cast<uint32_t>(info[1].As<Napi::Number>().Uint32Value());
 
         texture->Flags &= ~(BGFX_SAMPLER_MIN_MASK | BGFX_SAMPLER_MAG_MASK | BGFX_SAMPLER_MIP_MASK);
@@ -1370,7 +1370,7 @@ namespace Babylon
 
     void NativeEngine::SetTextureWrapMode(const Napi::CallbackInfo& info)
     {
-        const auto texture = info[0].As<Napi::External<TextureData>>().Data();
+        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
         auto addressModeU = static_cast<uint32_t>(info[1].As<Napi::Number>().Uint32Value());
         auto addressModeV = static_cast<uint32_t>(info[2].As<Napi::Number>().Uint32Value());
         auto addressModeW = static_cast<uint32_t>(info[3].As<Napi::Number>().Uint32Value());
@@ -1385,7 +1385,7 @@ namespace Babylon
 
     void NativeEngine::SetTextureAnisotropicLevel(const Napi::CallbackInfo& info)
     {
-        const auto texture = info[0].As<Napi::External<TextureData>>().Data();
+        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
         const auto value = info[1].As<Napi::Number>().Uint32Value();
 
         texture->AnisotropicLevel = static_cast<uint8_t>(value);
@@ -1403,7 +1403,7 @@ namespace Babylon
         bgfx::Encoder* encoder{GetUpdateToken().GetEncoder()};
 
         const auto& uniformInfo = m_uniformInfos.Get(info[0].ToNumber().Uint32Value());
-        const auto texture = info[1].As<Napi::External<TextureData>>().Data();
+        const auto texture = &m_textures.Get(info[1].ToNumber().Uint32Value());
 
         encoder->setTexture(uniformInfo.Stage, uniformInfo.Handle, texture->Handle, texture->Flags);
     }
@@ -1413,14 +1413,14 @@ namespace Babylon
 
     void NativeEngine::DeleteTexture(const Napi::CallbackInfo& info)
     {
-        const auto texture = info[0].As<Napi::External<TextureData>>().Data();
+        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
         m_graphicsImpl.RemoveTexture(texture->Handle);
         delete texture;
     }
 
     Napi::Value NativeEngine::CreateFrameBuffer(const Napi::CallbackInfo& info)
     {
-        TextureData* texture = info[0].As<Napi::External<TextureData>>().Data();
+        const auto texture = &m_textures.Get(info[0].ToNumber().Uint32Value());
         uint16_t width{static_cast<uint16_t>(info[1].As<Napi::Number>().Uint32Value())};
         uint16_t height{static_cast<uint16_t>(info[2].As<Napi::Number>().Uint32Value())};
         bgfx::TextureFormat::Enum format{static_cast<bgfx::TextureFormat::Enum>(info[3].As<Napi::Number>().Uint32Value())};

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -433,7 +433,7 @@ namespace Babylon
                 InstanceMethod("deleteFrameBuffer", &NativeEngine::DeleteFrameBuffer),
                 InstanceMethod("bindFrameBuffer", &NativeEngine::BindFrameBuffer),
                 InstanceMethod("unbindFrameBuffer", &NativeEngine::UnbindFrameBuffer),
-                InstanceMethod("drawIndexed", &NativeEngine::DrawIndexed),
+                //InstanceMethod("drawIndexed", &NativeEngine::DrawIndexed),
                 InstanceMethod("draw", &NativeEngine::Draw),
                 InstanceMethod("clear", &NativeEngine::Clear),
                 InstanceMethod("getRenderWidth", &NativeEngine::GetRenderWidth),
@@ -548,7 +548,8 @@ namespace Babylon
                 InstanceValue("COMMAND_SETFLOAT2", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetFloat2))),
                 InstanceValue("COMMAND_SETFLOAT3", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetFloat3))),
                 InstanceValue("COMMAND_SETFLOAT4", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetFloat4))),
-                InstanceValue("COMMAND_SETTEXTUREWRAPMODE", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetTextureWrapMode)))
+                InstanceValue("COMMAND_SETTEXTUREWRAPMODE", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetTextureWrapMode))),
+                InstanceValue("COMMAND_DRAWINDEXED", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::DrawIndexed)))
             });
         // clang-format on
 
@@ -1583,13 +1584,41 @@ namespace Babylon
         m_boundFrameBufferNeedsRebinding.Set(*encoder, false);
     }
 
-    void NativeEngine::DrawIndexed(const Napi::CallbackInfo& info)
+//    void NativeEngine::DrawIndexed(const Napi::CallbackInfo& info)
+//    {
+//        bgfx::Encoder* encoder{GetUpdateToken().GetEncoder()};
+//
+//        const auto fillMode = info[0].As<Napi::Number>().Int32Value();
+//        const auto indexStart = info[1].As<Napi::Number>().Int32Value();
+//        const auto indexCount = info[2].As<Napi::Number>().Int32Value();
+//
+//        if (m_boundVertexArray != nullptr)
+//        {
+//            const auto indexBufferData{m_boundVertexArray->indexBuffer.Data};
+//            if (indexBufferData != nullptr)
+//            {
+//                indexBufferData->SetBgfxIndexBuffer(encoder, indexStart, indexCount);
+//            }
+//
+//            const auto& vertexBuffers = m_boundVertexArray->VertexBuffers;
+//            for (const auto& vertexBufferPair : vertexBuffers)
+//            {
+//                const auto index{static_cast<uint8_t>(vertexBufferPair.first)};
+//                const auto& vertexBuffer{vertexBufferPair.second};
+//                vertexBuffer.Data->SetAsBgfxVertexBuffer(encoder, index, vertexBuffer.StartVertex, std::numeric_limits<uint32_t>::max(), vertexBuffer.VertexLayoutHandle);
+//            }
+//        }
+//
+//        Draw(encoder, fillMode);
+//    }
+
+    void NativeEngine::DrawIndexed(CommandBufferDecoder& decoder)
     {
         bgfx::Encoder* encoder{GetUpdateToken().GetEncoder()};
 
-        const auto fillMode = info[0].As<Napi::Number>().Int32Value();
-        const auto indexStart = info[1].As<Napi::Number>().Int32Value();
-        const auto indexCount = info[2].As<Napi::Number>().Int32Value();
+        const auto fillMode = decoder.DecodeCommandArgAsUInt32();
+        const auto indexStart = decoder.DecodeCommandArgAsUInt32();
+        const auto indexCount = decoder.DecodeCommandArgAsUInt32();
 
         if (m_boundVertexArray != nullptr)
         {

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -604,19 +604,19 @@ namespace Babylon
 
     Napi::Value NativeEngine::CreateVertexArray(const Napi::CallbackInfo& info)
     {
-        return Napi::Value::From(info.Env(), m_vertexArrays.Add({}));
+        return Napi::Value::From(info.Env(), VertexArray::Create());
     }
 
     void NativeEngine::DeleteVertexArray(const Napi::CallbackInfo& info)
     {
-        m_vertexArrays.Remove(info[0].ToNumber().Uint32Value());
+        VertexArray::Delete(info[0].ToNumber().Uint32Value());
         // TODO: should we clear the m_boundVertexArray if it gets deleted?
         //assert(vertexArray != m_boundVertexArray);
     }
 
     void NativeEngine::BindVertexArray(const Napi::CallbackInfo& info)
     {
-        const VertexArray& vertexArray = m_vertexArrays.Get(info[0].ToNumber().Uint32Value());
+        const VertexArray& vertexArray = VertexArray::Get(info[0].ToNumber().Uint32Value());
         m_boundVertexArray = &vertexArray;
     }
 
@@ -637,7 +637,7 @@ namespace Babylon
 
     void NativeEngine::RecordIndexBuffer(const Napi::CallbackInfo& info)
     {
-        VertexArray& vertexArray = m_vertexArrays.Get(info[0].ToNumber().Uint32Value());
+        VertexArray& vertexArray = VertexArray::Get(info[0].ToNumber().Uint32Value());
         const IndexBufferData& indexBufferData = IndexBufferData::Get(info[1].ToNumber().Uint32Value());
 
         vertexArray.indexBuffer.Data = &indexBufferData;
@@ -669,7 +669,7 @@ namespace Babylon
 
     void NativeEngine::RecordVertexBuffer(const Napi::CallbackInfo& info)
     {
-        VertexArray& vertexArray = m_vertexArrays.Get(info[0].ToNumber().Uint32Value());
+        VertexArray& vertexArray = VertexArray::Get(info[0].ToNumber().Uint32Value());
         VertexBufferData* vertexBufferData = info[1].As<Napi::External<VertexBufferData>>().Data();
 
         const uint32_t location = info[2].As<Napi::Number>().Uint32Value();

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -423,7 +423,7 @@ namespace Babylon
                 InstanceMethod("getTextureWidth", &NativeEngine::GetTextureWidth),
                 InstanceMethod("getTextureHeight", &NativeEngine::GetTextureHeight),
                 InstanceMethod("setTextureSampling", &NativeEngine::SetTextureSampling),
-                InstanceMethod("setTextureWrapMode", &NativeEngine::SetTextureWrapMode),
+                //InstanceMethod("setTextureWrapMode", &NativeEngine::SetTextureWrapMode),
                 InstanceMethod("setTextureAnisotropicLevel", &NativeEngine::SetTextureAnisotropicLevel),
                 //InstanceMethod("setTexture", &NativeEngine::SetTexture),
                 InstanceMethod("setTexture2", &NativeEngine::SetTexture2),
@@ -548,6 +548,7 @@ namespace Babylon
                 InstanceValue("COMMAND_SETFLOAT2", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetFloat2))),
                 InstanceValue("COMMAND_SETFLOAT3", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetFloat3))),
                 InstanceValue("COMMAND_SETFLOAT4", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetFloat4))),
+                InstanceValue("COMMAND_SETTEXTUREWRAPMODE", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetTextureWrapMode)))
             });
         // clang-format on
 
@@ -1426,19 +1427,34 @@ namespace Babylon
         }
     }
 
-    void NativeEngine::SetTextureWrapMode(const Napi::CallbackInfo& info)
+//    void NativeEngine::SetTextureWrapMode(const Napi::CallbackInfo& info)
+//    {
+//        const auto texture = &TextureData::Get(info[0].ToNumber().Uint32Value());
+//        auto addressModeU = static_cast<uint32_t>(info[1].As<Napi::Number>().Uint32Value());
+//        auto addressModeV = static_cast<uint32_t>(info[2].As<Napi::Number>().Uint32Value());
+//        auto addressModeW = static_cast<uint32_t>(info[3].As<Napi::Number>().Uint32Value());
+//
+//        uint32_t addressMode = addressModeU +
+//            (addressModeV << BGFX_SAMPLER_V_SHIFT) +
+//            (addressModeW << BGFX_SAMPLER_W_SHIFT);
+//
+//        texture->Flags &= ~(BGFX_SAMPLER_U_MASK | BGFX_SAMPLER_V_MASK | BGFX_SAMPLER_W_MASK);
+//        texture->Flags |= addressMode;
+//    }
+
+    void NativeEngine::SetTextureWrapMode(CommandBufferDecoder& decoder)
     {
-        const auto texture = &TextureData::Get(info[0].ToNumber().Uint32Value());
-        auto addressModeU = static_cast<uint32_t>(info[1].As<Napi::Number>().Uint32Value());
-        auto addressModeV = static_cast<uint32_t>(info[2].As<Napi::Number>().Uint32Value());
-        auto addressModeW = static_cast<uint32_t>(info[3].As<Napi::Number>().Uint32Value());
+        auto& texture = TextureData::Get(decoder.DecodeCommandArgAsUInt32());
+        auto addressModeU = decoder.DecodeCommandArgAsUInt32();
+        auto addressModeV = decoder.DecodeCommandArgAsUInt32();
+        auto addressModeW = decoder.DecodeCommandArgAsUInt32();
 
         uint32_t addressMode = addressModeU +
             (addressModeV << BGFX_SAMPLER_V_SHIFT) +
             (addressModeW << BGFX_SAMPLER_W_SHIFT);
 
-        texture->Flags &= ~(BGFX_SAMPLER_U_MASK | BGFX_SAMPLER_V_MASK | BGFX_SAMPLER_W_MASK);
-        texture->Flags |= addressMode;
+        texture.Flags &= ~(BGFX_SAMPLER_U_MASK | BGFX_SAMPLER_V_MASK | BGFX_SAMPLER_W_MASK);
+        texture.Flags |= addressMode;
     }
 
     void NativeEngine::SetTextureAnisotropicLevel(const Napi::CallbackInfo& info)

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -410,10 +410,10 @@ namespace Babylon
                 //InstanceMethod("setMatrices", &NativeEngine::SetMatrices),
                 InstanceMethod("setMatrix3x3", &NativeEngine::SetMatrix3x3),
                 InstanceMethod("setMatrix2x2", &NativeEngine::SetMatrix2x2),
-                InstanceMethod("setFloat", &NativeEngine::SetFloat),
-                InstanceMethod("setFloat2", &NativeEngine::SetFloat2),
-                InstanceMethod("setFloat3", &NativeEngine::SetFloat3),
-                InstanceMethod("setFloat4", &NativeEngine::SetFloat4),
+//                InstanceMethod("setFloat", &NativeEngine::SetFloat),
+//                InstanceMethod("setFloat2", &NativeEngine::SetFloat2),
+//                InstanceMethod("setFloat3", &NativeEngine::SetFloat3),
+//                InstanceMethod("setFloat4", &NativeEngine::SetFloat4),
                 InstanceMethod("createTexture", &NativeEngine::CreateTexture),
                 InstanceMethod("loadTexture", &NativeEngine::LoadTexture),
                 InstanceMethod("loadRawTexture", &NativeEngine::LoadRawTexture),
@@ -543,7 +543,11 @@ namespace Babylon
                 InstanceValue("COMMAND_SETMATRICES", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetMatrices))),
                 InstanceValue("COMMAND_SETTEXTURE", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetTexture))),
                 InstanceValue("COMMAND_BINDVERTEXARRAY", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::BindVertexArray))),
-                InstanceValue("COMMAND_SETSTATE", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetState)))
+                InstanceValue("COMMAND_SETSTATE", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetState))),
+                InstanceValue("COMMAND_SETFLOAT", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetFloat))),
+                InstanceValue("COMMAND_SETFLOAT2", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetFloat2))),
+                InstanceValue("COMMAND_SETFLOAT3", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetFloat3))),
+                InstanceValue("COMMAND_SETFLOAT4", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetFloat4))),
             });
         // clang-format on
 
@@ -999,15 +1003,29 @@ namespace Babylon
         ProgramData::Get(m_currentProgram).SetUniform(uniformInfo.Handle, m_scratch, elementLength / size);
     }
 
+//    template<int size>
+//    void NativeEngine::SetFloatN(const Napi::CallbackInfo& info)
+//    {
+//        const auto& uniformInfo = UniformInfo::Get(info[0].ToNumber().Uint32Value());
+//        const float values[] = {
+//            info[1].As<Napi::Number>().FloatValue(),
+//            (size > 1) ? info[2].As<Napi::Number>().FloatValue() : 0.f,
+//            (size > 2) ? info[3].As<Napi::Number>().FloatValue() : 0.f,
+//            (size > 3) ? info[4].As<Napi::Number>().FloatValue() : 0.f,
+//        };
+//
+//        ProgramData::Get(m_currentProgram).SetUniform(uniformInfo.Handle, values);
+//    }
+
     template<int size>
-    void NativeEngine::SetFloatN(const Napi::CallbackInfo& info)
+    void NativeEngine::SetFloatN(CommandBufferDecoder& decoder)
     {
-        const auto& uniformInfo = UniformInfo::Get(info[0].ToNumber().Uint32Value());
+        const auto& uniformInfo = UniformInfo::Get(decoder.DecodeCommandArgAsUInt32());
         const float values[] = {
-            info[1].As<Napi::Number>().FloatValue(),
-            (size > 1) ? info[2].As<Napi::Number>().FloatValue() : 0.f,
-            (size > 2) ? info[3].As<Napi::Number>().FloatValue() : 0.f,
-            (size > 3) ? info[4].As<Napi::Number>().FloatValue() : 0.f,
+            decoder.DecodeCommandArgAsFloat32(),
+            (size > 1) ? decoder.DecodeCommandArgAsFloat32() : 0.f,
+            (size > 2) ? decoder.DecodeCommandArgAsFloat32() : 0.f,
+            (size > 3) ? decoder.DecodeCommandArgAsFloat32() : 0.f,
         };
 
         ProgramData::Get(m_currentProgram).SetUniform(uniformInfo.Handle, values);
@@ -1121,24 +1139,44 @@ namespace Babylon
         SetMatrixN<4>(info);
     }
 
-    void NativeEngine::SetFloat(const Napi::CallbackInfo& info)
+//    void NativeEngine::SetFloat(const Napi::CallbackInfo& info)
+//    {
+//        SetFloatN<1>(info);
+//    }
+//
+//    void NativeEngine::SetFloat2(const Napi::CallbackInfo& info)
+//    {
+//        SetFloatN<2>(info);
+//    }
+//
+//    void NativeEngine::SetFloat3(const Napi::CallbackInfo& info)
+//    {
+//        SetFloatN<3>(info);
+//    }
+//
+//    void NativeEngine::SetFloat4(const Napi::CallbackInfo& info)
+//    {
+//        SetFloatN<4>(info);
+//    }
+
+    void NativeEngine::SetFloat(CommandBufferDecoder& decoder)
     {
-        SetFloatN<1>(info);
+        SetFloatN<1>(decoder);
     }
 
-    void NativeEngine::SetFloat2(const Napi::CallbackInfo& info)
+    void NativeEngine::SetFloat2(CommandBufferDecoder& decoder)
     {
-        SetFloatN<2>(info);
+        SetFloatN<2>(decoder);
     }
 
-    void NativeEngine::SetFloat3(const Napi::CallbackInfo& info)
+    void NativeEngine::SetFloat3(CommandBufferDecoder& decoder)
     {
-        SetFloatN<3>(info);
+        SetFloatN<3>(decoder);
     }
 
-    void NativeEngine::SetFloat4(const Napi::CallbackInfo& info)
+    void NativeEngine::SetFloat4(CommandBufferDecoder& decoder)
     {
-        SetFloatN<4>(info);
+        SetFloatN<4>(decoder);
     }
 
     Napi::Value NativeEngine::CreateTexture(const Napi::CallbackInfo& info)

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -389,7 +389,7 @@ namespace Babylon
                 InstanceMethod("getUniforms", &NativeEngine::GetUniforms),
                 InstanceMethod("getAttributes", &NativeEngine::GetAttributes),
                 InstanceMethod("setProgram", &NativeEngine::SetProgram),
-                InstanceMethod("setState", &NativeEngine::SetState),
+                //InstanceMethod("setState", &NativeEngine::SetState),
                 InstanceMethod("setZOffset", &NativeEngine::SetZOffset),
                 InstanceMethod("getZOffset", &NativeEngine::GetZOffset),
                 InstanceMethod("setDepthTest", &NativeEngine::SetDepthTest),
@@ -542,7 +542,8 @@ namespace Babylon
 
                 InstanceValue("COMMAND_SETMATRICES", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetMatrices))),
                 InstanceValue("COMMAND_SETTEXTURE", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetTexture))),
-                InstanceValue("COMMAND_BINDVERTEXARRAY", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::BindVertexArray)))
+                InstanceValue("COMMAND_BINDVERTEXARRAY", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::BindVertexArray))),
+                InstanceValue("COMMAND_SETSTATE", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetState)))
             });
         // clang-format on
 
@@ -884,11 +885,30 @@ namespace Babylon
         m_currentProgram = info[0].ToNumber().Uint32Value();
     }
 
-    void NativeEngine::SetState(const Napi::CallbackInfo& info)
+//    void NativeEngine::SetState(const Napi::CallbackInfo& info)
+//    {
+//        const auto culling = info[0].As<Napi::Boolean>().Value();
+//        const auto cullBackFaces = info[2].As<Napi::Boolean>().Value();
+//        const auto reverseSide = info[3].As<Napi::Boolean>().Value();
+//
+//        m_engineState &= ~(BGFX_STATE_CULL_MASK | BGFX_STATE_FRONT_CCW);
+//        m_engineState |= reverseSide ? 0 : BGFX_STATE_FRONT_CCW;
+//
+//        if (culling)
+//        {
+//            m_engineState |= cullBackFaces ? BGFX_STATE_CULL_CCW : BGFX_STATE_CULL_CW;
+//        }
+//        // TODO: zOffset
+//        //const auto zOffset = info[1].As<Napi::Number>().FloatValue();
+//    }
+
+    void NativeEngine::SetState(CommandBufferDecoder& decoder)
     {
-        const auto culling = info[0].As<Napi::Boolean>().Value();
-        const auto cullBackFaces = info[2].As<Napi::Boolean>().Value();
-        const auto reverseSide = info[3].As<Napi::Boolean>().Value();
+        const bool culling = decoder.DecodeCommandArgAsUInt32();
+        // TODO: zOffset
+        /*const float zOffset =*/ decoder.DecodeCommandArgAsFloat32();
+        const bool cullBackFaces = decoder.DecodeCommandArgAsUInt32();
+        const bool reverseSide = decoder.DecodeCommandArgAsUInt32();
 
         m_engineState &= ~(BGFX_STATE_CULL_MASK | BGFX_STATE_FRONT_CCW);
         m_engineState |= reverseSide ? 0 : BGFX_STATE_FRONT_CCW;
@@ -897,8 +917,6 @@ namespace Babylon
         {
             m_engineState |= cullBackFaces ? BGFX_STATE_CULL_CCW : BGFX_STATE_CULL_CW;
         }
-        // TODO: zOffset
-        //const auto zOffset = info[1].As<Napi::Number>().FloatValue();
     }
 
     void NativeEngine::SetZOffset(const Napi::CallbackInfo& /*info*/)

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1077,6 +1077,12 @@ namespace Babylon
 
     void NativeEngine::SetMatrices(const Napi::CallbackInfo& info)
     {
+//        const auto& uniformInfo = m_uniformInfos.Get(info[0].ToNumber().Uint32Value());
+//        const auto matricesArray = info[1].As<Napi::ArrayBuffer>();
+//        const auto elementLength = info[2].As<Napi::Number>().Uint32Value();
+//
+//        m_currentProgram->SetUniform(uniformInfo.Handle, gsl::span(static_cast<float*>(matricesArray.Data()), elementLength), elementLength >> 4);
+
         const auto& uniformInfo = m_uniformInfos.Get(info[0].ToNumber().Uint32Value());
         const auto matricesArray = info[1].As<Napi::Float32Array>();
 

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -378,11 +378,11 @@ namespace Babylon
                 //InstanceMethod("deleteVertexArray", &NativeEngine::DeleteVertexArray),
                 //InstanceMethod("bindVertexArray", &NativeEngine::BindVertexArray),
                 InstanceMethod("createIndexBuffer", &NativeEngine::CreateIndexBuffer),
-                InstanceMethod("deleteIndexBuffer", &NativeEngine::DeleteIndexBuffer),
+                //InstanceMethod("deleteIndexBuffer", &NativeEngine::DeleteIndexBuffer),
                 InstanceMethod("recordIndexBuffer", &NativeEngine::RecordIndexBuffer),
                 InstanceMethod("updateDynamicIndexBuffer", &NativeEngine::UpdateDynamicIndexBuffer),
                 InstanceMethod("createVertexBuffer", &NativeEngine::CreateVertexBuffer),
-                InstanceMethod("deleteVertexBuffer", &NativeEngine::DeleteVertexBuffer),
+                //InstanceMethod("deleteVertexBuffer", &NativeEngine::DeleteVertexBuffer),
                 InstanceMethod("recordVertexBuffer", &NativeEngine::RecordVertexBuffer),
                 InstanceMethod("updateDynamicVertexBuffer", &NativeEngine::UpdateDynamicVertexBuffer),
                 InstanceMethod("createProgram", &NativeEngine::CreateProgram),
@@ -541,6 +541,8 @@ namespace Babylon
                 InstanceValue("STENCIL_OP_PASS_Z_INVERT", Napi::Number::From(env, BGFX_STENCIL_OP_PASS_Z_INVERT)),
 
                 InstanceValue("COMMAND_DELETEVERTEXARRAY", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::DeleteVertexArray))),
+                InstanceValue("COMMAND_DELETEINDEXBUFFER", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::DeleteIndexBuffer))),
+                InstanceValue("COMMAND_DELETEVERTEXBUFFER", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::DeleteVertexBuffer))),
                 InstanceValue("COMMAND_SETMATRICES", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetMatrices))),
                 InstanceValue("COMMAND_SETTEXTURE", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetTexture))),
                 InstanceValue("COMMAND_BINDVERTEXARRAY", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::BindVertexArray))),
@@ -651,9 +653,14 @@ namespace Babylon
         return Napi::Value::From(info.Env(), IndexBufferData::Create(data, flags, dynamic));
     }
 
-    void NativeEngine::DeleteIndexBuffer(const Napi::CallbackInfo& /*info*/)
+//    void NativeEngine::DeleteIndexBuffer(const Napi::CallbackInfo& /*info*/)
+//    {
+//        //IndexBufferData::Delete(info[0].ToNumber().Uint32Value());
+//    }
+
+    void NativeEngine::DeleteIndexBuffer(CommandBufferDecoder& decoder)
     {
-        //IndexBufferData::Delete(info[0].ToNumber().Uint32Value());
+        IndexBufferData::Delete(decoder.DecodeCommandArgAsUInt32());
     }
 
     void NativeEngine::RecordIndexBuffer(const Napi::CallbackInfo& info)
@@ -682,9 +689,14 @@ namespace Babylon
         return Napi::Value::From(info.Env(), VertexBufferData::Create(data, dynamic));
     }
 
-    void NativeEngine::DeleteVertexBuffer(const Napi::CallbackInfo& /*info*/)
+//    void NativeEngine::DeleteVertexBuffer(const Napi::CallbackInfo& /*info*/)
+//    {
+//        //VertexBufferData::Delete(info[0].ToNumber().Uint32Value());
+//    }
+
+    void NativeEngine::DeleteVertexBuffer(CommandBufferDecoder& decoder)
     {
-        //VertexBufferData::Delete(info[0].ToNumber().Uint32Value());
+        VertexBufferData::Delete(decoder.DecodeCommandArgAsUInt32());
     }
 
     void NativeEngine::RecordVertexBuffer(const Napi::CallbackInfo& info)

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -375,7 +375,7 @@ namespace Babylon
                 InstanceMethod("dispose", &NativeEngine::Dispose),
                 InstanceMethod("requestAnimationFrame", &NativeEngine::RequestAnimationFrame),
                 InstanceMethod("createVertexArray", &NativeEngine::CreateVertexArray),
-                InstanceMethod("deleteVertexArray", &NativeEngine::DeleteVertexArray),
+                //InstanceMethod("deleteVertexArray", &NativeEngine::DeleteVertexArray),
                 //InstanceMethod("bindVertexArray", &NativeEngine::BindVertexArray),
                 InstanceMethod("createIndexBuffer", &NativeEngine::CreateIndexBuffer),
                 InstanceMethod("deleteIndexBuffer", &NativeEngine::DeleteIndexBuffer),
@@ -540,6 +540,7 @@ namespace Babylon
                 InstanceValue("STENCIL_OP_PASS_Z_DECRSAT", Napi::Number::From(env, BGFX_STENCIL_OP_PASS_Z_DECRSAT)),
                 InstanceValue("STENCIL_OP_PASS_Z_INVERT", Napi::Number::From(env, BGFX_STENCIL_OP_PASS_Z_INVERT)),
 
+                InstanceValue("COMMAND_DELETEVERTEXARRAY", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::DeleteVertexArray))),
                 InstanceValue("COMMAND_SETMATRICES", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetMatrices))),
                 InstanceValue("COMMAND_SETTEXTURE", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetTexture))),
                 InstanceValue("COMMAND_BINDVERTEXARRAY", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::BindVertexArray))),
@@ -614,9 +615,16 @@ namespace Babylon
         return Napi::Value::From(info.Env(), VertexArray::Create());
     }
 
-    void NativeEngine::DeleteVertexArray(const Napi::CallbackInfo& info)
+//    void NativeEngine::DeleteVertexArray(const Napi::CallbackInfo& info)
+//    {
+//        VertexArray::Delete(info[0].ToNumber().Uint32Value());
+//        // TODO: should we clear the m_boundVertexArray if it gets deleted?
+//        //assert(vertexArray != m_boundVertexArray);
+//    }
+
+    void NativeEngine::DeleteVertexArray(CommandBufferDecoder& decoder)
     {
-        VertexArray::Delete(info[0].ToNumber().Uint32Value());
+        VertexArray::Delete(decoder.DecodeCommandArgAsUInt32());
         // TODO: should we clear the m_boundVertexArray if it gets deleted?
         //assert(vertexArray != m_boundVertexArray);
     }

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -65,11 +65,6 @@ namespace Babylon
             constexpr uint64_t SCREENMODE = BGFX_STATE_BLEND_FUNC_SEPARATE(BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_INV_SRC_COLOR, BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_INV_SRC_ALPHA);
         }
 
-        namespace Command
-        {
-            constexpr uint32_t SetMatrices = 1;
-        }
-
         static_assert(static_cast<bgfx::TextureFormat::Enum>(bimg::TextureFormat::Count) == bgfx::TextureFormat::Count);
         static_assert(static_cast<bgfx::TextureFormat::Enum>(bimg::TextureFormat::RGBA8) == bgfx::TextureFormat::RGBA8);
         static_assert(static_cast<bgfx::TextureFormat::Enum>(bimg::TextureFormat::RGB8) == bgfx::TextureFormat::RGB8);
@@ -567,7 +562,7 @@ namespace Babylon
                 InstanceValue("STENCIL_OP_PASS_Z_DECRSAT", Napi::Number::From(env, BGFX_STENCIL_OP_PASS_Z_DECRSAT)),
                 InstanceValue("STENCIL_OP_PASS_Z_INVERT", Napi::Number::From(env, BGFX_STENCIL_OP_PASS_Z_INVERT)),
 
-                InstanceValue("COMMAND_SETMATRICES", Napi::Number::From(env, Command::SetMatrices)),
+                InstanceValue("COMMAND_SETMATRICES", Napi::Number::From(env, s_commandTable.Add(&NativeEngine::SetMatrices))),
             });
         // clang-format on
 
@@ -1086,12 +1081,6 @@ namespace Babylon
 
 //    void NativeEngine::SetMatrices(const Napi::CallbackInfo& info)
 //    {
-////        const auto& uniformInfo = m_uniformInfos.Get(info[0].ToNumber().Uint32Value());
-////        const auto matricesArray = info[1].As<Napi::ArrayBuffer>();
-////        const auto elementLength = info[2].As<Napi::Number>().Uint32Value();
-////
-////        m_currentProgram->SetUniform(uniformInfo.Handle, gsl::span(static_cast<float*>(matricesArray.Data()), elementLength), elementLength >> 4);
-//
 //        const auto& uniformInfo = m_uniformInfos.Get(info[0].ToNumber().Uint32Value());
 //        const auto matricesArray = info[1].As<Napi::Float32Array>();
 //
@@ -1788,14 +1777,7 @@ namespace Babylon
         uint8_t command{};
         while (commandBufferDecoder.TryDecodeCommand(command))
         {
-            switch (command)
-            {
-                case Command::SetMatrices:
-                {
-                    SetMatrices(commandBufferDecoder);
-                    break;
-                }
-            }
+            std::invoke(s_commandTable.Get(command), this, commandBufferDecoder);
         }
     }
 

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -268,7 +268,8 @@ namespace Babylon
         void RequestAnimationFrame(const Napi::CallbackInfo& info);
         Napi::Value CreateVertexArray(const Napi::CallbackInfo& info);
         void DeleteVertexArray(const Napi::CallbackInfo& info);
-        void BindVertexArray(const Napi::CallbackInfo& info);
+        //void BindVertexArray(const Napi::CallbackInfo& info);
+        void BindVertexArray(CommandBufferDecoder& decoder);
         Napi::Value CreateIndexBuffer(const Napi::CallbackInfo& info);
         void DeleteIndexBuffer(const Napi::CallbackInfo& info);
         void RecordIndexBuffer(const Napi::CallbackInfo& info);

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -322,7 +322,8 @@ namespace Babylon
         Napi::Value GetTextureWidth(const Napi::CallbackInfo& info);
         Napi::Value GetTextureHeight(const Napi::CallbackInfo& info);
         void SetTextureSampling(const Napi::CallbackInfo& info);
-        void SetTextureWrapMode(const Napi::CallbackInfo& info);
+        //void SetTextureWrapMode(const Napi::CallbackInfo& info);
+        void SetTextureWrapMode(CommandBufferDecoder& decoder);
         void SetTextureAnisotropicLevel(const Napi::CallbackInfo& info);
         //void SetTexture(const Napi::CallbackInfo& info);
         void SetTexture(CommandBufferDecoder& decoder);

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -276,6 +276,7 @@ namespace Babylon
         ResourceTable<UniformInfo> m_uniformInfos{};
         ResourceTable<TextureData> m_textures{};
         ResourceTable<VertexArray> m_vertexArrays{};
+        ResourceTable<IndexBufferData*> m_indexBuffers{};
 
         const VertexArray* m_boundVertexArray{};
         FrameBuffer m_defaultFrameBuffer;

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -337,7 +337,8 @@ namespace Babylon
         //void DrawIndexed(const Napi::CallbackInfo& info);
         void DrawIndexed(CommandBufferDecoder& decoder);
         void Draw(const Napi::CallbackInfo& info);
-        void Clear(const Napi::CallbackInfo& info);
+        //void Clear(const Napi::CallbackInfo& info);
+        void Clear(CommandBufferDecoder& decoder);
         Napi::Value GetRenderWidth(const Napi::CallbackInfo& info);
         Napi::Value GetRenderHeight(const Napi::CallbackInfo& info);
         void SetViewPort(const Napi::CallbackInfo& info);

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -178,7 +178,7 @@ namespace Babylon
         std::variant<Handle1T, Handle2T> m_handle{};
     };
 
-    class IndexBufferData final : protected VariantHandleHolder<bgfx::IndexBufferHandle, bgfx::DynamicIndexBufferHandle>
+    class IndexBufferData final : protected VariantHandleHolder<bgfx::IndexBufferHandle, bgfx::DynamicIndexBufferHandle>, public NativeResource<IndexBufferData>
     {
     public:
         IndexBufferData(const Napi::TypedArray& bytes, uint16_t flags, bool dynamic);
@@ -415,7 +415,6 @@ namespace Babylon
 
         ResourceTable<UniformInfo> m_uniformInfos{};
         ResourceTable<VertexArray> m_vertexArrays{};
-        ResourceTable<IndexBufferData> m_indexBuffers{};
 
         const VertexArray* m_boundVertexArray{};
         FrameBuffer m_defaultFrameBuffer;

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -123,7 +123,7 @@ namespace Babylon
         uint32_t Add(T&& resource)
         {
             const uint32_t resourceHandle{m_nextResourceId};
-            m_resources.insert({resourceHandle, std::forward(resource)});
+            m_resources.insert({resourceHandle, std::forward<T>(resource)});
             m_nextResourceId++;
             return resourceHandle;
         }
@@ -133,11 +133,9 @@ namespace Babylon
             return m_resources.at(resourceHandle);
         }
 
-        T& Remove(uint32_t resourceHandle)
+        void Remove(uint32_t resourceHandle)
         {
-            T& resource{Get(resourceHandle)};
             m_resources.erase(resourceHandle);
-            return resource;
         }
     private:
         uint32_t m_nextResourceId{};
@@ -274,9 +272,7 @@ namespace Babylon
 
         std::vector<Napi::FunctionReference> m_requestAnimationFrameCallbacks{};
 
-        size_t m_nextVertexArrayHandle{0};
-        std::unordered_map<size_t, std::unique_ptr<VertexArray>> m_vertexArrays{};
-//        ResourceTable<std::unique_ptr<VertexArray>> m_vertexArrays{};
+        ResourceTable<VertexArray> m_vertexArrays{};
         const VertexArray* m_boundVertexArray{};
         FrameBuffer m_defaultFrameBuffer;
         FrameBuffer* m_boundFrameBuffer{};

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -25,6 +25,8 @@
 #include <arcana/threading/cancellation.h>
 #include <unordered_map>
 
+//#include <Foundation/Foundation.h>
+
 namespace Babylon
 {
     struct TextureData final : public NativeResource<TextureData>
@@ -216,27 +218,36 @@ namespace Babylon
             }
 
             command = m_commandBuffer[m_commandBufferIndex++];
+            //NSLog(@"COMMAND BUFFER: Decode command: %u", command);
             return true;
         }
 
         uint32_t DecodeCommandArgAsUInt32()
         {
-            return m_uint32ArgBuffer[m_uint32ArgBufferIndex++];
+            auto ret = m_uint32ArgBuffer[m_uint32ArgBufferIndex++];
+            //NSLog(@"COMMAND BUFFER:   Decode uint32: %u", ret);
+            return ret;
         }
 
         UInt32Buffer DecodeCommandArgAsUInt32s(UInt32Buffer::index_type count)
         {
-            return m_uint32ArgBuffer.subspan((m_uint32ArgBufferIndex += count) - count, count);
+            auto ret = m_uint32ArgBuffer.subspan((m_uint32ArgBufferIndex += count) - count, count);
+            //NSLog(@"COMMAND BUFFER:   Decode uint32s: %u", static_cast<uint32_t>(ret.size()));
+            return ret;
         }
 
         float DecodeCommandArgAsFloat32()
         {
-            return m_float32ArgBuffer[m_float32ArgBufferIndex++];
+            auto ret = m_float32ArgBuffer[m_float32ArgBufferIndex++];
+            //NSLog(@"COMMAND BUFFER:   Decode float32: %f", ret);
+            return ret;
         }
 
         Float32Buffer DecodeCommandArgAsFloat32s(Float32Buffer::index_type count)
         {
-            return m_float32ArgBuffer.subspan((m_float32ArgBufferIndex += count) - count, count);
+            auto ret = m_float32ArgBuffer.subspan((m_float32ArgBufferIndex += count) - count, count);
+            //NSLog(@"COMMAND BUFFER:   Decode float32s: %u", static_cast<uint32_t>(ret.size()));
+            return ret;
         }
 
     private:

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -117,6 +117,33 @@ namespace Babylon
         std::unordered_map<uint32_t, VertexBuffer> VertexBuffers;
     };
 
+    template<typename T>
+    class ResourceTable final {
+    public:
+        uint32_t Add(T&& resource)
+        {
+            const uint32_t resourceHandle{m_nextResourceId};
+            m_resources.insert({resourceHandle, std::forward(resource)});
+            m_nextResourceId++;
+            return resourceHandle;
+        }
+
+        T& Get(uint32_t resourceHandle)
+        {
+            return m_resources.at(resourceHandle);
+        }
+
+        T& Remove(uint32_t resourceHandle)
+        {
+            T& resource{Get(resourceHandle)};
+            m_resources.erase(resourceHandle);
+            return resource;
+        }
+    private:
+        uint32_t m_nextResourceId{};
+        std::unordered_map<uint32_t, T> m_resources{};
+    };
+
     class NativeEngine final : public Napi::ObjectWrap<NativeEngine>
     {
         static constexpr auto JS_CLASS_NAME = "_NativeEngine";
@@ -186,6 +213,8 @@ namespace Babylon
         void SetTextureWrapMode(const Napi::CallbackInfo& info);
         void SetTextureAnisotropicLevel(const Napi::CallbackInfo& info);
         void SetTexture(const Napi::CallbackInfo& info);
+        void SetTexture2(const Napi::CallbackInfo& info);
+        void SetTexture3(const Napi::CallbackInfo& info);
         void DeleteTexture(const Napi::CallbackInfo& info);
         Napi::Value CreateFrameBuffer(const Napi::CallbackInfo& info);
         void DeleteFrameBuffer(const Napi::CallbackInfo& info);
@@ -245,6 +274,9 @@ namespace Babylon
 
         std::vector<Napi::FunctionReference> m_requestAnimationFrameCallbacks{};
 
+        size_t m_nextVertexArrayHandle{0};
+        std::unordered_map<size_t, std::unique_ptr<VertexArray>> m_vertexArrays{};
+//        ResourceTable<std::unique_ptr<VertexArray>> m_vertexArrays{};
         const VertexArray* m_boundVertexArray{};
         FrameBuffer m_defaultFrameBuffer;
         FrameBuffer* m_boundFrameBuffer{};

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -305,10 +305,14 @@ namespace Babylon
         void SetMatrices(CommandBufferDecoder& decoder);
         void SetMatrix3x3(const Napi::CallbackInfo& info);
         void SetMatrix2x2(const Napi::CallbackInfo& info);
-        void SetFloat(const Napi::CallbackInfo& info);
-        void SetFloat2(const Napi::CallbackInfo& info);
-        void SetFloat3(const Napi::CallbackInfo& info);
-        void SetFloat4(const Napi::CallbackInfo& info);
+        //void SetFloat(const Napi::CallbackInfo& info);
+        //void SetFloat2(const Napi::CallbackInfo& info);
+        //void SetFloat3(const Napi::CallbackInfo& info);
+        //void SetFloat4(const Napi::CallbackInfo& info);
+        void SetFloat(CommandBufferDecoder& decoder);
+        void SetFloat2(CommandBufferDecoder& decoder);
+        void SetFloat3(CommandBufferDecoder& decoder);
+        void SetFloat4(CommandBufferDecoder& decoder);
         Napi::Value CreateTexture(const Napi::CallbackInfo& info);
         void LoadTexture(const Napi::CallbackInfo& info);
         void CopyTexture(const Napi::CallbackInfo& info);
@@ -377,7 +381,8 @@ namespace Babylon
         void SetTypeArrayN(const Napi::CallbackInfo& info);
 
         template<int size>
-        void SetFloatN(const Napi::CallbackInfo& info);
+        //void SetFloatN(const Napi::CallbackInfo& info);
+        void SetFloatN(CommandBufferDecoder& decoder);
 
         template<int size>
         void SetMatrixN(const Napi::CallbackInfo& info);

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -137,8 +137,9 @@ namespace Babylon
         {
             m_resources.erase(resourceHandle);
         }
+
     private:
-        uint32_t m_nextResourceId{};
+        uint32_t m_nextResourceId{1};
         std::unordered_map<uint32_t, T> m_resources{};
     };
 
@@ -273,6 +274,7 @@ namespace Babylon
         std::vector<Napi::FunctionReference> m_requestAnimationFrameCallbacks{};
 
         ResourceTable<UniformInfo> m_uniformInfos{};
+        ResourceTable<TextureData> m_textures{};
         ResourceTable<VertexArray> m_vertexArrays{};
 
         const VertexArray* m_boundVertexArray{};

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -334,7 +334,8 @@ namespace Babylon
         void DeleteFrameBuffer(const Napi::CallbackInfo& info);
         void BindFrameBuffer(const Napi::CallbackInfo& info);
         void UnbindFrameBuffer(const Napi::CallbackInfo& info);
-        void DrawIndexed(const Napi::CallbackInfo& info);
+        //void DrawIndexed(const Napi::CallbackInfo& info);
+        void DrawIndexed(CommandBufferDecoder& decoder);
         void Draw(const Napi::CallbackInfo& info);
         void Clear(const Napi::CallbackInfo& info);
         Napi::Value GetRenderWidth(const Napi::CallbackInfo& info);

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -66,8 +66,8 @@ namespace Babylon
         }
 
         std::unordered_map<std::string, uint32_t> VertexAttributeLocations{};
-        std::unordered_map<std::string, UniformInfo> VertexUniformInfos{};
-        std::unordered_map<std::string, UniformInfo> FragmentUniformInfos{};
+        std::unordered_map<std::string, uint32_t> VertexUniformInfos{};
+        std::unordered_map<std::string, uint32_t> FragmentUniformInfos{};
 
         bgfx::ProgramHandle Handle{bgfx::kInvalidHandle};
 
@@ -272,7 +272,9 @@ namespace Babylon
 
         std::vector<Napi::FunctionReference> m_requestAnimationFrameCallbacks{};
 
+        ResourceTable<UniformInfo> m_uniformInfos{};
         ResourceTable<VertexArray> m_vertexArrays{};
+
         const VertexArray* m_boundVertexArray{};
         FrameBuffer m_defaultFrameBuffer;
         FrameBuffer* m_boundFrameBuffer{};

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "BgfxCallback.h"
-#include "FrameBuffer.h"
 #include "PerFrameValue.h"
 #include "ShaderCompiler.h"
 
@@ -9,6 +7,9 @@
 #include <Babylon/JsRuntimeScheduler.h>
 
 #include <GraphicsImpl.h>
+#include <BgfxCallback.h>
+#include <FrameBuffer.h>
+#include <ResourceManagement.h>
 
 #include <napi/napi.h>
 
@@ -26,57 +27,6 @@
 
 namespace Babylon
 {
-    template<typename T>
-    class ResourceTable final
-    {
-    public:
-        uint32_t Add(T resource)
-        {
-            const uint32_t resourceHandle{m_nextResourceId};
-            m_resources.insert({resourceHandle, std::move(resource)});
-            m_nextResourceId++;
-            return resourceHandle;
-        }
-
-        T& Get(uint32_t resourceHandle)
-        {
-            return m_resources.at(resourceHandle);
-        }
-
-        void Remove(uint32_t resourceHandle)
-        {
-            m_resources.erase(resourceHandle);
-        }
-
-    private:
-        uint32_t m_nextResourceId{1};
-        std::unordered_map<uint32_t, T> m_resources{};
-    };
-
-    template<typename T>
-    struct NativeResource
-    {
-    public:
-        static T& Get(uint32_t handle)
-        {
-            return s_resources.Get(handle);
-        }
-
-        template<typename... Args>
-        static uint32_t Create(Args&&... args)
-        {
-            return s_resources.Add({std::forward<Args>(args)...});
-        }
-
-        static void Delete(uint32_t handle)
-        {
-            s_resources.Remove(handle);
-        }
-
-    private:
-        inline static ResourceTable<T> s_resources{};
-    };
-
     struct TextureData final : public NativeResource<TextureData>
     {
         ~TextureData()

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -278,7 +278,8 @@ namespace Babylon
         void Dispose(const Napi::CallbackInfo& info);
         void RequestAnimationFrame(const Napi::CallbackInfo& info);
         Napi::Value CreateVertexArray(const Napi::CallbackInfo& info);
-        void DeleteVertexArray(const Napi::CallbackInfo& info);
+        //void DeleteVertexArray(const Napi::CallbackInfo& info);
+        void DeleteVertexArray(CommandBufferDecoder& decoder);
         //void BindVertexArray(const Napi::CallbackInfo& info);
         void BindVertexArray(CommandBufferDecoder& decoder);
         Napi::Value CreateIndexBuffer(const Napi::CallbackInfo& info);

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -196,7 +196,7 @@ namespace Babylon
 
     class VertexBufferData;
 
-    struct VertexArray final
+    struct VertexArray final : public NativeResource<VertexArray>
     {
         ~VertexArray()
         {
@@ -418,8 +418,6 @@ namespace Babylon
         Napi::Reference<Napi::Uint32Array> m_commandUint32Buffer{};
         Napi::Reference<Napi::Float32Array> m_commandFloat32Buffer{};
         inline static ResourceTable<void(NativeEngine::*)(CommandBufferDecoder&)> s_commandTable{};
-
-        ResourceTable<VertexArray> m_vertexArrays{};
 
         const VertexArray* m_boundVertexArray{};
         FrameBuffer m_defaultFrameBuffer;

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -354,6 +354,7 @@ namespace Babylon
 
         std::vector<Napi::FunctionReference> m_requestAnimationFrameCallbacks{};
 
+        inline static ResourceTable<void(NativeEngine::*)(CommandBufferDecoder&)> s_commandTable{};
         ResourceTable<UniformInfo> m_uniformInfos{};
         ResourceTable<VertexArray> m_vertexArrays{};
         ResourceTable<IndexBufferData*> m_indexBuffers{};

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -21,7 +21,6 @@
 
 #include <assert.h>
 
-#include <arcana/containers/weak_table.h>
 #include <arcana/threading/cancellation.h>
 #include <unordered_map>
 
@@ -34,7 +33,8 @@ namespace Babylon
         uint32_t Add(T resource)
         {
             const uint32_t resourceHandle{m_nextResourceId};
-            m_resources.insert({resourceHandle, std::move(resource)});
+            //m_resources.insert({resourceHandle, std::move(resource)});
+            m_resources.emplace(resourceHandle, std::move(resource));
             m_nextResourceId++;
             return resourceHandle;
         }
@@ -108,10 +108,10 @@ namespace Babylon
         bgfx::UniformHandle Handle{bgfx::kInvalidHandle};
     };
 
-    struct ProgramData final
+    struct ProgramData final : public NativeResource<ProgramData>
     {
         ProgramData() = default;
-        ProgramData(const ProgramData&) = delete;
+        //ProgramData(const ProgramData&) = delete;
         ProgramData(ProgramData&&) = delete;
 
         ~ProgramData()
@@ -398,7 +398,7 @@ namespace Babylon
         ShaderCompiler m_shaderCompiler{};
 
         ProgramData* m_currentProgram{nullptr};
-        arcana::weak_table<std::unique_ptr<ProgramData>> m_programDataCollection{};
+        std::unordered_set<uint32_t> m_programDataCollection{};
 
         JsRuntime& m_runtime;
         GraphicsImpl& m_graphicsImpl;

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -311,6 +311,9 @@ namespace Babylon
         Napi::Value ResizeImageBitmap(const Napi::CallbackInfo& info);
         void GetFrameBufferData(const Napi::CallbackInfo& info);
         void SetStencil(const Napi::CallbackInfo& info);
+        void SetCommandBuffer(const Napi::CallbackInfo& info);
+        void SetCommandUint32Buffer(const Napi::CallbackInfo& info);
+        void SetCommandFloat32Buffer(const Napi::CallbackInfo& info);
         void SubmitCommandBuffer(const Napi::CallbackInfo& info);
         void Draw(bgfx::Encoder* encoder, int fillMode);
 
@@ -354,7 +357,11 @@ namespace Babylon
 
         std::vector<Napi::FunctionReference> m_requestAnimationFrameCallbacks{};
 
+        Napi::Reference<Napi::Uint8Array> m_commandBuffer{};
+        Napi::Reference<Napi::Uint32Array> m_commandUint32Buffer{};
+        Napi::Reference<Napi::Float32Array> m_commandFloat32Buffer{};
         inline static ResourceTable<void(NativeEngine::*)(CommandBufferDecoder&)> s_commandTable{};
+
         ResourceTable<UniformInfo> m_uniformInfos{};
         ResourceTable<VertexArray> m_vertexArrays{};
         ResourceTable<IndexBufferData*> m_indexBuffers{};

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -283,11 +283,13 @@ namespace Babylon
         //void BindVertexArray(const Napi::CallbackInfo& info);
         void BindVertexArray(CommandBufferDecoder& decoder);
         Napi::Value CreateIndexBuffer(const Napi::CallbackInfo& info);
-        void DeleteIndexBuffer(const Napi::CallbackInfo& info);
+        //void DeleteIndexBuffer(const Napi::CallbackInfo& info);
+        void DeleteIndexBuffer(CommandBufferDecoder& decoder);
         void RecordIndexBuffer(const Napi::CallbackInfo& info);
         void UpdateDynamicIndexBuffer(const Napi::CallbackInfo& info);
         Napi::Value CreateVertexBuffer(const Napi::CallbackInfo& info);
-        void DeleteVertexBuffer(const Napi::CallbackInfo& info);
+        //void DeleteVertexBuffer(const Napi::CallbackInfo& info);
+        void DeleteVertexBuffer(CommandBufferDecoder& decoder);
         void RecordVertexBuffer(const Napi::CallbackInfo& info);
         void UpdateDynamicVertexBuffer(const Napi::CallbackInfo& info);
         Napi::Value CreateProgram(const Napi::CallbackInfo& info);

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -282,7 +282,8 @@ namespace Babylon
         Napi::Value GetUniforms(const Napi::CallbackInfo& info);
         Napi::Value GetAttributes(const Napi::CallbackInfo& info);
         void SetProgram(const Napi::CallbackInfo& info);
-        void SetState(const Napi::CallbackInfo& info);
+        //void SetState(const Napi::CallbackInfo& info);
+        void SetState(CommandBufferDecoder& decoder);
         void SetZOffset(const Napi::CallbackInfo& info);
         Napi::Value GetZOffset(const Napi::CallbackInfo& info);
         void SetDepthTest(const Napi::CallbackInfo& info);

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -96,8 +96,14 @@ namespace Babylon
         uint8_t AnisotropicLevel{0};
     };
 
-    struct UniformInfo final
+    struct UniformInfo final : public NativeResource<UniformInfo>
     {
+        UniformInfo(uint8_t stage, bgfx::UniformHandle handle) :
+            Stage{stage},
+            Handle{handle}
+        {
+        }
+
         uint8_t Stage{};
         bgfx::UniformHandle Handle{bgfx::kInvalidHandle};
     };
@@ -413,7 +419,6 @@ namespace Babylon
         Napi::Reference<Napi::Float32Array> m_commandFloat32Buffer{};
         inline static ResourceTable<void(NativeEngine::*)(CommandBufferDecoder&)> s_commandTable{};
 
-        ResourceTable<UniformInfo> m_uniformInfos{};
         ResourceTable<VertexArray> m_vertexArrays{};
 
         const VertexArray* m_boundVertexArray{};

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -291,7 +291,8 @@ namespace Babylon
         void SetTextureSampling(const Napi::CallbackInfo& info);
         void SetTextureWrapMode(const Napi::CallbackInfo& info);
         void SetTextureAnisotropicLevel(const Napi::CallbackInfo& info);
-        void SetTexture(const Napi::CallbackInfo& info);
+        //void SetTexture(const Napi::CallbackInfo& info);
+        void SetTexture(CommandBufferDecoder& decoder);
         void SetTexture2(const Napi::CallbackInfo& info);
         void SetTexture3(const Napi::CallbackInfo& info);
         void DeleteTexture(const Napi::CallbackInfo& info);

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -33,8 +33,7 @@ namespace Babylon
         uint32_t Add(T resource)
         {
             const uint32_t resourceHandle{m_nextResourceId};
-            //m_resources.insert({resourceHandle, std::move(resource)});
-            m_resources.emplace(resourceHandle, std::move(resource));
+            m_resources.insert({resourceHandle, std::move(resource)});
             m_nextResourceId++;
             return resourceHandle;
         }
@@ -111,8 +110,16 @@ namespace Babylon
     struct ProgramData final : public NativeResource<ProgramData>
     {
         ProgramData() = default;
-        //ProgramData(const ProgramData&) = delete;
-        ProgramData(ProgramData&&) = delete;
+        ProgramData(const ProgramData&) = delete;
+        ProgramData(ProgramData&& other) :
+            VertexAttributeLocations{std::move(other.VertexAttributeLocations)},
+            VertexUniformInfos{std::move(other.VertexUniformInfos)},
+            FragmentUniformInfos{std::move(other.FragmentUniformInfos)},
+            Handle{other.Handle},
+            Uniforms{std::move(other.Uniforms)}
+        {
+            other.Handle.idx = bgfx::kInvalidHandle;
+        };
 
         ~ProgramData()
         {
@@ -397,7 +404,7 @@ namespace Babylon
 
         ShaderCompiler m_shaderCompiler{};
 
-        ProgramData* m_currentProgram{nullptr};
+        uint32_t m_currentProgram{};
         std::unordered_set<uint32_t> m_programDataCollection{};
 
         JsRuntime& m_runtime;

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -155,11 +155,11 @@ namespace Babylon
 
             constexpr auto nonDynamic = [](auto& handle) {
                 // TODO: Fix this const cast
-                const_cast<bgfx::IndexBufferHandle&>(handle).idx = bgfx::kInvalidHandle;
+                const_cast<Handle1T&>(handle).idx = bgfx::kInvalidHandle;
             };
             constexpr auto dynamic = [](auto& handle) {
                 // TODO: Fix this const cast
-                const_cast<bgfx::DynamicIndexBufferHandle&>(handle).idx = bgfx::kInvalidHandle;
+                const_cast<Handle2T&>(handle).idx = bgfx::kInvalidHandle;
             };
             other.DoForHandleTypes(nonDynamic, dynamic);
         }
@@ -194,7 +194,21 @@ namespace Babylon
         void SetBgfxIndexBuffer(bgfx::Encoder* encoder, uint32_t firstIndex, uint32_t numIndices) const;
     };
 
-    class VertexBufferData;
+    class VertexBufferData final : protected VariantHandleHolder<bgfx::VertexBufferHandle, bgfx::DynamicVertexBufferHandle>, public NativeResource<VertexBufferData>
+    {
+    public:
+        VertexBufferData(const Napi::Uint8Array& bytes, bool dynamic);
+        VertexBufferData(VertexBufferData&& other) = default;
+        ~VertexBufferData();
+        template<typename sourceType> void PromoteToFloats(uint32_t numElements, uint32_t byteOffset, uint32_t byteStride);
+        void PromoteToFloats(bgfx::AttribType::Enum attribType, uint32_t numElements, uint32_t byteOffset, uint32_t byteStride);
+        void EnsureFinalized(Napi::Env /*env*/, const bgfx::VertexLayout& layout);
+        void Update(Napi::Env env, const Napi::Uint8Array& bytes, uint32_t offset, uint32_t byteLength);
+        void SetAsBgfxVertexBuffer(bgfx::Encoder* encoder, uint8_t index, uint32_t startVertex, uint32_t numVertices, bgfx::VertexLayoutHandle layout) const;
+
+    private:
+        std::vector<uint8_t> m_bytes{};
+    };
 
     struct VertexArray final : public NativeResource<VertexArray>
     {

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -347,7 +347,8 @@ namespace Babylon
         Napi::Value CreateImageBitmap(const Napi::CallbackInfo& info);
         Napi::Value ResizeImageBitmap(const Napi::CallbackInfo& info);
         void GetFrameBufferData(const Napi::CallbackInfo& info);
-        void SetStencil(const Napi::CallbackInfo& info);
+        //void SetStencil(const Napi::CallbackInfo& info);
+        void SetStencil(CommandBufferDecoder& decoder);
         void SetCommandBuffer(const Napi::CallbackInfo& info);
         void SetCommandUint32Buffer(const Napi::CallbackInfo& info);
         void SetCommandFloat32Buffer(const Napi::CallbackInfo& info);

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -698,6 +698,7 @@ namespace Babylon
 
                             auto jsWidth{Napi::Value::From(m_env, viewConfig.ViewTextureSize.Width)};
                             auto jsHeight{Napi::Value::From(m_env, viewConfig.ViewTextureSize.Height)};
+                            // TODO (ryantrem) the frame buffer should be getting deleted by JS (via NativeEngine.deleteTexture), so is this double deleting?
                             auto jsFrameBuffer{Napi::External<FrameBuffer>::New(m_env, frameBuffer, [](Napi::Env, FrameBuffer* data) { delete data; })};
                             viewConfig.JsTextures[frameBuffer] = Napi::Persistent(m_sessionState->CreateRenderTexture.Call({jsWidth, jsHeight, jsFrameBuffer}).As<Napi::Object>());
                         }

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -116,7 +116,7 @@ namespace Babylon::Polyfills::Internal
         textureData->OwnsHandle = false;
         textureData->Width = m_width;
         textureData->Height = m_height;
-        // TODO
+        // TODO (ryantrem)
         return Napi::External<TextureData>::New(info.Env(), textureData, [](Napi::Env, TextureData* data) { delete data; });
     }
 

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -116,6 +116,7 @@ namespace Babylon::Polyfills::Internal
         textureData->OwnsHandle = false;
         textureData->Width = m_width;
         textureData->Height = m_height;
+        // TODO
         return Napi::External<TextureData>::New(info.Env(), textureData, [](Napi::Env, TextureData* data) { delete data; });
     }
 


### PR DESCRIPTION
The Babylon.js half of this change is here: 

Engine related resources are now have numeric handles, and those handles are what gets passed back to JavaScript. This allows "references" to these resources to be encoded into a command buffer, such that many calls to native are mashed down to a single call (in the common case of the render loop). This drastically reduces the per-frame overhead of calling into native code. The notable parts of this change are:

- Introduction of the `ResourceTable` and `NativeResource` constructs, which are the (simple) core mechanisms for managing resources by numeric handle.
- All native resources created and managed by JS now inherit from `NativeResource`, and the associated numeric handle is passed back to JS.
- A command buffer and associated command argument buffers are passed from JS to native (as typed arrays).
- Introduction of a `CommandBufferDecoder` that reads commands and their arguments out of those typed arrays.
- Many `NativeEngine` functions are converted from Napi based functions to command buffer based functions (they read args from the `CommandBufferDecoder`, and they have generated command ids that are exposed off of `NativeEngine` to the JS side (so those commands can properly be encoded).
- There is a new `submitCommandBuffer` Napi based function that can be called to process a command buffer. In my tests, this command buffer often has around ~2000 commands encoded into it per frame.

Some other changes included are:
- `FrameBuffer` no longer has a `Dispose` function, and instead just does its cleanup in the destructor. It used to dispose when the `External<FrameBuffer>` got garbage collected on the JS side, but now the JS side just has a numeric handle, so we can't hook into finalization. Rather, `FrameBuffer`s are just deleted in the `NativeEngine::DeleteFrameBuffer` call.

There is a bunch of work to do to finish this change:
- [ ] Convert a bunch more functions to use the command buffer (not everything, but probably all functions that set state or delete resources (creating resources needs to continue to be synchronous, or the numeric resource handles need to be generated on the JS side and passed to the native side)).
- [ ] `ResourceTable` is a very naive implementation - it's just a map with a handle that increases indefinitely. The numeric type is `uint32_t`, so I think it is unlikely that we will ever create more than 4.3 billion native resources in a single run of an app, but maybe we should be smarter about this (at least check for overflow on increment).
- [ ] Shader programs were previously returned as an `External<ProgramData>`, and *relied* on JS GC to delete those objects. Now, they are only deleted when the `NativeEngine` instance is destroyed. There should be an explicit call from JS to do this, perhaps in `_releaseEffect` (not sure, need to check with @bghgary).
- [ ] Buffer validation (see description in the associated Babylon.js PR).
- [ ] Revert the changes around move semantics for native resources. I started going down this path because I was storing native resources directly, but this got complicated so I ended up just switching to using `unique_ptr`s and just moving the `unique_ptr` itself.
- [ ] Update (and test) `NativeCamera` to use `TextureData::Get(info[0].ToNumber().Uint32Value())` instead of `info[0].As<Napi::External<TextureData>>().Data()`.
- [ ] Update (and test) `NativeCapture` to use `FrameBuffer::Get(info[0].ToNumber().Uint32Value())` instead of `info[0].As<Napi::External<FrameBuffer>>().Data()`.
- [ ] Ensure `FrameBuffers` get cleaned up when `NativeEngine` is destroyed. Previously, we relied on the JS side GC to trigger the `External<FrameBuffer>` finalizer and delete the `FrameBuffer` (which already isn't great, but is now just broken).
- [ ] Fix NativeXR's `FrameBuffer` management to not use `Napi::External<FrameBuffer>`. We probably need to do some more work to ensure they are explicitly deleted as well.
- [ ] Change the way `Canvas` deals with textures. Currently, it creates a texture and relies on JS GC to delete it. Instead, `NativeEngine.updateDynamicTexture` (on the JS side) should probably be responsible for creating the texture, then `Canvas` should expose a `LoadCanvasTexture` function instead of a `GetCanvasTexture` function (which does exactly the same thing, but doesn't create the texture), then after `NativeEngine.updateDynamicTexture` calls `LoadCanvasTexture` it can safely call `deleteTexture` (on the texture it created and owns).
- [ ] Make reference/pointer semantics consistent for native resources (currently the code sometimes deals with them as pointers, sometimes as references).
- [ ] Probably switch `m_currentProgram` back to a raw pointer. I switched it to a handle because it seemed dangerous to hold onto a raw pointer of an object with move semantics that is expected to move, but when we revert those changes its not a movable object and so holding the pointer directly seems fine.
- [ ] Test on other platforms (I've only tested on iOS so far).
- [ ] Remove all the commented out code (left there to make testing the old code path easier).
- [ ] Merge master.