### PR TITLE
Move XHR URL encoding to JavaScript

### DIFF
--- a/Apps/UnitTests/Scripts/tests.js
+++ b/Apps/UnitTests/Scripts/tests.js
@@ -39,11 +39,11 @@ describe("XMLHTTPRequest", function () {
         expect(xhr.status).to.equal(200);
     })
     it("should load URLs with escaped spaces", async function () {
-        const xhr = await createRequest("GET", "https://github.com/BabylonJS/Assets/raw/master/meshes/aerobatic%20plane.glb");
+        const xhr = await createRequest("GET", "https://powermrblobtest.blob.core.windows.net/modles/Airplane%20Galaxy.glb");
         expect(xhr.status).to.equal(200);
     })
     it("should load URLs with unescaped spaces", async function () {
-        const xhr = await createRequest("GET", "https://github.com/BabylonJS/Assets/raw/master/meshes/aerobatic plane.glb");
+        const xhr = await createRequest("GET", "https://powermrblobtest.blob.core.windows.net/modles/Airplane Galaxy.glb");
         expect(xhr.status).to.equal(200);
     })
     it("should have status=404 for a file that does not exist", async function () {

--- a/Apps/UnitTests/Scripts/tests.js
+++ b/Apps/UnitTests/Scripts/tests.js
@@ -38,12 +38,16 @@ describe("XMLHTTPRequest", function () {
         const xhr = await createRequest("GET", "https://babylonjs.com");
         expect(xhr.status).to.equal(200);
     })
+    it("should load URL with no spaces", async function () {
+        const xhr = await createRequest("GET", "https://github.com/BabylonJS/Assets/raw/master/meshes/aerobatic_plane.glb");
+        expect(xhr.status).to.equal(200);
+    })
     it("should load URLs with escaped spaces", async function () {
-        const xhr = await createRequest("GET", "https://powermrblobtest.blob.core.windows.net/modles/Airplane%20Galaxy.glb");
+        const xhr = await createRequest("GET", "https://github.com/BabylonJS/Assets/raw/master/meshes/aerobatic%20plane.glb");
         expect(xhr.status).to.equal(200);
     })
     it("should load URLs with unescaped spaces", async function () {
-        const xhr = await createRequest("GET", "https://powermrblobtest.blob.core.windows.net/modles/Airplane Galaxy.glb");
+        const xhr = await createRequest("GET", "https://github.com/BabylonJS/Assets/raw/master/meshes/aerobatic plane.glb");
         expect(xhr.status).to.equal(200);
     })
     it("should have status=404 for a file that does not exist", async function () {

--- a/Apps/UnitTests/Scripts/tests.js
+++ b/Apps/UnitTests/Scripts/tests.js
@@ -38,6 +38,14 @@ describe("XMLHTTPRequest", function () {
         const xhr = await createRequest("GET", "https://babylonjs.com");
         expect(xhr.status).to.equal(200);
     })
+    it("should load URLs with escaped spaces", async function () {
+        const xhr = await createRequest("GET", "https://github.com/BabylonJS/Assets/raw/master/meshes/aerobatic%20plane.glb");
+        expect(xhr.status).to.equal(200);
+    })
+    it("should load URLs with unescaped spaces", async function () {
+        const xhr = await createRequest("GET", "https://github.com/BabylonJS/Assets/raw/master/meshes/aerobatic plane.glb");
+        expect(xhr.status).to.equal(200);
+    })
     it("should have status=404 for a file that does not exist", async function () {
         const xhr = await createRequest("GET", "https://babylonjs.com/invalid");
         expect(xhr.status).to.equal(404);

--- a/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
+++ b/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
@@ -26,7 +26,7 @@ namespace UrlLib
         void Open(UrlMethod method, std::string url)
         {
             m_method = method;
-            NSString* urlString = [[NSString stringWithUTF8String:url.data()] stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
+            NSString* urlString = [NSString stringWithUTF8String:url.data()];
             m_nsURL = {[NSURL URLWithString:urlString]};
             if (!m_nsURL || !m_nsURL.scheme)
             {

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
@@ -183,7 +183,10 @@ namespace Babylon::Polyfills::Internal
             auto inputURL{info[1].As<Napi::String>()};
             auto decodedURL{info.Env().Global().Get("decodeURI").As<Napi::Function>().Call({inputURL}).As<Napi::String>()};
             auto encodedURL{inputURL};
-            if (inputURL.StrictEquals(decodedURL)) {
+            // We need to percent encode the URL
+            // If decoding the URL changes something, it's already encoded - don't change anything
+            if (inputURL.StrictEquals(decodedURL))
+            {
                 encodedURL = info.Env().Global().Get("encodeURI").As<Napi::Function>().Call({inputURL}).As<Napi::String>();
             }
             m_request.Open(MethodType::StringToEnum(info[0].As<Napi::String>().Utf8Value()), encodedURL.Utf8Value());

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
@@ -180,7 +180,13 @@ namespace Babylon::Polyfills::Internal
     {
         try
         {
-            m_request.Open(MethodType::StringToEnum(info[0].As<Napi::String>().Utf8Value()), info[1].As<Napi::String>().Utf8Value());
+            auto inputURL{info[1].As<Napi::String>()};
+            auto decodedURL{info.Env().Global().Get("decodeURI").As<Napi::Function>().Call({inputURL}).As<Napi::String>()};
+            auto encodedURL{inputURL};
+            if (inputURL.StrictEquals(decodedURL)) {
+                encodedURL = info.Env().Global().Get("encodeURI").As<Napi::Function>().Call({inputURL}).As<Napi::String>();
+            }
+            m_request.Open(MethodType::StringToEnum(info[0].As<Napi::String>().Utf8Value()), encodedURL.Utf8Value());
             SetReadyState(ReadyState::Opened);
         }
         catch (const std::exception& e)


### PR DESCRIPTION
This PR removes platform-specific URI encoding in UrlLib, and replaces it with a call to encodeURI() from the XMLHttpRequest polyfill. This helps ensure consistency between platforms and allows us to remove the platform-specific encoding code for Apple and Unix.