### PR TITLE
Fix Apple Memory Management Bug in UrlLib

### DIFF
--- a/Dependencies/UrlLib/CMakeLists.txt
+++ b/Dependencies/UrlLib/CMakeLists.txt
@@ -36,5 +36,11 @@ target_include_directories(UrlLib PRIVATE "Source")
 target_link_libraries(UrlLib
     PUBLIC arcana
     ${ADDITIONAL_LIBRARIES})
+    
+if(APPLE)
+    set_target_properties(UrlLib PROPERTIES
+        XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)
+endif()
+
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
+++ b/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
@@ -1,7 +1,5 @@
 #if ! __has_feature(objc_arc)
-
 #error "ARC is off"
-
 #endif
 
 #include <UrlLib/UrlLib.h>

--- a/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
+++ b/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
@@ -16,6 +16,10 @@ namespace UrlLib
             {
                 [m_responseBuffer release];
             }
+            if (m_nsURL)
+            {
+                [m_nsURL release];
+            }
         }
 
         void Abort()
@@ -25,6 +29,10 @@ namespace UrlLib
 
         void Open(UrlMethod method, std::string url)
         {
+            if (m_nsURL)
+            {
+                [m_nsURL release];
+            }
             m_method = method;
             NSString* urlString = [[NSString stringWithUTF8String:url.data()] stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
             m_nsURL = {[NSURL URLWithString:urlString]};
@@ -42,6 +50,7 @@ namespace UrlLib
                 }
                 m_nsURL = [NSURL fileURLWithPath:path];
             }
+            [m_nsURL retain]; // Don't let this be released automatically
         }
 
         UrlResponseType ResponseType() const

--- a/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
+++ b/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
@@ -1,3 +1,9 @@
+#if ! __has_feature(objc_arc)
+
+#error "ARC is off"
+
+#endif
+
 #include <UrlLib/UrlLib.h>
 #include <arcana/threading/task.h>
 #include <arcana/threading/task_schedulers.h>
@@ -12,14 +18,6 @@ namespace UrlLib
         ~Impl()
         {
             Abort();
-            if (m_responseBuffer)
-            {
-                [m_responseBuffer release];
-            }
-            if (m_nsURL)
-            {
-                [m_nsURL release];
-            }
         }
 
         void Abort()
@@ -29,28 +27,24 @@ namespace UrlLib
 
         void Open(UrlMethod method, std::string url)
         {
-            if (m_nsURL)
-            {
-                [m_nsURL release];
-            }
             m_method = method;
             NSString* urlString = [[NSString stringWithUTF8String:url.data()] stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
-            m_nsURL = {[NSURL URLWithString:urlString]};
-            if (!m_nsURL || !m_nsURL.scheme)
+            NSURL* nsURL{[NSURL URLWithString:urlString]};
+            if (!nsURL || !nsURL.scheme)
             {
                 throw std::runtime_error{"URL does not have a valid scheme"};
             }
-            NSString* scheme{m_nsURL.scheme};
+            NSString* scheme{nsURL.scheme};
             if ([scheme isEqual:@"app"])
             {
-                NSString* path{[[NSBundle mainBundle] pathForResource:m_nsURL.path ofType:nil]};
+                NSString* path{[[NSBundle mainBundle] pathForResource:nsURL.path ofType:nil]};
                 if (path == nil)
                 {
                     throw std::runtime_error{"No file exists at local path"};
                 }
-                m_nsURL = [NSURL fileURLWithPath:path];
+                nsURL = [NSURL fileURLWithPath:path];
             }
-            [m_nsURL retain]; // Don't let this be released automatically
+            m_nsURL = nsURL; // Only store the URL if we didn't throw
         }
 
         UrlResponseType ResponseType() const
@@ -106,7 +100,6 @@ namespace UrlLib
                         }
                         case UrlResponseType::Buffer:
                         {
-                            [data retain];
                             m_responseBuffer = data;
                             break;
                         }


### PR DESCRIPTION
~~Currently, we are storing a pointer to an NSURL object when we call Open(), and then creating the URLRequest in SendAsync(). The problem is that it's possible for the underlying object to be released in between these calls. This fix simply increments the refCount on Open() and then decrements it when the object is destroyed or when Open() is called again.~~

Makes UrlLib use Automated Reference Counting: https://en.wikipedia.org/wiki/Automatic_Reference_Counting

This way, we no longer have to manually retain/release objects.

Also, stops storing the URL from Open() as a member variable unless it's a valid URL. If it's a bad URL, we should not be retaining it.