### PR TITLE
 Update to babylonjs 5.0.0-alpha.44

### DIFF
--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -5,38 +5,38 @@
   "requires": true,
   "dependencies": {
     "babylonjs": {
-      "version": "5.0.0-alpha.38",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-5.0.0-alpha.38.tgz",
-      "integrity": "sha512-yZJhOaH+VVnTperRZzPJXqLdFB7oKr3HxRcauxhgD2iO7kHwDnbXIqQV2w1aRBtEv7s+N4WDhOikTV8F7rzN1w=="
+      "version": "5.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-5.0.0-alpha.44.tgz",
+      "integrity": "sha512-FSZNBLoKakOjibFz+NXuEXJfFeCOLqizMRoDmOurhBedchm7g90gXyh4dl8SD7p2w+SEmT59yG+rASkYh0ECjw=="
     },
     "babylonjs-gltf2interface": {
-      "version": "5.0.0-alpha.38",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-alpha.38.tgz",
-      "integrity": "sha512-e1IRFMn3fKs79vAZwb0cAHmU97SwsLVnHWhoLPR+bDDjl4EjjwzmEmN3TBepO9jrySGm9oZ1CY5lhVWGMwsGsw=="
+      "version": "5.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-alpha.44.tgz",
+      "integrity": "sha512-t253Yf3SCTwcshXrXa2kYYBh24M7twx0IffKSJhmdtHA1zyZAQ+g8GScoh9cgmoDysQ6KoZ0xGuxJfj7axFT5w=="
     },
     "babylonjs-gui": {
-      "version": "5.0.0-alpha.38",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-5.0.0-alpha.38.tgz",
-      "integrity": "sha512-hi4THagz4kEhN0l3A2ySDFPpJ9JDoNJ59azsQ/lqzj70ef/rGw1UHRJZX9hcBxJqxqE+/TxUshQrtVWJ5QlU8Q==",
+      "version": "5.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-5.0.0-alpha.44.tgz",
+      "integrity": "sha512-Mi+Jinj/ls4niUdifjJvV5ztCG4npTwTIxhEAVoyzb7c6wOdpYIgHbnji7TNGhF7clEFoOcXiQAzx7vE78QBSg==",
       "requires": {
-        "babylonjs": "5.0.0-alpha.38"
+        "babylonjs": "5.0.0-alpha.44"
       }
     },
     "babylonjs-loaders": {
-      "version": "5.0.0-alpha.38",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-5.0.0-alpha.38.tgz",
-      "integrity": "sha512-he4sbb5RZt1a7FGBYj8oXB+XoYFr082hpZKnYjXLnwJjPmON0qHXPeJn0tnBhsPGDWKOiTyAQWnd9muzG5jiXg==",
+      "version": "5.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-5.0.0-alpha.44.tgz",
+      "integrity": "sha512-5hi/qse/gGlhUaEcysR9XD79lAvn+QVqWWtURH0U4mZFfLT6Y1/mSKu7rqomtW9zVZknUig+vyhNkGd1C2d+pw==",
       "requires": {
-        "babylonjs": "5.0.0-alpha.38",
-        "babylonjs-gltf2interface": "5.0.0-alpha.38"
+        "babylonjs": "5.0.0-alpha.44",
+        "babylonjs-gltf2interface": "5.0.0-alpha.44"
       }
     },
     "babylonjs-materials": {
-      "version": "5.0.0-alpha.38",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-5.0.0-alpha.38.tgz",
-      "integrity": "sha512-ezHCmCtsZ6J0qnkEpLTiQj8qfzGqS4fBGbR5VMa5E2IFIHcqA6CFFClPvsg4rc4aWgkGSvA3hXi0xcpkaMilQw==",
+      "version": "5.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-5.0.0-alpha.44.tgz",
+      "integrity": "sha512-wYYOmyZM22NU3QnW4Xtm0wuLyf7RMuPr6Ko5hm5fqrBY444MiL3WwoXtwkaNRs/96f2bohke7PYAQ4NONg9BEQ==",
       "requires": {
-        "babylonjs": "5.0.0-alpha.38"
+        "babylonjs": "5.0.0-alpha.44"
       }
     },
     "jsc-android": {

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "babylonjs": "5.0.0-alpha.38",
-    "babylonjs-gui": "5.0.0-alpha.38",
-    "babylonjs-loaders": "5.0.0-alpha.38",
-    "babylonjs-materials": "5.0.0-alpha.38",
+    "babylonjs": "5.0.0-alpha.44",
+    "babylonjs-gui": "5.0.0-alpha.44",
+    "babylonjs-loaders": "5.0.0-alpha.44",
+    "babylonjs-materials": "5.0.0-alpha.44",
     "jsc-android": "^241213.1.0",
     "v8-android": "^7.8.2"
   }


### PR DESCRIPTION
Fixes #871

This is the last step to fixing the problem. It brings in a change that will not call clear for `immersive-ar` scenarios.

Testing:
- [x] Win32 - MR
- [x] Android
- [x] iOS