### PR TITLE
Remove finalizer for vertex array to avoid crash

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -541,12 +541,15 @@ namespace Babylon
     Napi::Value NativeEngine::CreateVertexArray(const Napi::CallbackInfo& info)
     {
         VertexArray* vertexArray = new VertexArray{};
-        return Napi::Pointer<VertexArray>::Create(info.Env(), vertexArray, Napi::NapiPointerDeleter(vertexArray));
+        // HACK: Temporary fix for crash
+        //return Napi::Pointer<VertexArray>::Create(info.Env(), vertexArray, Napi::NapiPointerDeleter(vertexArray));
+        return Napi::Pointer<VertexArray>::Create(info.Env(), vertexArray);
     }
 
     void NativeEngine::DeleteVertexArray(NativeDataStream::Reader& data)
     {
-        data.ReadPointer<VertexArray>()->Dispose();
+        VertexArray* vertexArray = data.ReadPointer<VertexArray>();
+        vertexArray->Dispose();
         // TODO: should we clear the m_boundVertexArray if it gets deleted?
         //assert(vertexArray != m_boundVertexArray);
     }


### PR DESCRIPTION
See https://github.com/BabylonJS/BabylonReactNative/issues/299

This isn't the right fix, but it will prevent the crash. This will re-introduce a memory leak when deleting the engine without calling the JS dispose, but it's better than crashing. Will figure out the right solution afterwards.