### PR TITLE
Parse rgb() color strings in Canvas polyfill

### DIFF
--- a/Polyfills/Canvas/Source/Colors.h
+++ b/Polyfills/Canvas/Source/Colors.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <regex>
 
 namespace Babylon::Polyfills::Internal
 {
@@ -185,17 +186,18 @@ namespace Babylon::Polyfills::Internal
             }
             return nvgRGBA(components[0], components[1], components[2], components[3]);
         }
-        else if (str.substr(0, 4) == "rgb(" && str[str.length() - 1] == ')')
-        {
-            auto rEnd = str.find(",", 4);
-            auto gEnd = str.find(",", rEnd + 1);
-            auto r = str.substr(4, rEnd - 4);
-            auto g = str.substr(rEnd + 1, gEnd - rEnd - 1);
-            auto b = str.substr(gEnd + 1, str.length() - gEnd - 2);
-            return nvgRGB(std::stoi(r), std::stoi(g), std::stoi(b));
-        }
         else
         {
+            // std::smatch pieces_match;
+            // const std::regex pieces_regex("/rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)/");
+            // if (std::regex_match(str, pieces_match, pieces_regex))
+            // {
+            //     if (pieces_match.size() == 3)
+            //     {
+            //         return nvgRGB(std::stoi(pieces_match[0]), std::stoi(pieces_match[1]), std::stoi(pieces_match[2]));
+            //     }
+            // }
+
             if (str == "transparent" || !str.length())
             {
                 return nvgRGBA(0, 0, 0, 0);

--- a/Polyfills/Canvas/Source/Colors.h
+++ b/Polyfills/Canvas/Source/Colors.h
@@ -188,6 +188,7 @@ namespace Babylon::Polyfills::Internal
         }
         else
         {
+            // matches strings of the form rgb(#,#,#)
             static const std::regex rgbRegex("rgb\\(\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*\\)");
             std::smatch rgbMatch;
             if (std::regex_match(str, rgbMatch, rgbRegex))

--- a/Polyfills/Canvas/Source/Colors.h
+++ b/Polyfills/Canvas/Source/Colors.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <regex>
 
+const std::regex rgbRegex("rgb\\(\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*\\)");
+
 namespace Babylon::Polyfills::Internal
 {
     namespace
@@ -188,7 +190,6 @@ namespace Babylon::Polyfills::Internal
         }
         else
         {
-            const std::regex rgbRegex("rgb\\(\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*\\)");
             std::smatch rgbMatch;
             if (std::regex_match(str, rgbMatch, rgbRegex))
             {

--- a/Polyfills/Canvas/Source/Colors.h
+++ b/Polyfills/Canvas/Source/Colors.h
@@ -185,6 +185,15 @@ namespace Babylon::Polyfills::Internal
             }
             return nvgRGBA(components[0], components[1], components[2], components[3]);
         }
+        else if (str.substr(0, 4) == "rgb(" && str[str.length() - 1] == ')')
+        {
+            auto rEnd = str.find(",", 4);
+            auto gEnd = str.find(",", rEnd + 1);
+            auto r = str.substr(4, rEnd - 4);
+            auto g = str.substr(rEnd + 1, gEnd - rEnd - 1);
+            auto b = str.substr(gEnd + 1, str.length() - gEnd - 2);
+            return nvgRGB(std::stoi(r), std::stoi(g), std::stoi(b));
+        }
         else
         {
             if (str == "transparent" || !str.length())

--- a/Polyfills/Canvas/Source/Colors.h
+++ b/Polyfills/Canvas/Source/Colors.h
@@ -188,15 +188,15 @@ namespace Babylon::Polyfills::Internal
         }
         else
         {
-            // std::smatch pieces_match;
-            // const std::regex pieces_regex("/rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)/");
-            // if (std::regex_match(str, pieces_match, pieces_regex))
-            // {
-            //     if (pieces_match.size() == 3)
-            //     {
-            //         return nvgRGB(std::stoi(pieces_match[0]), std::stoi(pieces_match[1]), std::stoi(pieces_match[2]));
-            //     }
-            // }
+            const std::regex rgbRegex("rgb\\(\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*\\)");
+            std::smatch rgbMatch;
+            if (std::regex_match(str, rgbMatch, rgbRegex))
+            {
+                if (rgbMatch.size() == 4)
+                {
+                    return nvgRGB(std::stoi(rgbMatch[1]), std::stoi(rgbMatch[2]), std::stoi(rgbMatch[3]));
+                }
+            }
 
             if (str == "transparent" || !str.length())
             {

--- a/Polyfills/Canvas/Source/Colors.h
+++ b/Polyfills/Canvas/Source/Colors.h
@@ -1,8 +1,6 @@
 #pragma once
 #include <regex>
 
-const std::regex rgbRegex("rgb\\(\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*\\)");
-
 namespace Babylon::Polyfills::Internal
 {
     namespace
@@ -190,6 +188,7 @@ namespace Babylon::Polyfills::Internal
         }
         else
         {
+            static const std::regex rgbRegex("rgb\\(\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*\\)");
             std::smatch rgbMatch;
             if (std::regex_match(str, rgbMatch, rgbRegex))
             {

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -18,9 +18,6 @@
 #include "ImageData.h"
 #include "Colors.h"
 
-// Regex to parse font styling information. For now we are only capturing font size (capture group 3) and font family name (capture group 4).
-const std::regex fontStyleRegex("([[a-zA-Z]+\\s+)*((\\d+)px\\s+)?(\\w+)");
-
 /*
 Most of these context methods are preliminary work. They are currenbly not tested properly.
 */
@@ -536,6 +533,8 @@ namespace Babylon::Polyfills::Internal
         m_currentFontId = -1;
         int fontSize = 16;
 
+        // Regex to parse font styling information. For now we are only capturing font size (capture group 3) and font family name (capture group 4).
+        static const std::regex fontStyleRegex("([[a-zA-Z]+\\s+)*((\\d+)px\\s+)?(\\w+)");
         std::smatch fontStyleMatch;
 
         // Perform the actual regex_match.

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -18,6 +18,9 @@
 #include "ImageData.h"
 #include "Colors.h"
 
+// Regex to parse font styling information. For now we are only capturing font size (capture group 3) and font family name (capture group 4).
+const std::regex fontStyleRegex("([[a-zA-Z]+\\s+)*((\\d+)px\\s+)?(\\w+)");
+
 /*
 Most of these context methods are preliminary work. They are currenbly not tested properly.
 */
@@ -533,8 +536,6 @@ namespace Babylon::Polyfills::Internal
         m_currentFontId = -1;
         int fontSize = 16;
 
-        // Regex to parse font styling information. For now we are only capturing font size (capture group 3) and font family name (capture group 4).
-        const std::regex fontStyleRegex("([[a-zA-Z]+\\s+)*((\\d+)px\\s+)?(\\w+)");
         std::smatch fontStyleMatch;
 
         // Perform the actual regex_match.


### PR DESCRIPTION
Parses strings of the form "rgb(#,#,#)". Does not currently support rgba() strings; I'm happy to add support for those later if we need them. Needed for LensRenderingPipeline.