### PR TITLE
Canvas graphic resources flush

### DIFF
--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -33,6 +33,7 @@ std::unique_ptr<Babylon::AppRuntime> runtime{};
 std::unique_ptr<Babylon::Graphics> graphics{};
 std::unique_ptr<InputManager<Babylon::AppRuntime>::InputBuffer> inputBuffer{};
 std::unique_ptr<Babylon::Plugins::ChromeDevTools> chromeDevTools{};
+std::unique_ptr<Babylon::Polyfills::Canvas> g_nativeCanvas{};
 bool minimized{false};
 
 // Forward declarations of functions included in this code module:
@@ -124,7 +125,7 @@ namespace
             Babylon::Polyfills::Window::Initialize(env);
 
             Babylon::Polyfills::XMLHttpRequest::Initialize(env);
-            Babylon::Polyfills::Canvas::Initialize(env);
+            g_nativeCanvas = std::make_unique <Babylon::Polyfills::Canvas>(Babylon::Polyfills::Canvas::Initialize(env));
 
             Babylon::Plugins::NativeEngine::Initialize(env);
 

--- a/Polyfills/Canvas/Include/Babylon/Polyfills/Canvas.h
+++ b/Polyfills/Canvas/Include/Babylon/Polyfills/Canvas.h
@@ -2,7 +2,23 @@
 
 #include <napi/env.h>
 
-namespace Babylon::Polyfills::Canvas
+namespace Babylon::Polyfills
 {
-    void Initialize(Napi::Env env);
-}
+    class Canvas final
+    {
+    public:
+        class Impl;
+
+        Canvas(const Canvas& other) = default;
+        Canvas(Canvas&&) = default;
+        ~Canvas();
+
+        static Canvas Initialize(Napi::Env env);
+
+        void FlushGraphicResources();
+
+    private:
+        Canvas(std::shared_ptr<Impl> impl);
+        std::shared_ptr<Impl> m_impl{};
+    };
+} // namespace

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -8,11 +8,16 @@
 #include <assert.h>
 #include <NativeEngine.h>
 
+namespace
+{
+    constexpr auto JS_CANVAS_NAME = "_CanvasImpl";
+}
+
 namespace Babylon::Polyfills::Internal
 {
     static constexpr auto JS_CONSTRUCTOR_NAME = "NativeCanvas";
 
-    void NativeCanvas::CreateInstance(Napi::Env env)
+    void NativeCanvas::CreateInstance(Napi::Env env, std::shared_ptr<Polyfills::Canvas::Impl> nativeCanvas)
     {
         Napi::HandleScope scope{env};
 
@@ -33,11 +38,19 @@ namespace Babylon::Polyfills::Internal
 
     NativeCanvas::NativeCanvas(const Napi::CallbackInfo& info)
         : Napi::ObjectWrap<NativeCanvas>{info}
-        , m_graphicsImpl{ Babylon::GraphicsImpl::GetFromJavaScript(info.Env()) }
+        , m_graphicsImpl{Babylon::GraphicsImpl::GetFromJavaScript(info.Env())}
+        , m_canvasImpl{Polyfills::Canvas::Impl::GetFromJavaScript(info.Env())}
     {
+        m_canvasImpl.AddMonitoredResource(this);
     }
 
     NativeCanvas::~NativeCanvas()
+    {
+        m_canvasImpl.RemoveMonitoredResource(this);
+        Dispose();
+    }
+
+    void NativeCanvas::FlushGraphicResources()
     {
         Dispose();
     }
@@ -130,11 +143,74 @@ namespace Babylon::Polyfills::Internal
     }
 }
 
-namespace Babylon::Polyfills::Canvas
+namespace Babylon::Polyfills
 {
-    void Initialize(Napi::Env env)
+    Canvas::Impl::Impl(Napi::Env env)
+        : m_env{env}
     {
-        Internal::NativeCanvas::CreateInstance(env);
+        AddToJavaScript(env);
+    }
+
+    void Canvas::Impl::AddToJavaScript(Napi::Env env)
+    {
+        JsRuntime::NativeObject::GetFromJavaScript(env)
+            .Set(JS_CANVAS_NAME, Napi::External<Canvas::Impl>::New(env, this));
+    }
+
+    Canvas::Impl& Canvas::Impl::GetFromJavaScript(Napi::Env env)
+    {
+        return *JsRuntime::NativeObject::GetFromJavaScript(env)
+            .Get(JS_CANVAS_NAME)
+            .As<Napi::External<Canvas::Impl>>()
+            .Data();
+    }
+
+    void Canvas::Impl::AddMonitoredResource(MonitoredResource* monitoredResource)
+    {
+        if (std::find(m_monitoredResources.begin(), m_monitoredResources.end(), monitoredResource) == m_monitoredResources.end())
+        {
+            m_monitoredResources.push_back(monitoredResource);
+        }
+    }
+
+    void Canvas::Impl::RemoveMonitoredResource(MonitoredResource* monitoredResource)
+    {
+        auto iter = std::find(m_monitoredResources.begin(), m_monitoredResources.end(), monitoredResource);
+        if (iter != m_monitoredResources.end())
+        {
+            m_monitoredResources.erase(iter);
+        }
+    }
+
+    void Canvas::Impl::FlushGraphicResources()
+    {
+        for(auto monitoredResource : m_monitoredResources)
+        {
+            monitoredResource->FlushGraphicResources();
+        }
+    }
+
+    Canvas::Canvas(std::shared_ptr<Impl> impl)
+        : m_impl{std::move(impl)}
+    {
+    }
+
+    Canvas::~Canvas()
+    {
+    }
+
+    Canvas Canvas::Initialize(Napi::Env env)
+    {
+        auto impl{std::make_shared<Canvas::Impl>(env)};
+
+        Internal::NativeCanvas::CreateInstance(env, impl);
         Internal::NativeCanvasImage::CreateInstance(env);
+
+        return {impl};
+    }
+
+    void Canvas::FlushGraphicResources()
+    {
+        m_impl->FlushGraphicResources();
     }
 }

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -84,9 +84,11 @@ namespace Babylon::Polyfills::Internal
         , m_canvas{info[0].As<Napi::External<NativeCanvas>>().Data()}
         , m_nvg{nvgCreate(1)}
         , m_graphicsImpl{Babylon::GraphicsImpl::GetFromJavaScript(info.Env())}
+        , m_canvasImpl{Polyfills::Canvas::Impl::GetFromJavaScript(info.Env())}
         , m_cancellationSource{std::make_shared<arcana::cancellation_source>()}
         , m_runtimeScheduler{Babylon::JsRuntime::GetFromJavaScript(info.Env())}
     {
+        m_canvasImpl.AddMonitoredResource(this);
         for (auto& font : NativeCanvas::fontsInfos)
         {
             m_fonts[font.first] = nvgCreateFontMem(m_nvg, font.first.c_str(), font.second.data(), font.second.size(), 0);
@@ -96,11 +98,17 @@ namespace Babylon::Polyfills::Internal
 
     Context::~Context()
     {
+        m_canvasImpl.RemoveMonitoredResource(this);
         Dispose();
         m_cancellationSource->cancel();
     }
 
     void Context::Dispose(const Napi::CallbackInfo&)
+    {
+        Dispose();
+    }
+
+    void Context::FlushGraphicResources()
     {
         Dispose();
     }

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -8,7 +8,7 @@ struct NVGcontext;
 
 namespace Babylon::Polyfills::Internal
 {
-    class Context final : public Napi::ObjectWrap<Context>
+    class Context final : public Napi::ObjectWrap<Context>, Polyfills::Canvas::Impl::MonitoredResource
     {
     public:
         static Napi::Value CreateInstance(Napi::Env env, NativeCanvas* canvas);
@@ -86,9 +86,13 @@ namespace Babylon::Polyfills::Internal
         int m_currentFontId{ -1 };
 
         Babylon::GraphicsImpl& m_graphicsImpl;
+        Polyfills::Canvas::Impl& m_canvasImpl;
+
         bool m_dirty{};
         std::shared_ptr<arcana::cancellation_source> m_cancellationSource{};
         JsRuntimeScheduler m_runtimeScheduler;
+
+        void FlushGraphicResources() override;
 
         friend class Canvas;
     };


### PR DESCRIPTION
keep a list of active Canvas and Context.

Added method `FlushGraphicResources` to force free all bgfx resources. JS canvas/context object can be disposed later.
