### PR TITLE
Factor index and vertex buffers and fix load perf

### DIFF
--- a/Plugins/NativeEngine/CMakeLists.txt
+++ b/Plugins/NativeEngine/CMakeLists.txt
@@ -12,6 +12,8 @@ endif()
 
 set(SOURCES
     "Include/Babylon/Plugins/NativeEngine.h"
+    "Source/IndexBuffer.cpp"
+    "Source/IndexBuffer.h"
     "Source/NativeEngineAPI.cpp"
     "Source/NativeEngine.cpp"
     "Source/NativeEngine.h"
@@ -23,7 +25,12 @@ set(SOURCES
     "Source/ShaderCompilerCommon.cpp"
     "Source/ShaderCompilerTraversers.cpp"
     "Source/ShaderCompilerTraversers.h"
-    "Source/ShaderCompiler${GRAPHICS_API}.cpp")
+    "Source/ShaderCompiler${GRAPHICS_API}.cpp"
+    "Source/VertexArray.cpp"
+    "Source/VertexArray.h"
+    "Source/VertexBuffer.cpp"
+    "Source/VertexBuffer.h"
+    )
 
 add_library(NativeEngine ${SOURCES})
 

--- a/Plugins/NativeEngine/Source/IndexBuffer.cpp
+++ b/Plugins/NativeEngine/Source/IndexBuffer.cpp
@@ -1,0 +1,82 @@
+#include "IndexBuffer.h"
+
+namespace Babylon
+{
+    IndexBuffer::IndexBuffer(gsl::span<uint8_t> bytes, uint16_t flags, bool dynamic)
+        : m_bytes{bytes.data(), bytes.data() + bytes.size()}
+        , m_flags{flags}
+        , m_dynamic{dynamic}
+    {
+    }
+
+    IndexBuffer::~IndexBuffer()
+    {
+        if (m_dynamic)
+        {
+            if (bgfx::isValid(m_dynamicHandle))
+            {
+                bgfx::destroy(m_dynamicHandle);
+            }
+        }
+        else
+        {
+            if (bgfx::isValid(m_handle))
+            {
+                bgfx::destroy(m_handle);
+            }
+        }
+    }
+
+    void IndexBuffer::Update(Napi::Env env, gsl::span<uint8_t> bytes, uint32_t startIndex)
+    {
+        if (!m_dynamic)
+        {
+            throw Napi::Error::New(env, "Cannot update non-dynamic index buffer.");
+        }
+
+        if (bgfx::isValid(m_dynamicHandle))
+        {
+            // Buffer was already created, do a real update operation.
+            bgfx::update(m_dynamicHandle, startIndex, bgfx::copy(bytes.data(), static_cast<uint32_t>(bytes.size())));
+        }
+        else
+        {
+            // Buffer hasn't been finalized yet, all that's necessary is to swap out the bytes.
+            m_bytes = {bytes.data(), bytes.data() + bytes.size()};
+        }
+    }
+
+    void IndexBuffer::Record()
+    {
+        auto releaseFn = [](void*, void* userData)
+        {
+            auto* bytes = reinterpret_cast<std::vector<uint8_t>*>(userData);
+            bytes->clear();
+        };
+
+        const bgfx::Memory* memory = bgfx::makeRef(m_bytes.data(), static_cast<uint32_t>(m_bytes.size()), releaseFn, &m_bytes);
+
+        if (m_dynamic)
+        {
+            assert(!bgfx::isValid(m_dynamicHandle));
+            m_dynamicHandle = bgfx::createDynamicIndexBuffer(memory, m_flags);
+        }
+        else
+        {
+            assert(!bgfx::isValid(m_handle));
+            m_handle = bgfx::createIndexBuffer(memory, m_flags);
+        }
+    }
+
+    void IndexBuffer::Set(bgfx::Encoder* encoder, uint32_t firstIndex, uint32_t numIndices)
+    {
+        if (m_dynamic)
+        {
+            encoder->setIndexBuffer(m_dynamicHandle, firstIndex, numIndices);
+        }
+        else
+        {
+            encoder->setIndexBuffer(m_handle, firstIndex, numIndices);
+        }
+    }
+}

--- a/Plugins/NativeEngine/Source/IndexBuffer.h
+++ b/Plugins/NativeEngine/Source/IndexBuffer.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <bgfx/bgfx.h>
+#include <napi/napi.h>
+#include <gsl/gsl>
+
+namespace Babylon
+{
+    class IndexBuffer final
+    {
+    public:
+        IndexBuffer(gsl::span<uint8_t> bytes, uint16_t flags, bool dynamic);
+        ~IndexBuffer();
+
+        void Update(Napi::Env env, gsl::span<uint8_t> bytes, uint32_t startIndex);
+        void Record();
+        void Set(bgfx::Encoder* encoder, uint32_t firstIndex, uint32_t numIndices);
+
+    private:
+        std::vector<uint8_t> m_bytes{};
+        uint16_t m_flags{};
+        bool m_dynamic{};
+
+        union
+        {
+            bgfx::IndexBufferHandle m_handle{bgfx::kInvalidHandle};
+            bgfx::DynamicIndexBufferHandle m_dynamicHandle;
+        };
+    };
+}

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -322,204 +322,6 @@ namespace Babylon
         }
     };
 
-    class IndexBufferData final : private VariantHandleHolder<bgfx::IndexBufferHandle, bgfx::DynamicIndexBufferHandle>
-    {
-    public:
-        IndexBufferData(const Napi::TypedArray& bytes, uint16_t flags, bool dynamic)
-        {
-            const bgfx::Memory* memory = bgfx::copy(bytes.As<Napi::Uint8Array>().Data(), static_cast<uint32_t>(bytes.ByteLength()));
-            if (!dynamic)
-            {
-                m_handle = bgfx::createIndexBuffer(memory, flags);
-            }
-            else
-            {
-                m_handle = bgfx::createDynamicIndexBuffer(memory, flags);
-            }
-        }
-
-        ~IndexBufferData()
-        {
-            constexpr auto nonDynamic = [](auto handle) {
-                bgfx::destroy(handle);
-            };
-            constexpr auto dynamic = [](auto handle) {
-                bgfx::destroy(handle);
-            };
-            DoForHandleTypes(nonDynamic, dynamic);
-        }
-
-        void Update(Napi::Env env, const Napi::TypedArray& bytes, uint32_t startingIdx)
-        {
-            const bgfx::Memory* memory = bgfx::copy(bytes.As<Napi::Uint8Array>().Data(), static_cast<uint32_t>(bytes.ByteLength()));
-
-            auto nonDynamic = [env](auto) {
-                throw Napi::Error::New(env, "Cannot update a non-dynamic index buffer.");
-            };
-            const auto dynamic = [memory, startingIdx](auto handle) {
-                bgfx::update(handle, startingIdx, memory);
-            };
-            DoForHandleTypes(nonDynamic, dynamic);
-        }
-
-        void SetBgfxIndexBuffer(bgfx::Encoder* encoder, uint32_t firstIndex, uint32_t numIndices) const
-        {
-            const auto nonDynamic = [&encoder, firstIndex, numIndices](auto handle) {
-                encoder->setIndexBuffer(handle, firstIndex, numIndices);
-            };
-            const auto dynamic = [&encoder, firstIndex, numIndices](auto handle) {
-                encoder->setIndexBuffer(handle, firstIndex, numIndices);
-            };
-            DoForHandleTypes(nonDynamic, dynamic);
-        }
-    };
-
-    class VertexBufferData final : VariantHandleHolder<bgfx::VertexBufferHandle, bgfx::DynamicVertexBufferHandle>
-    {
-    public:
-        VertexBufferData(const Napi::Uint8Array& bytes, bool dynamic)
-            : m_bytes{bytes.Data(), bytes.Data() + bytes.ByteLength()}
-        {
-            if (!dynamic)
-            {
-                m_handle = bgfx::VertexBufferHandle{bgfx::kInvalidHandle};
-            }
-            else
-            {
-                m_handle = bgfx::DynamicVertexBufferHandle{bgfx::kInvalidHandle};
-            }
-        }
-
-        ~VertexBufferData()
-        {
-            constexpr auto nonDynamic = [](auto handle) {
-                if (handle.idx != bgfx::kInvalidHandle)
-                {
-                    bgfx::destroy(handle);
-                }
-            };
-            constexpr auto dynamic = [](auto handle) {
-                if (handle.idx != bgfx::kInvalidHandle)
-                {
-                    bgfx::destroy(handle);
-                }
-            };
-            DoForHandleTypes(nonDynamic, dynamic);
-        }
-
-        template<typename sourceType> void PromoteToFloats(uint32_t numElements, uint32_t byteOffset, uint32_t byteStride)
-        {
-            const size_t count = m_bytes.size() / byteStride;
-            const size_t destinationSize = count * numElements * sizeof(float);
-            if (destinationSize != m_bytes.size()) // ensure both vectors have different size
-            {
-                std::vector<uint8_t> bytes(destinationSize);
-                float* destination = reinterpret_cast<float*>(bytes.data());
-                for (size_t i = 0; i < count; i++)
-                {
-                    sourceType* source = reinterpret_cast<sourceType*>(m_bytes.data() + byteOffset + byteStride * i);
-                    for (size_t element = 0; element < numElements; element++)
-                    {
-                        *destination++ = static_cast<float>(*source++);
-                    }
-                }
-                m_bytes = std::move(bytes);
-            }
-        }
-
-        void PromoteToFloats(bgfx::AttribType::Enum attribType, uint32_t numElements, uint32_t byteOffset, uint32_t byteStride)
-        {
-            switch (attribType)
-            {
-            case bgfx::AttribType::Int8:
-                PromoteToFloats<int8_t>(numElements, byteOffset, byteStride);
-                break;
-            case bgfx::AttribType::Uint8:
-                PromoteToFloats<uint8_t>(numElements, byteOffset, byteStride);
-                break;
-            case bgfx::AttribType::Int16:
-                PromoteToFloats<int16_t>(numElements, byteOffset, byteStride);
-                break;
-            case bgfx::AttribType::Uint16:
-                PromoteToFloats<uint16_t>(numElements, byteOffset, byteStride);
-                break;
-            case bgfx::AttribType::Uint10: // is supported by any format ?
-            default:
-                throw std::runtime_error("Unable to promote vertex stream to a float array.");
-            }
-        }
-
-        void EnsureFinalized(Napi::Env /*env*/, const bgfx::VertexLayout& layout)
-        {
-            const auto nonDynamic = [&layout, this](auto handle) {
-                if (handle.idx != bgfx::kInvalidHandle)
-                {
-                    return;
-                }
-
-                const bgfx::Memory* memory = bgfx::makeRef(
-                    m_bytes.data(), static_cast<uint32_t>(m_bytes.size()), [](void*, void* userData) {
-                        auto* bytes = reinterpret_cast<std::vector<uint8_t>*>(userData);
-                        bytes->clear();
-                    },
-                    &m_bytes);
-
-                m_handle = bgfx::createVertexBuffer(memory, layout);
-            };
-            const auto dynamic = [&layout, this](auto handle) {
-                if (handle.idx != bgfx::kInvalidHandle)
-                {
-                    return;
-                }
-
-                const bgfx::Memory* memory = bgfx::makeRef(
-                    m_bytes.data(), static_cast<uint32_t>(m_bytes.size()), [](void*, void* userData) {
-                        auto* bytes = reinterpret_cast<std::vector<uint8_t>*>(userData);
-                        bytes->clear();
-                    },
-                    &m_bytes);
-
-                m_handle = bgfx::createDynamicVertexBuffer(memory, layout);
-            };
-            DoForHandleTypes(nonDynamic, dynamic);
-        }
-
-        void Update(Napi::Env env, const Napi::Uint8Array& bytes, uint32_t offset, uint32_t byteLength)
-        {
-            auto nonDynamic = [env](auto) {
-                throw Napi::Error::New(env, "Cannot update non-dynamic vertex buffer.");
-            };
-            const auto dynamic = [&bytes, offset, byteLength, this](auto handle) {
-                if (handle.idx == bgfx::kInvalidHandle)
-                {
-                    // Buffer hasn't been finalized yet, all that's necessary is to swap out the bytes.
-                    m_bytes = {bytes.Data() + offset, bytes.Data() + offset + byteLength};
-                }
-                else
-                {
-                    // Buffer was already created, do a real update operation.
-                    const bgfx::Memory* memory = bgfx::copy(bytes.Data() + offset, byteLength);
-                    bgfx::update(handle, 0, memory);
-                }
-            };
-            DoForHandleTypes(nonDynamic, dynamic);
-        }
-
-        void SetAsBgfxVertexBuffer(bgfx::Encoder* encoder, uint8_t index, uint32_t startVertex, uint32_t numVertices, bgfx::VertexLayoutHandle layout) const
-        {
-            const auto nonDynamic = [&encoder, index, startVertex, numVertices, layout](auto handle) {
-                encoder->setVertexBuffer(index, handle, startVertex, numVertices, layout);
-            };
-            const auto dynamic = [&encoder, index, startVertex, numVertices, layout](auto handle) {
-                encoder->setVertexBuffer(index, handle, startVertex, numVertices, layout);
-            };
-            DoForHandleTypes(nonDynamic, dynamic);
-        }
-
-    private:
-        std::vector<uint8_t> m_bytes{};
-    };
-
     void NativeEngine::Initialize(Napi::Env env)
     {
         // Initialize the JavaScript side.
@@ -757,119 +559,85 @@ namespace Babylon
 
     void NativeEngine::BindVertexArray(const Napi::CallbackInfo& info)
     {
-        const VertexArray& vertexArray = *(info[0].As<Napi::External<VertexArray>>().Data());
+        VertexArray& vertexArray{*(info[0].As<Napi::External<VertexArray>>().Data())};
         m_boundVertexArray = &vertexArray;
     }
 
     Napi::Value NativeEngine::CreateIndexBuffer(const Napi::CallbackInfo& info)
     {
-        const Napi::TypedArray data = info[0].As<Napi::TypedArray>();
-        const bool dynamic = info[1].As<Napi::Boolean>().Value();
+        const Napi::ArrayBuffer bytes{info[0].As<Napi::ArrayBuffer>()};
+        const uint32_t byteOffset{info[1].As<Napi::Number>().Uint32Value()};
+        const uint32_t byteLength{info[2].As<Napi::Number>().Uint32Value()};
+        const bool is32Bits{info[3].As<Napi::Boolean>().Value()};
+        const bool dynamic{info[4].As<Napi::Boolean>().Value()};
 
-        const uint16_t flags = data.TypedArrayType() == napi_typedarray_type::napi_uint16_array ? 0 : BGFX_BUFFER_INDEX32;
-
-        return Napi::External<IndexBufferData>::New(info.Env(), new IndexBufferData(data, flags, dynamic));
+        const uint16_t flags{static_cast<uint16_t>(is32Bits ? BGFX_BUFFER_INDEX32 : 0)};
+        return Napi::External<IndexBuffer>::New(info.Env(), new IndexBuffer{gsl::make_span(static_cast<uint8_t*>(bytes.Data()) + byteOffset, byteLength), flags, dynamic});
     }
 
     void NativeEngine::DeleteIndexBuffer(const Napi::CallbackInfo& info)
     {
-        IndexBufferData* indexBufferData = info[0].As<Napi::External<IndexBufferData>>().Data();
-        delete indexBufferData;
+        IndexBuffer* indexBuffer{info[0].As<Napi::External<IndexBuffer>>().Data()};
+        delete indexBuffer;
     }
 
     void NativeEngine::RecordIndexBuffer(const Napi::CallbackInfo& info)
     {
-        VertexArray& vertexArray = *(info[0].As<Napi::External<VertexArray>>().Data());
-        const IndexBufferData* indexBufferData = info[1].As<Napi::External<IndexBufferData>>().Data();
+        VertexArray& vertexArray{*(info[0].As<Napi::External<VertexArray>>().Data())};
+        IndexBuffer& indexBuffer{*(info[1].As<Napi::External<IndexBuffer>>().Data())};
 
-        vertexArray.indexBuffer.Data = indexBufferData;
+        vertexArray.RecordIndexBuffer(indexBuffer);
     }
 
     void NativeEngine::UpdateDynamicIndexBuffer(const Napi::CallbackInfo& info)
     {
-        IndexBufferData& indexBufferData = *(info[0].As<Napi::External<IndexBufferData>>().Data());
+        IndexBuffer& indexBuffer{*(info[0].As<Napi::External<IndexBuffer>>().Data())};
+        const Napi::ArrayBuffer bytes{info[1].As<Napi::ArrayBuffer>()};
+        const uint32_t byteOffset{info[2].As<Napi::Number>().Uint32Value()};
+        const uint32_t byteLength{info[3].As<Napi::Number>().Uint32Value()};
+        const uint32_t startingIndex{info[4].As<Napi::Number>().Uint32Value()};
 
-        const Napi::TypedArray data = info[1].As<Napi::TypedArray>();
-        const uint32_t startingIdx = info[2].As<Napi::Number>().Uint32Value();
-
-        indexBufferData.Update(info.Env(), data, startingIdx);
+        indexBuffer.Update(info.Env(), gsl::make_span(static_cast<uint8_t*>(bytes.Data()) + byteOffset, byteLength), startingIndex);
     }
 
     Napi::Value NativeEngine::CreateVertexBuffer(const Napi::CallbackInfo& info)
     {
-        const Napi::Uint8Array data = info[0].As<Napi::Uint8Array>();
-        const bool dynamic = info[1].As<Napi::Boolean>().Value();
+        const Napi::ArrayBuffer bytes{info[0].As<Napi::ArrayBuffer>()};
+        const uint32_t byteOffset{info[1].As<Napi::Number>().Uint32Value()};
+        const uint32_t byteLength{info[2].As<Napi::Number>().Uint32Value()};
+        const bool dynamic{info[3].As<Napi::Boolean>().Value()};
 
-        return Napi::External<VertexBufferData>::New(info.Env(), new VertexBufferData(data, dynamic));
+        return Napi::External<VertexBuffer>::New(info.Env(), new VertexBuffer(gsl::make_span(static_cast<uint8_t*>(bytes.Data()) + byteOffset, byteLength), dynamic));
     }
 
     void NativeEngine::DeleteVertexBuffer(const Napi::CallbackInfo& info)
     {
-        auto* vertexBufferData = info[0].As<Napi::External<VertexBufferData>>().Data();
-        delete vertexBufferData;
+        auto* vertexBuffer{info[0].As<Napi::External<VertexBuffer>>().Data()};
+        delete vertexBuffer;
     }
 
     void NativeEngine::RecordVertexBuffer(const Napi::CallbackInfo& info)
     {
-        VertexArray& vertexArray = *(info[0].As<Napi::External<VertexArray>>().Data());
-        VertexBufferData* vertexBufferData = info[1].As<Napi::External<VertexBufferData>>().Data();
+        VertexArray& vertexArray{*(info[0].As<Napi::External<VertexArray>>().Data())};
+        VertexBuffer& vertexBuffer{*(info[1].As<Napi::External<VertexBuffer>>().Data())};
+        const uint32_t location{info[2].As<Napi::Number>().Uint32Value()};
+        const uint32_t byteOffset{info[3].As<Napi::Number>().Uint32Value()};
+        const uint32_t byteStride{info[4].As<Napi::Number>().Uint32Value()};
+        const uint32_t numElements{info[5].As<Napi::Number>().Uint32Value()};
+        const uint32_t type{info[6].As<Napi::Number>().Uint32Value()};
+        const bool normalized{info[7].As<Napi::Boolean>().Value()};
 
-        const uint32_t location = info[2].As<Napi::Number>().Uint32Value();
-        const uint32_t byteOffset = info[3].As<Napi::Number>().Uint32Value();
-        const uint32_t byteStride = info[4].As<Napi::Number>().Uint32Value();
-        const uint32_t numElements = info[5].As<Napi::Number>().Uint32Value();
-        const uint32_t type = info[6].As<Napi::Number>().Uint32Value();
-        const bool normalized = info[7].As<Napi::Boolean>().Value();
-
-        bgfx::VertexLayout vertexLayout{};
-        vertexLayout.begin();
-
-        const bgfx::Attrib::Enum attrib = static_cast<bgfx::Attrib::Enum>(location);
-        const bgfx::AttribType::Enum attribType = static_cast<bgfx::AttribType::Enum>(type);
-
-        const bool promoteToFloats = !normalized
-            && (bgfx::getCaps()->rendererType == bgfx::RendererType::Direct3D11 ||
-                bgfx::getCaps()->rendererType == bgfx::RendererType::Direct3D12 ||
-                bgfx::getCaps()->rendererType == bgfx::RendererType::Vulkan)
-            && (attribType == bgfx::AttribType::Int8 ||
-                attribType == bgfx::AttribType::Uint8 ||
-                attribType == bgfx::AttribType::Uint10 ||
-                attribType == bgfx::AttribType::Int16 ||
-                attribType == bgfx::AttribType::Uint16);
-
-        if (promoteToFloats)
-        {
-            vertexLayout.add(attrib, static_cast<uint8_t>(numElements), bgfx::AttribType::Float);
-            vertexLayout.m_stride = static_cast<uint16_t>(sizeof(float) * numElements);
-            vertexBufferData->PromoteToFloats(attribType, numElements, byteOffset, byteStride);
-        }
-        else
-        {
-            vertexLayout.add(attrib, static_cast<uint8_t>(numElements), attribType, normalized);
-            vertexLayout.m_stride = static_cast<uint16_t>(byteStride);
-            vertexLayout.m_offset[attrib] = static_cast<uint16_t>(byteOffset % byteStride);
-        }
-
-        vertexLayout.end();
-        vertexBufferData->EnsureFinalized(info.Env(), vertexLayout);
-
-        // Second parameter is first vertex. byteOffset and byteStride are both using original values (without float promotion)
-        vertexArray.VertexBuffers[location] = {vertexBufferData, byteOffset / byteStride, bgfx::createVertexLayout(vertexLayout)};
+        vertexArray.RecordVertexBuffer(vertexBuffer, location, byteOffset, byteStride, numElements, type, normalized);
     }
 
     void NativeEngine::UpdateDynamicVertexBuffer(const Napi::CallbackInfo& info)
     {
-        VertexBufferData& vertexBufferData = *(info[0].As<Napi::External<VertexBufferData>>().Data());
-        const Napi::Uint8Array data = info[1].As<Napi::Uint8Array>();
-        const uint32_t byteOffset = info[2].As<Napi::Number>().Uint32Value();
+        VertexBuffer& vertexBuffer{*(info[0].As<Napi::External<VertexBuffer>>().Data())};
+        const Napi::ArrayBuffer bytes{info[1].As<Napi::ArrayBuffer>()};
+        const uint32_t byteOffset{info[2].As<Napi::Number>().Uint32Value()};
+        const uint32_t byteLength{info[3].As<Napi::Number>().Uint32Value()};
 
-        uint32_t byteLength = info[2].As<Napi::Number>().Uint32Value();
-        if (byteLength == 0)
-        {
-            byteLength = static_cast<uint32_t>(data.ByteLength());
-        }
-
-        vertexBufferData.Update(info.Env(), data, byteOffset, byteLength);
+        vertexBuffer.Update(info.Env(), gsl::make_span(static_cast<uint8_t*>(bytes.Data()) + byteOffset, byteLength));
     }
 
     // Change VS output coordinate system
@@ -1577,25 +1345,14 @@ namespace Babylon
     {
         bgfx::Encoder* encoder{GetUpdateToken().GetEncoder()};
 
-        const auto fillMode = info[0].As<Napi::Number>().Int32Value();
-        const auto indexStart = info[1].As<Napi::Number>().Int32Value();
-        const auto indexCount = info[2].As<Napi::Number>().Int32Value();
+        const auto fillMode = info[0].As<Napi::Number>().Uint32Value();
+        const auto indexStart = info[1].As<Napi::Number>().Uint32Value();
+        const auto indexCount = info[2].As<Napi::Number>().Uint32Value();
 
         if (m_boundVertexArray != nullptr)
         {
-            const auto indexBufferData{m_boundVertexArray->indexBuffer.Data};
-            if (indexBufferData != nullptr)
-            {
-                indexBufferData->SetBgfxIndexBuffer(encoder, indexStart, indexCount);
-            }
-
-            const auto& vertexBuffers = m_boundVertexArray->VertexBuffers;
-            for (const auto& vertexBufferPair : vertexBuffers)
-            {
-                const auto index{static_cast<uint8_t>(vertexBufferPair.first)};
-                const auto& vertexBuffer{vertexBufferPair.second};
-                vertexBuffer.Data->SetAsBgfxVertexBuffer(encoder, index, vertexBuffer.StartVertex, std::numeric_limits<uint32_t>::max(), vertexBuffer.VertexLayoutHandle);
-            }
+            m_boundVertexArray->SetIndexBuffer(encoder, indexStart, indexCount);
+            m_boundVertexArray->SetVertexBuffers(encoder, 0, std::numeric_limits<uint32_t>::max());
         }
 
         Draw(encoder, fillMode);
@@ -1605,19 +1362,13 @@ namespace Babylon
     {
         bgfx::Encoder* encoder{GetUpdateToken().GetEncoder()};
 
-        const auto fillMode = info[0].As<Napi::Number>().Int32Value();
-        const auto verticesStart = info[1].As<Napi::Number>().Int32Value();
-        const auto verticesCount = info[2].As<Napi::Number>().Int32Value();
+        const auto fillMode = info[0].As<Napi::Number>().Uint32Value();
+        const auto verticesStart = info[1].As<Napi::Number>().Uint32Value();
+        const auto verticesCount = info[2].As<Napi::Number>().Uint32Value();
 
         if (m_boundVertexArray != nullptr)
         {
-            const auto& vertexBuffers = m_boundVertexArray->VertexBuffers;
-            for (const auto& vertexBufferPair : vertexBuffers)
-            {
-                const auto index{static_cast<uint8_t>(vertexBufferPair.first)};
-                const auto& vertexBuffer = vertexBufferPair.second;
-                vertexBuffer.Data->SetAsBgfxVertexBuffer(encoder, index, vertexBuffer.StartVertex + verticesStart, verticesCount, vertexBuffer.VertexLayoutHandle);
-            }
+            m_boundVertexArray->SetVertexBuffers(encoder, verticesStart, verticesCount);
         }
 
         Draw(encoder, fillMode);
@@ -1820,7 +1571,7 @@ namespace Babylon
         m_stencilState |= BGFX_STENCIL_FUNC_REF(ref);
     }
 
-    void NativeEngine::Draw(bgfx::Encoder* encoder, int fillMode)
+    void NativeEngine::Draw(bgfx::Encoder* encoder, uint32_t fillMode)
     {
         uint64_t fillModeState{0}; // indexed triangle list
         switch (fillMode)

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -4,6 +4,7 @@
 #include "FrameBuffer.h"
 #include "PerFrameValue.h"
 #include "ShaderCompiler.h"
+#include "VertexArray.h"
 
 #include <Babylon/JsRuntime.h>
 #include <Babylon/JsRuntimeScheduler.h>
@@ -87,36 +88,6 @@ namespace Babylon
             value.Data.assign(data.begin(), data.end());
             value.ElementLength = static_cast<uint16_t>(elementLength);
         }
-    };
-
-    class IndexBufferData;
-    class VertexBufferData;
-
-    struct VertexArray final
-    {
-        ~VertexArray()
-        {
-            for (auto& vertexBufferPair : VertexBuffers)
-            {
-                bgfx::destroy(vertexBufferPair.second.VertexLayoutHandle);
-            }
-        }
-
-        struct IndexBuffer
-        {
-            const IndexBufferData* Data{};
-        };
-
-        IndexBuffer indexBuffer{};
-
-        struct VertexBuffer
-        {
-            const VertexBufferData* Data{};
-            uint32_t StartVertex{};
-            bgfx::VertexLayoutHandle VertexLayoutHandle{};
-        };
-
-        std::unordered_map<uint32_t, VertexBuffer> VertexBuffers;
     };
 
     class NativeEngine final : public Napi::ObjectWrap<NativeEngine>
@@ -205,7 +176,7 @@ namespace Babylon
         Napi::Value ResizeImageBitmap(const Napi::CallbackInfo& info);
         void GetFrameBufferData(const Napi::CallbackInfo& info);
         void SetStencil(const Napi::CallbackInfo& info);
-        void Draw(bgfx::Encoder* encoder, int fillMode);
+        void Draw(bgfx::Encoder* encoder, uint32_t fillMode);
 
         std::string ProcessShaderCoordinates(const std::string& vertexSource);
 
@@ -247,7 +218,7 @@ namespace Babylon
 
         std::vector<Napi::FunctionReference> m_requestAnimationFrameCallbacks{};
 
-        const VertexArray* m_boundVertexArray{};
+        VertexArray* m_boundVertexArray{};
         FrameBuffer m_defaultFrameBuffer;
         FrameBuffer* m_boundFrameBuffer{};
         PerFrameValue<bool> m_boundFrameBufferNeedsRebinding;

--- a/Plugins/NativeEngine/Source/VertexArray.cpp
+++ b/Plugins/NativeEngine/Source/VertexArray.cpp
@@ -1,0 +1,34 @@
+#include "VertexArray.h"
+#include <cassert>
+
+namespace Babylon
+{
+    void VertexArray::RecordIndexBuffer(IndexBuffer& indexBuffer)
+    {
+        indexBuffer.Record();
+        assert(m_indexBuffer == nullptr);
+        m_indexBuffer = &indexBuffer;
+    }
+
+    void VertexArray::RecordVertexBuffer(VertexBuffer& vertexBuffer, uint32_t location, uint32_t byteOffset, uint32_t byteStride, uint32_t numElements, uint32_t type, bool normalized)
+    {
+        vertexBuffer.Record(location, byteOffset, byteStride, numElements, type, normalized);
+        m_vertexBuffers.push_back(&vertexBuffer);
+    }
+
+    void VertexArray::SetIndexBuffer(bgfx::Encoder* encoder, uint32_t firstIndex, uint32_t numIndices)
+    {
+        if (m_indexBuffer != nullptr)
+        {
+            m_indexBuffer->Set(encoder, firstIndex, numIndices);
+        }
+    }
+
+    void VertexArray::SetVertexBuffers(bgfx::Encoder* encoder, uint32_t vertexStart, uint32_t vertexCount)
+    {
+        for (VertexBuffer* vertexBuffer : m_vertexBuffers)
+        {
+            vertexBuffer->Set(encoder, vertexStart, vertexCount);
+        }
+    }
+}

--- a/Plugins/NativeEngine/Source/VertexArray.h
+++ b/Plugins/NativeEngine/Source/VertexArray.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "IndexBuffer.h"
+#include "VertexBuffer.h"
+#include <map>
+
+namespace Babylon
+{
+    class VertexArray final
+    {
+    public:
+        void RecordIndexBuffer(IndexBuffer& indexBuffer);
+        void RecordVertexBuffer(VertexBuffer& vertexBuffer, uint32_t location, uint32_t byteOffset, uint32_t byteStride, uint32_t numElements, uint32_t type, bool normalized);
+        void SetIndexBuffer(bgfx::Encoder* encoder, uint32_t firstIndex, uint32_t numIndices);
+        void SetVertexBuffers(bgfx::Encoder* encoder, uint32_t startVertex, uint32_t numVertices);
+
+    private:
+        IndexBuffer* m_indexBuffer{};
+        std::vector<VertexBuffer*> m_vertexBuffers;
+    };
+}

--- a/Plugins/NativeEngine/Source/VertexBuffer.cpp
+++ b/Plugins/NativeEngine/Source/VertexBuffer.cpp
@@ -1,0 +1,182 @@
+#include "VertexBuffer.h"
+#include <cassert>
+
+namespace
+{
+    template<typename sourceType> void PromoteToFloats(std::vector<uint8_t>& bytes, uint32_t numElements, uint32_t byteOffset, uint32_t byteStride)
+    {
+        const size_t count = bytes.size() / byteStride;
+        const size_t destinationSize = count * numElements * sizeof(float);
+        if (destinationSize != bytes.size()) // ensure both vectors have different size
+        {
+            std::vector<uint8_t> newBytes(destinationSize);
+            float* destination = reinterpret_cast<float*>(newBytes.data());
+            for (size_t i = 0; i < count; ++i)
+            {
+                sourceType* source = reinterpret_cast<sourceType*>(bytes.data() + byteOffset + byteStride * i);
+                for (size_t element = 0; element < numElements; element++)
+                {
+                    *destination++ = static_cast<float>(*source++);
+                }
+            }
+            bytes.swap(newBytes);
+        }
+    }
+
+    void PromoteToFloats(std::vector<uint8_t>& bytes, bgfx::AttribType::Enum attribType, uint32_t numElements, uint32_t byteOffset, uint32_t byteStride)
+    {
+        switch (attribType)
+        {
+            case bgfx::AttribType::Int8:
+            {
+                PromoteToFloats<int8_t>(bytes, numElements, byteOffset, byteStride);
+                break;
+            }
+            case bgfx::AttribType::Uint8:
+            {
+                PromoteToFloats<uint8_t>(bytes, numElements, byteOffset, byteStride);
+                break;
+            }
+            case bgfx::AttribType::Int16:
+            {
+                PromoteToFloats<int16_t>(bytes, numElements, byteOffset, byteStride);
+                break;
+            }
+            case bgfx::AttribType::Uint16:
+            {
+                PromoteToFloats<uint16_t>(bytes, numElements, byteOffset, byteStride);
+                break;
+            }
+            case bgfx::AttribType::Uint10: // is supported by any format ?
+            default:
+            {
+                throw std::runtime_error("Unable to promote vertex stream to a float array.");
+            }
+        }
+    }
+}
+
+namespace Babylon
+{
+    VertexBuffer::VertexBuffer(gsl::span<uint8_t> bytes, bool dynamic)
+        : m_bytes{bytes.data(), bytes.data() + bytes.size()}
+        , m_dynamic{dynamic}
+    {
+    }
+
+    VertexBuffer::~VertexBuffer()
+    {
+        if (bgfx::isValid(m_layoutHandle))
+        {
+            bgfx::destroy(m_layoutHandle);
+        }
+
+        if (m_dynamic)
+        {
+            if (bgfx::isValid(m_dynamicHandle))
+            {
+                bgfx::destroy(m_dynamicHandle);
+            }
+        }
+        else
+        {
+            if (bgfx::isValid(m_handle))
+            {
+                bgfx::destroy(m_handle);
+            }
+        }
+    }
+
+    void VertexBuffer::Update(Napi::Env env, gsl::span<uint8_t> bytes)
+    {
+        if (!m_dynamic)
+        {
+            throw Napi::Error::New(env, "Cannot update non-dynamic vertex buffer.");
+        }
+
+        if (bgfx::isValid(m_dynamicHandle))
+        {
+            // Buffer was already created, do a real update operation.
+            bgfx::update(m_dynamicHandle, 0, bgfx::copy(bytes.data(), static_cast<uint32_t>(bytes.size())));
+        }
+        else
+        {
+            // Buffer hasn't been finalized yet, all that's necessary is to swap out the bytes.
+            m_bytes = {bytes.data(), bytes.data() + bytes.size()};
+        }
+    }
+
+    void VertexBuffer::Record(uint32_t location, uint32_t byteOffset, uint32_t byteStride, uint32_t numElements, uint32_t type, bool normalized)
+    {
+        m_attrib = static_cast<bgfx::Attrib::Enum>(location);
+        m_vertexOffset = byteOffset / byteStride;
+
+        bgfx::AttribType::Enum attribType{static_cast<bgfx::AttribType::Enum>(type)};
+
+        bgfx::VertexLayout layout{};
+
+        layout.begin();
+
+        // clang-format off
+        const bool promoteToFloats = !normalized
+            && (bgfx::getCaps()->rendererType == bgfx::RendererType::Direct3D11 ||
+                bgfx::getCaps()->rendererType == bgfx::RendererType::Direct3D12 ||
+                bgfx::getCaps()->rendererType == bgfx::RendererType::Vulkan)
+            && (attribType == bgfx::AttribType::Int8 ||
+                attribType == bgfx::AttribType::Uint8 ||
+                attribType == bgfx::AttribType::Uint10 ||
+                attribType == bgfx::AttribType::Int16 ||
+                attribType == bgfx::AttribType::Uint16);
+        // clang-format on
+
+        if (promoteToFloats)
+        {
+            layout.add(m_attrib, static_cast<uint8_t>(numElements), bgfx::AttribType::Float);
+            layout.m_stride = static_cast<uint16_t>(sizeof(float) * numElements);
+            PromoteToFloats(m_bytes, attribType, numElements, byteOffset, byteStride);
+        }
+        else
+        {
+            layout.add(m_attrib, static_cast<uint8_t>(numElements), attribType, normalized);
+            layout.m_stride = static_cast<uint16_t>(byteStride);
+            layout.m_offset[m_attrib] = static_cast<uint16_t>(byteOffset % byteStride);
+        }
+
+        layout.end();
+
+        auto releaseFn = [](void*, void* userData)
+        {
+            auto* bytes = reinterpret_cast<std::vector<uint8_t>*>(userData);
+            bytes->clear();
+        };
+
+        const bgfx::Memory* memory = bgfx::makeRef(m_bytes.data(), static_cast<uint32_t>(m_bytes.size()), releaseFn, &m_bytes);
+
+        if (m_dynamic)
+        {
+            assert(!bgfx::isValid(m_dynamicHandle));
+            m_dynamicHandle = bgfx::createDynamicVertexBuffer(memory, layout);
+        }
+        else
+        {
+            assert(!bgfx::isValid(m_handle));
+            m_handle = bgfx::createVertexBuffer(memory, layout);
+        };
+
+        m_layoutHandle = bgfx::createVertexLayout(layout);
+    }
+
+    void VertexBuffer::Set(bgfx::Encoder* encoder, uint32_t vertexStart, uint32_t numVertices)
+    {
+        uint8_t stream{static_cast<uint8_t>(m_attrib)};
+
+        if (m_dynamic)
+        {
+            encoder->setVertexBuffer(stream, m_dynamicHandle, m_vertexOffset + vertexStart, numVertices, m_layoutHandle);
+        }
+        else
+        {
+            encoder->setVertexBuffer(stream, m_handle, m_vertexOffset + vertexStart, numVertices, m_layoutHandle);
+        }
+    }
+}

--- a/Plugins/NativeEngine/Source/VertexBuffer.h
+++ b/Plugins/NativeEngine/Source/VertexBuffer.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <bgfx/bgfx.h>
+#include <napi/napi.h>
+#include <gsl/gsl>
+
+namespace Babylon
+{
+    class VertexBuffer final
+    {
+    public:
+        VertexBuffer(gsl::span<uint8_t> bytes, bool dynamic);
+        ~VertexBuffer();
+
+        void Update(Napi::Env env, gsl::span<uint8_t> bytes);
+        void Record(uint32_t index, uint32_t byteOffset, uint32_t byteStride, uint32_t numElements, uint32_t type, bool normalized);
+        void Set(bgfx::Encoder* encoder, uint32_t vertexStart, uint32_t vertexCount);
+
+    private:
+        std::vector<uint8_t> m_bytes{};
+        bool m_dynamic{};
+
+        bgfx::Attrib::Enum m_attrib{};
+        uint32_t m_vertexOffset{};
+        bgfx::VertexLayoutHandle m_layoutHandle{bgfx::kInvalidHandle};
+
+        union
+        {
+            bgfx::VertexBufferHandle m_handle{bgfx::kInvalidHandle};
+            bgfx::DynamicVertexBufferHandle m_dynamicHandle;
+        };
+    };
+}


### PR DESCRIPTION
TODO: Requires a PR on the Babylon.js side.

Most of the slowness comes from creating the index buffer.

There are two main causes for this:
1. Getting the type of the typed array is super slow using N-API. The solution is simply to check the type on the JS side instead.
2. There is thread contention from the bgfx resource mutex when creating a bgfx index buffer that slow the creation down a lot since it's not during a graphics safe timespan. The solution is to defer the creating until the index buffer is being recorded which is during a safe timespan.

This change also factors out the index buffer, vertex buffer, and vertex array into its own files and moves a bunch of code from native engine into the respective classes.