### PR TITLE
Add console logging to the Playground App on Apple Devices

### DIFF
--- a/Apps/Playground/iOS/LibNativeBridge.mm
+++ b/Apps/Playground/iOS/LibNativeBridge.mm
@@ -10,6 +10,7 @@
 #import <Babylon/Polyfills/Window.h>
 #import <Babylon/Polyfills/XMLHttpRequest.h>
 #import <Babylon/Polyfills/Canvas.h>
+#import <Babylon/Polyfills/Console.h>
 #import <Shared/InputManager.h>
 
 #import <optional>
@@ -59,6 +60,10 @@ bool g_isXrActive{};
         Babylon::Polyfills::XMLHttpRequest::Initialize(env);
 
         Babylon::Polyfills::Canvas::Initialize(env);
+
+        Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
+            NSLog(@"%s", message);
+        });
 
         Babylon::Plugins::NativeEngine::Initialize(env);
 

--- a/Apps/Playground/macOS/ViewController.mm
+++ b/Apps/Playground/macOS/ViewController.mm
@@ -6,6 +6,7 @@
 #import <Babylon/Polyfills/Window.h>
 #import <Babylon/Polyfills/XMLHttpRequest.h>
 #import <Babylon/Polyfills/Canvas.h>
+#import <Babylon/Polyfills/Console.h>
 #import <Babylon/Plugins/NativeCamera.h>
 #import <Babylon/Plugins/NativeOptimizations.h>
 #import <Babylon/ScriptLoader.h>
@@ -95,6 +96,9 @@ std::unique_ptr<InputManager<Babylon::AppRuntime>::InputBuffer> inputBuffer{};
 
         Babylon::Polyfills::XMLHttpRequest::Initialize(env);
         Babylon::Polyfills::Canvas::Initialize(env);
+        Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
+            NSLog(@"%s", message);
+        });
         Babylon::Plugins::Camera::Initialize(env);
 
         Babylon::Plugins::NativeEngine::Initialize(env);


### PR DESCRIPTION
Initializes the Console polyfill on MacOS+iOS and uses NSLog to print the messages.