### PR TITLE
Fix Resize for Apple

### DIFF
--- a/Apps/Playground/iOS/LibNativeBridge.mm
+++ b/Apps/Playground/iOS/LibNativeBridge.mm
@@ -46,7 +46,6 @@ bool g_isXrActive{};
     graphicsConfig.Width = static_cast<size_t>(width);
     graphicsConfig.Height = static_cast<size_t>(height);
     graphics = Babylon::Graphics::CreateGraphics(graphicsConfig);
-    graphics->StartRenderingCurrentFrame();
     runtime = std::make_unique<Babylon::AppRuntime>();
     inputBuffer = std::make_unique<InputManager<Babylon::AppRuntime>::InputBuffer>(*runtime);
 
@@ -98,8 +97,8 @@ bool g_isXrActive{};
 {
     if (graphics)
     {
-        graphics->FinishRenderingCurrentFrame();
         graphics->StartRenderingCurrentFrame();
+        graphics->FinishRenderingCurrentFrame();
     }
 }
 

--- a/Apps/Playground/macOS/ViewController.mm
+++ b/Apps/Playground/macOS/ViewController.mm
@@ -32,8 +32,8 @@ std::unique_ptr<InputManager<Babylon::AppRuntime>::InputBuffer> inputBuffer{};
 - (void)drawInMTKView:(MTKView *)__unused view
 {
     if (graphics) {
-        graphics->FinishRenderingCurrentFrame();
         graphics->StartRenderingCurrentFrame();
+        graphics->FinishRenderingCurrentFrame();
     }
 }
 
@@ -46,11 +46,6 @@ std::unique_ptr<InputManager<Babylon::AppRuntime>::InputBuffer> inputBuffer{};
 }
 
 - (void)uninitialize {
-    if (graphics)
-    {
-        graphics->FinishRenderingCurrentFrame();
-    }
-
     inputBuffer.reset();
     runtime.reset();
     graphics.reset();
@@ -82,7 +77,6 @@ std::unique_ptr<InputManager<Babylon::AppRuntime>::InputBuffer> inputBuffer{};
     graphicsConfig.Width = width;
     graphicsConfig.Height = height;
     graphics = Babylon::Graphics::CreateGraphics(graphicsConfig);
-    graphics->StartRenderingCurrentFrame();
 
     runtime = std::make_unique<Babylon::AppRuntime>();
     inputBuffer = std::make_unique<InputManager<Babylon::AppRuntime>::InputBuffer>(*runtime);

--- a/Core/Graphics/Source/FrameBuffer.cpp
+++ b/Core/Graphics/Source/FrameBuffer.cpp
@@ -47,12 +47,12 @@ namespace Babylon
 
     uint16_t FrameBuffer::Width() const
     {
-        return (m_width == 0 ? bgfx::getStats()->width : m_width);
+        return (m_width == 0 ? m_impl.GetWidth() : m_width);
     }
 
     uint16_t FrameBuffer::Height() const
     {
-        return (m_height == 0 ? bgfx::getStats()->height : m_height);
+        return (m_height == 0 ? m_impl.GetHeight() : m_height);
     }
 
     bool FrameBuffer::DefaultBackBuffer() const

--- a/Core/Graphics/Source/GraphicsImpl.cpp
+++ b/Core/Graphics/Source/GraphicsImpl.cpp
@@ -69,6 +69,16 @@ namespace Babylon
         UpdateBgfxResolution();
     }
 
+    size_t GraphicsImpl::GetWidth() const
+    {
+        return m_state.Resolution.Width;
+    }
+
+    size_t GraphicsImpl::GetHeight() const
+    {
+        return m_state.Resolution.Height;
+    }
+
     void GraphicsImpl::AddToJavaScript(Napi::Env env)
     {
         JsRuntime::NativeObject::GetFromJavaScript(env)

--- a/Core/Graphics/Source/GraphicsImpl.h
+++ b/Core/Graphics/Source/GraphicsImpl.h
@@ -74,6 +74,8 @@ namespace Babylon
         void UpdateWindow(const WindowConfiguration& config);
         void UpdateContext(const ContextConfiguration& config);
         void Resize(size_t width, size_t height);
+        size_t GetWidth() const;
+        size_t GetHeight() const;
 
         void AddToJavaScript(Napi::Env);
         static GraphicsImpl& GetFromJavaScript(Napi::Env);


### PR DESCRIPTION
fixes #877 

This bug has 2 parts but are both related to a 1 frame delay of resize infos propagation.

1)

`StartRenderingCurrentFrame` and `FinishRenderingCurrentFrame` are called once per frame but do not concern the same frame. Frame is rendered using previous back buffer size and a new one is started just after. Scisor infos in bgfx were out of sync leading to an assert in Metal. 
This one doesn't concern BabylonReactNative:
https://github.com/BabylonJS/BabylonReactNative/blob/eea89150682a28155811d671666dfe553bf34d61/Modules/%40babylonjs/react-native/shared/BabylonNative.cpp#L111
OpenGL and D3D are more tolerant to view rect different from backbuffer dimension. Metal and Vulkan are more strict.

2)

In the next frame rendering after a resize, the view rect was using `bgfx::getStats()` to get the dimension. As the rendering/init didn't occur yet, it returned the former size. Because the viewRect is different from the backBuffer dimension, `clearWithRenderPass` is false:
https://github.com/bkaradzic/bgfx/blob/ad8e7eb974c943757c804f121ca52f60048d129c/src/renderer_mtl.mm#L3906
And the attachment store action is not set here:

https://github.com/bkaradzic/bgfx/blob/ad8e7eb974c943757c804f121ca52f60048d129c/src/renderer_mtl.mm#L3955

When this happens, it does nothing when MSAA is off. But assert and crashes with MSAA.
I think setting a storeAction here:
https://github.com/bkaradzic/bgfx/blob/ad8e7eb974c943757c804f121ca52f60048d129c/src/renderer_mtl.mm#L4002
is needed and I'll do a PR in bgfx but anyways, the size provided to bgfx is wrong. 
Before this PR, when MSAA is off and window is resized, there were some rendering artifacts in the border. This this PR, the size is correct and there is no more artifact.



