### PR TITLE
Remove thread blocking operations in XR mode on iOS by sharing a command queue with bgfx

### DIFF
--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -32,7 +32,6 @@ if(APPLE)
     # no Vulkan on Apple but Metal
     target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_RENDERER_VULKAN=0)
     target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_RENDERER_METAL=1)
-    target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_WAIT_FOR_FLIP=1)
 elseif(ANDROID)
     target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_RENDERER_OPENGLES=30)
     target_compile_definitions(bgfx PRIVATE BGFX_GL_CONFIG_TEXTURE_READ_BACK_EMULATION=1)

--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -329,12 +329,12 @@ namespace xr
                 std::unique_ptr<Impl> m_impl{};
             };
 
-            static arcana::task<std::shared_ptr<Session>, std::exception_ptr> CreateAsync(System& system, void* graphicsDevice, std::function<void*()> windowProvider);
+            static arcana::task<std::shared_ptr<Session>, std::exception_ptr> CreateAsync(System& system, void* graphicsDevice, void* commandQueue, std::function<void*()> windowProvider);
             ~Session();
 
             // Do not use, call CreateAsync instead. Kept public to keep compatibility with make_shared.
             // Move to private when changing to unique_ptr.
-            Session(System& system, void* graphicsDevice, std::function<void*()> windowProvider);
+            Session(System& system, void* graphicsDevice, void* commandQueue, std::function<void*()> windowProvider);
 
             std::unique_ptr<Frame> GetNextFrame(bool& shouldEndSession, bool& shouldRestartSession, std::function<arcana::task<void, std::exception_ptr>(void*)> deletedTextureAsyncCallback = [](void*){ return arcana::task_from_result<std::exception_ptr>(); });
             void RequestEndSession();

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -1233,7 +1233,7 @@ namespace xr
         {
             // Next check for camera permissions, and request if not already granted.
             return android::Permissions::CheckCameraPermissionAsync();
-        }).then(arcana::inline_scheduler, arcana::cancellation::none(), [&system, graphicsDevice, windowProvider{ std::move(windowProvider) }]()
+        }).then(arcana::inline_scheduler, arcana::cancellation::none(), [&system, graphicsDevice, commandQueue, windowProvider{ std::move(windowProvider) }]()
         {
             // Finally if the previous two tasks succeed, start the AR session.
             return std::make_shared<System::Session>(system, graphicsDevice, commandQueue, windowProvider);

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -1226,7 +1226,7 @@ namespace xr
         return "ARCore";
     }
 
-    arcana::task<std::shared_ptr<System::Session>, std::exception_ptr> System::Session::CreateAsync(System& system, void* graphicsDevice, std::function<void*()> windowProvider)
+    arcana::task<std::shared_ptr<System::Session>, std::exception_ptr> System::Session::CreateAsync(System& system, void* graphicsDevice, void* commandQueue, std::function<void*()> windowProvider)
     {
         // First perform the ARCore installation check, request install if not yet installed.
         return CheckAndInstallARCoreAsync().then(arcana::inline_scheduler, arcana::cancellation::none(), []()
@@ -1236,11 +1236,11 @@ namespace xr
         }).then(arcana::inline_scheduler, arcana::cancellation::none(), [&system, graphicsDevice, windowProvider{ std::move(windowProvider) }]()
         {
             // Finally if the previous two tasks succeed, start the AR session.
-            return std::make_shared<System::Session>(system, graphicsDevice, windowProvider);
+            return std::make_shared<System::Session>(system, graphicsDevice, commandQueue, windowProvider);
         });
     }
 
-    System::Session::Session(System& system, void* graphicsDevice, std::function<void*()> windowProvider)
+    System::Session::Session(System& system, void* graphicsDevice, void*, std::function<void*()> windowProvider)
         : m_impl{ std::make_unique<System::Session::Impl>(*system.m_impl, graphicsDevice, std::move(windowProvider)) }
     {}
 

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -675,10 +675,11 @@ namespace xr {
         float DepthFarZ{ DEFAULT_DEPTH_FAR_Z };
         bool FeaturePointCloudEnabled{ false };
 
-        Impl(System::Impl& systemImpl, void* graphicsContext, std::function<void*()> windowProvider)
+        Impl(System::Impl& systemImpl, void* graphicsContext, void* commandQueue, std::function<void*()> windowProvider)
             : SystemImpl{ systemImpl }
             , getXRView{ [windowProvider{ std::move(windowProvider) }] { return (__bridge MTKView*)windowProvider(); } }
-            , metalDevice{ (__bridge id<MTLDevice>)graphicsContext } {
+            , metalDevice{ (__bridge id<MTLDevice>)graphicsContext }
+            , commandQueue{ (__bridge id<MTLCommandQueue>)commandQueue } {
 
             // Create the ARSession enable plane detection, include scene reconstruction mesh if supported, and disable lighting estimation.
             SystemImpl.XrContext->Session = [ARSession new];
@@ -737,8 +738,6 @@ namespace xr {
                     NSLog(@"Failed to create screen pipeline state: %@", error);
                 }
             }
-
-            commandQueue = [metalDevice newCommandQueue];
         }
 
         ~Impl() {
@@ -921,7 +920,6 @@ namespace xr {
 
                 // Finalize rendering here & push the command buffer to the GPU.
                 [commandBuffer commit];
-                [commandBuffer waitUntilCompleted];
             }
             @finally {
                 if (cameraTextureY != nil) {
@@ -1602,15 +1600,15 @@ namespace xr {
         return "ARKit";
     }
 
-    arcana::task<std::shared_ptr<System::Session>, std::exception_ptr> System::Session::CreateAsync(System& system, void* graphicsDevice, std::function<void*()> windowProvider) {
-        auto session = std::make_shared<System::Session>(system, graphicsDevice, std::move(windowProvider));
+    arcana::task<std::shared_ptr<System::Session>, std::exception_ptr> System::Session::CreateAsync(System& system, void* graphicsDevice, void* commandQueue, std::function<void*()> windowProvider) {
+        auto session = std::make_shared<System::Session>(system, graphicsDevice, commandQueue, std::move(windowProvider));
         return session->m_impl->WhenReady().then(arcana::inline_scheduler, arcana::cancellation::none(), [session] {
             return session;
         });
     }
 
-    System::Session::Session(System& system, void* graphicsDevice, std::function<void*()> windowProvider)
-        : m_impl{ std::make_unique<System::Session::Impl>(*system.m_impl, graphicsDevice, std::move(windowProvider)) } {}
+    System::Session::Session(System& system, void* graphicsDevice, void* commandQueue, std::function<void*()> windowProvider)
+        : m_impl{ std::make_unique<System::Session::Impl>(*system.m_impl, graphicsDevice, commandQueue, std::move(windowProvider)) } {}
 
     System::Session::~Session() {
         // Free textures

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -1213,12 +1213,12 @@ namespace xr
         return XrRegistry::GetNativeXrContextType();
     }
 
-    arcana::task<std::shared_ptr<System::Session>, std::exception_ptr> System::Session::CreateAsync(System& system, void* graphicsDevice, std::function<void*()> windowProvider)
+    arcana::task<std::shared_ptr<System::Session>, std::exception_ptr> System::Session::CreateAsync(System& system, void* graphicsDevice, void* commandQueue, std::function<void*()> windowProvider)
     {
-        return arcana::task_from_result<std::exception_ptr>(std::make_shared<System::Session>(system, graphicsDevice, windowProvider));
+        return arcana::task_from_result<std::exception_ptr>(std::make_shared<System::Session>(system, graphicsDevice, commandQueue, windowProvider));
     }
 
-    System::Session::Session(System& headMountedDisplay, void* graphicsDevice, std::function<void*()>)
+    System::Session::Session(System& headMountedDisplay, void* graphicsDevice, void*, std::function<void*()>)
         : m_impl{ std::make_unique<System::Session::Impl>(*headMountedDisplay.m_impl, graphicsDevice) }
     {}
 

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -502,7 +502,7 @@ namespace Babylon
                         throw std::runtime_error{"Failed to initialize xr system."};
                     }
 
-                    return xr::System::Session::CreateAsync(m_system, bgfx::getInternalData()->context, [this, thisRef{shared_from_this()}] { return m_windowPtr; })
+                    return xr::System::Session::CreateAsync(m_system, bgfx::getInternalData()->context, bgfx::getInternalData()->commandQueue, [this, thisRef{shared_from_this()}] { return m_windowPtr; })
                         .then(m_sessionState->GraphicsImpl.AfterRenderScheduler(), arcana::cancellation::none(), [this, thisRef{shared_from_this()}](std::shared_ptr<xr::System::Session> session) {
                             m_sessionState->Session = std::move(session);
                             NotifySessionStateChanged(true);


### PR DESCRIPTION
Previously, xr.mm used a different `MtlCommandQueue` from bgfx, which basically means the xr.mm command queue needed to be fully drained before the bgfx command queue started processing, and then the bgfx command queue needed to be fully drained before the xr.mm presented the final render texture to the display, and both of these were done by blocking the main thread while waiting for queues to drain. This resulted in a lot of blocked time that increased frame time unnecessarily. The fix is to use the same command queue as bgfx and remove the blocking operations, which ensures things happen in the right order and happen as efficiently as possible.