### PR TITLE
[WIP] Refactor NativeXR for performance

### DIFF
--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -270,7 +270,7 @@ namespace xr
 
                 struct Plane
                 {
-                    using Identifier = size_t;
+                    using Identifier = uint32_t;
                     const Identifier ID{ NEXT_ID++ };
                     Pose Center{};
                     std::vector<float> Polygon{};

--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -95,10 +95,15 @@ namespace xr
         Vector3f Direction;
     };
 
+    struct Space
+    {
+        Pose Pose;
+    };
+
     using NativeAnchorPtr = void*;
     struct Anchor
     {
-        Pose Pose{};
+        Space Space{};
         NativeAnchorPtr NativeAnchor{};
         bool IsValid{true};
     };
@@ -188,11 +193,6 @@ namespace xr
             class Frame
             {
             public:
-                struct Space
-                {
-                    Pose Pose;
-                };
-
                 struct JointSpace : Space
                 {
                     float PoseRadius{};

--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -285,7 +285,7 @@ namespace xr
                 struct Mesh
                 {
                     using IndexType = uint32_t;
-                    using Identifier = size_t;
+                    using Identifier = uint32_t;
                     const Identifier ID{ NEXT_ID++ };
                     std::vector<xr::Vector3f> Positions{};
                     std::vector<IndexType> Indices{};

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -184,7 +184,7 @@ namespace xr
         std::vector<Frame::Plane> Planes{};
         std::vector<Frame::Mesh> Meshes{};
         std::vector<FeaturePoint> FeaturePointCloud{};
-        std::optional<Frame::Space> EyeTrackerSpace{};
+        std::optional<Space> EyeTrackerSpace{};
         float DepthNearZ{ DEFAULT_DEPTH_NEAR_Z };
         float DepthFarZ{ DEFAULT_DEPTH_FAR_Z };
         bool PlaneDetectionEnabled{ false };
@@ -688,7 +688,7 @@ namespace xr
 
             // Store the anchor the vector tracking currently allocated anchors, and pass back the result.
             arCoreAnchors.push_back(arAnchor);
-            return {pose, reinterpret_cast<NativeAnchorPtr>(arAnchor)};
+            return { { pose }, reinterpret_cast<NativeAnchorPtr>(arAnchor) };
         }
 
         Anchor DeclareAnchor(NativeAnchorPtr anchor)
@@ -705,7 +705,7 @@ namespace xr
             Pose pose{};
             RawToPose(rawPose, pose);
 
-            return {pose, reinterpret_cast<NativeAnchorPtr>(arAnchor)};
+            return { { pose }, reinterpret_cast<NativeAnchorPtr>(arAnchor) };
         };
 
         void UpdateAnchor(xr::Anchor& anchor)
@@ -728,7 +728,7 @@ namespace xr
                 ArAnchor_getPose(xrContext->Session, arAnchor, tempPose);
                 float rawPose[7]{};
                 ArPose_getPoseRaw(xrContext->Session, tempPose, rawPose);
-                RawToPose(rawPose, anchor.Pose);
+                RawToPose(rawPose, anchor.Space.Pose);
             }
             else if (trackingState == AR_TRACKING_STATE_STOPPED)
             {

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -670,7 +670,7 @@ namespace xr {
         std::vector<Frame::Plane> Planes{};
         std::vector<Frame::Mesh> Meshes{};
         std::vector<FeaturePoint> FeaturePointCloud{};
-        std::optional<Frame::Space> EyeTrackerSpace{};
+        std::optional<Space> EyeTrackerSpace{};
         float DepthNearZ{ DEFAULT_DEPTH_NEAR_Z };
         float DepthFarZ{ DEFAULT_DEPTH_FAR_Z };
         bool FeaturePointCloudEnabled{ false };
@@ -1008,7 +1008,7 @@ namespace xr {
             auto anchor = [[ARAnchor alloc] initWithTransform:poseTransform];
             [SystemImpl.XrContext->Session addAnchor:anchor];
             nativeAnchors.push_back(anchor);
-            return { pose, (__bridge NativeAnchorPtr)anchor };
+            return { { pose }, (__bridge NativeAnchorPtr)anchor };
         }
 
         /**
@@ -1019,7 +1019,7 @@ namespace xr {
             const auto arAnchor = (__bridge ARAnchor*)anchor;
             nativeAnchors.push_back(arAnchor);
             const auto pose{TransformToPose(arAnchor.transform)};
-            return { pose, anchor };
+            return { { pose }, anchor };
         }
         
         /**
@@ -1034,7 +1034,7 @@ namespace xr {
             }
 
             // Then update the anchor's pose based on its transform.
-            anchor.Pose = TransformToPose(arAnchor.transform);
+            anchor.Space.Pose = TransformToPose(arAnchor.transform);
         }
 
         /**

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -314,7 +314,7 @@ namespace xr
         struct
         {
             std::vector<System::Session::Frame::InputSource> ActiveInputSources{};
-            std::optional<System::Session::Frame::Space> EyeTrackerSpace{};
+            std::optional<Space> EyeTrackerSpace{};
             std::vector<FeaturePoint> FeaturePointCloud{};
         } ActionResources{};
 
@@ -492,7 +492,7 @@ namespace xr
 
             if (xr::math::Pose::IsPoseValid(spaceLocation)) 
             {
-                anchor.Pose = {
+                anchor.Space.Pose = {
                     spaceLocation.pose.position.x, spaceLocation.pose.position.y, spaceLocation.pose.position.z,
                     spaceLocation.pose.orientation.x, spaceLocation.pose.orientation.y, spaceLocation.pose.orientation.z, spaceLocation.pose.orientation.w 
                 };

--- a/Dependencies/xr/Source/OpenXR/XrInput.h
+++ b/Dependencies/xr/Source/OpenXR/XrInput.h
@@ -25,7 +25,7 @@ namespace xr
             const XrTime DisplayTime;
             const XrSupportedExtensions& Extensions;
             std::vector<System::Session::Frame::InputSource>& activeInputSources;
-            std::optional<System::Session::Frame::Space>& eyeTrackerSpace;
+            std::optional<Space>& eyeTrackerSpace;
         };
 
         XrInput();

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -2138,7 +2138,8 @@ namespace Babylon
                 const auto spaces = info[0].As<Napi::Array>();
                 const auto spaceCount = info[2].As<Napi::Number>().Uint32Value();
                 auto transforms = info[3].As<Napi::ArrayBuffer>();
-                auto transformsData = reinterpret_cast<std::array<float, 16>*>(transforms.Data());
+                auto byteOffset = info[4].As<Napi::Number>().Uint32Value();
+                auto transformsData = reinterpret_cast<std::array<float, 16>*>(reinterpret_cast<char*>(transforms.Data()) + byteOffset);
 
                 for (uint32_t spaceIdx = 0; spaceIdx < spaceCount; spaceIdx++)
                 {
@@ -2154,7 +2155,8 @@ namespace Babylon
                 const auto spaces = info[0].As<Napi::Array>();
                 const auto spaceCount = info[1].As<Napi::Number>().Uint32Value();
                 auto radii = info[2].As<Napi::ArrayBuffer>();
-                auto radiiData = reinterpret_cast<float*>(radii.Data());
+                auto byteOffset = info[3].As<Napi::Number>().Uint32Value();
+                auto radiiData = reinterpret_cast<float*>(reinterpret_cast<char*>(radii.Data()) + byteOffset);
 
                 for (uint32_t spaceIdx = 0; spaceIdx < spaceCount; spaceIdx++)
                 {

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -1964,13 +1964,13 @@ namespace Babylon
 
             XRFrame(const Napi::CallbackInfo& info)
                 : Napi::ObjectWrap<XRFrame>{info}
+                , m_jsThis{Napi::Persistent(info.This().As<Napi::Object>())}
                 , m_jsXRViewerPose{Napi::Persistent(XRViewerPose::New(info))}
                 , m_xrViewerPose{*XRViewerPose::Unwrap(m_jsXRViewerPose.Value())}
                 , m_jsTransform{Napi::Persistent(XRRigidTransform::New(info))}
                 , m_transform{*XRRigidTransform::Unwrap(m_jsTransform.Value())}
                 , m_jsPose{Napi::Persistent(Napi::Object::New(info.Env()))}
                 , m_jsJointPose{Napi::Persistent(Napi::Object::New(info.Env()))}
-                , m_jsThis{Napi::Persistent(info.This().As<Napi::Object>())}
             {
                 m_jsPose.Set("transform", m_jsTransform.Value());
                 m_jsJointPose.Set("transform", m_jsTransform.Value());

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -2297,7 +2297,7 @@ namespace Babylon
 
                 for (uint32_t i = 0; i < numNewPlaneIds; i++)
                 {
-                    const auto planeId = newPlaneIds[numNewPlaneIds].As<Napi::Number>().Uint32Value();
+                    const auto planeId = newPlaneIds[i].As<Napi::Number>().Uint32Value();
                     auto napiPlane = XRPlane::New(info.Env());
                     auto xrPlane = XRPlane::Unwrap(napiPlane);
                     const auto& nativePlane = GetPlaneFromID(planeId);


### PR DESCRIPTION
This refactor gives an 8% improvement in frame time on HoloLens when visualizing scene understanding meshes, and significantly decreases (90%) `xrFrame.getPose` CPU time. In a performance test with 200 anchors, time spent per frame was reduced 70%.

<img width="1594" alt="mesh-and-anchors-perf" src="https://user-images.githubusercontent.com/4724014/137397065-277f0e82-5c19-45fc-983c-f267aaf5eea5.png">

* Set properties directly on native-backed javascript objects as instance values rather than instance accessors to make for fast reading on the javascript side.
* Rewrite part of the XRFrame::getPoses function in javascript and use memcpy to avoid multiple expensive Set calls over-the-wire (see the babylon.js part of this PR (https://github.com/BabylonJS/Babylon.js/pull/11276) for more details).
* Return spaces instead of reference spaces for planes and anchors.
* Move the Space struct from `xr::System::Session::Frame::Space` to `xr::Space` so that (1) we can attach a space to an anchor to be consistent with the OpenXR and WebXR specs and (2) remove the implication that a space is a frame-bound construct.

Still want to do some more profiling & cleaning up, some other small to-do's:
- [x] Profile anchor tracking performance
- [x] Fix mobile compile errors
- [ ] Test & profile on mobile