### PR TITLE
Refactor Shader Traversers

### DIFF
--- a/Plugins/NativeEngine/Source/ShaderCompilerD3D.cpp
+++ b/Plugins/NativeEngine/Source/ShaderCompilerD3D.cpp
@@ -98,7 +98,7 @@ namespace Babylon
         ShaderCompilerTraversers::IdGenerator ids{};
         auto utstScope = ShaderCompilerTraversers::MoveNonSamplerUniformsIntoStruct(program, ids);
         std::unordered_map<std::string, std::string> vertexAttributeRenaming = {};
-        ShaderCompilerTraversers::AssignLocationsAndNamesToVertexVaryings(program, ids, vertexAttributeRenaming);
+        ShaderCompilerTraversers::AssignLocationsAndNamesToVertexVaryingsD3D(program, ids, vertexAttributeRenaming);
         ShaderCompilerTraversers::SplitSamplersIntoSamplersAndTextures(program, ids);
         ShaderCompilerTraversers::InvertYDerivativeOperands(program);
 

--- a/Plugins/NativeEngine/Source/ShaderCompilerMetal.cpp
+++ b/Plugins/NativeEngine/Source/ShaderCompilerMetal.cpp
@@ -102,7 +102,7 @@ namespace Babylon
         auto cutScope = ShaderCompilerTraversers::ChangeUniformTypes(program, ids);
         auto utstScope = ShaderCompilerTraversers::MoveNonSamplerUniformsIntoStruct(program, ids);
         std::unordered_map<std::string, std::string> vertexAttributeRenaming = {};
-        ShaderCompilerTraversers::AssignLocationsAndNamesToVertexVaryings(program, ids, vertexAttributeRenaming);
+        ShaderCompilerTraversers::AssignLocationsAndNamesToVertexVaryingsOpenGLMetal(program, ids, vertexAttributeRenaming);
         ShaderCompilerTraversers::SplitSamplersIntoSamplersAndTextures(program, ids);
         ShaderCompilerTraversers::InvertYDerivativeOperands(program);
 

--- a/Plugins/NativeEngine/Source/ShaderCompilerOpenGL.cpp
+++ b/Plugins/NativeEngine/Source/ShaderCompilerOpenGL.cpp
@@ -83,7 +83,7 @@ namespace Babylon
         ShaderCompilerTraversers::IdGenerator ids{};
         auto cutScope = ShaderCompilerTraversers::ChangeUniformTypes(program, ids);
         std::unordered_map<std::string, std::string> vertexAttributeRenaming = {};
-        ShaderCompilerTraversers::AssignLocationsAndNamesToVertexVaryings(program, ids, vertexAttributeRenaming);
+        ShaderCompilerTraversers::AssignLocationsAndNamesToVertexVaryingsOpenGLMetal(program, ids, vertexAttributeRenaming);
 
         std::string vertexGLSL(vertexSource.data(), vertexSource.size());
         auto [vertexParser, vertexCompiler] = CompileShader(program, EShLangVertex, vertexGLSL);

--- a/Plugins/NativeEngine/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/NativeEngine/Source/ShaderCompilerTraversers.cpp
@@ -517,9 +517,10 @@ namespace Babylon::ShaderCompilerTraversers
         public:
             static void Traverse(TProgram& program, IdGenerator& ids, std::unordered_map<std::string, std::string>& replacementToOriginalName)
             {
+                auto intermediate{program.getIntermediate(EShLangVertex)};
                 VertexVaryingInTraverserOpenGLMetal traverser{};
-                program.getIntermediate(EShLangVertex)->getTreeRoot()->traverse(&traverser);
-                VertexVaryingInTraverser::Traverse(program.getIntermediate(EShLangVertex), ids, replacementToOriginalName, traverser);
+                intermediate->getTreeRoot()->traverse(&traverser);
+                VertexVaryingInTraverser::Traverse(intermediate, ids, replacementToOriginalName, traverser);
             }
 
         private:
@@ -568,8 +569,9 @@ namespace Babylon::ShaderCompilerTraversers
         public:
             static void Traverse(TProgram& program, IdGenerator& ids, std::unordered_map<std::string, std::string>& replacementToOriginalName)
             {
+                auto intermediate{program.getIntermediate(EShLangVertex)};
                 VertexVaryingInTraverserD3D traverser{};
-                program.getIntermediate(EShLangVertex)->getTreeRoot()->traverse(&traverser);
+                intermediate->getTreeRoot()->traverse(&traverser);
                 // UVs are effectively a special kind of generic attribute since they both use
                 // are implemented using texture coordinates, so we preprocess to pre-count the
                 // number of UV coordinate variables to prevent collisions.
@@ -580,7 +582,7 @@ namespace Babylon::ShaderCompilerTraversers
                         traverser.m_genericAttributesRunningCount++;
                     }
                 }
-                VertexVaryingInTraverser::Traverse(program.getIntermediate(EShLangVertex), ids, replacementToOriginalName, traverser);
+                VertexVaryingInTraverser::Traverse(intermediate, ids, replacementToOriginalName, traverser);
             }
 
         private:

--- a/Plugins/NativeEngine/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/NativeEngine/Source/ShaderCompilerTraversers.cpp
@@ -436,7 +436,7 @@ namespace Babylon::ShaderCompilerTraversers
         /// This traverser modifies all vertex attributes (position, UV, etc.) to conform to
         /// bgfx's expectations regarding name and location. It is currently required for
         /// DirectX, OpenGL, and Metal.
-        class VertexVaryingInTraverser : private TIntermTraverser
+        class VertexVaryingInTraverser : protected TIntermTraverser
         {
         protected:
             virtual void visitSymbol(TIntermSymbol* symbol) override
@@ -465,7 +465,7 @@ namespace Babylon::ShaderCompilerTraversers
                 return {0, name};
             }
 
-            static void Traverse(TIntermediate* intermediate, IdGenerator& ids, std::unordered_map<std::string, std::string>& replacementToOriginalName, VertexVaryingInTraverser traverser)
+            static void Traverse(TIntermediate* intermediate, IdGenerator& ids, std::unordered_map<std::string, std::string>& replacementToOriginalName, VertexVaryingInTraverser& traverser)
             {
                 intermediate->getTreeRoot()->traverse(&traverser);
 

--- a/Plugins/NativeEngine/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/NativeEngine/Source/ShaderCompilerTraversers.cpp
@@ -336,7 +336,8 @@ namespace Babylon::ShaderCompilerTraversers
 
                     // Helper function to correctly insert the shape conversion into the AST.
                     // More about shape conversion below.
-                    constexpr auto injectShapeConversion = [](TIntermTyped* node, TIntermNode* parent, TIntermTyped* shapeConversion) {
+                    constexpr auto injectShapeConversion = [](TIntermTyped* node, TIntermNode* parent, TIntermTyped* shapeConversion)
+                    {
                         if (auto* aggregate = parent->getAsAggregate())
                         {
                             auto& sequence = aggregate->getSequence();
@@ -753,8 +754,8 @@ namespace Babylon::ShaderCompilerTraversers
         public:
             static void Traverse(TProgram& program)
             {
-                auto intermediate{ program.getIntermediate(EShLangFragment) };
-                InvertYDerivativeOperandsTraverser invertYDerivativeOperandsTraverser{ intermediate };
+                auto intermediate{program.getIntermediate(EShLangFragment)};
+                InvertYDerivativeOperandsTraverser invertYDerivativeOperandsTraverser{intermediate};
                 intermediate->getTreeRoot()->traverse(&invertYDerivativeOperandsTraverser);
             }
 
@@ -776,7 +777,7 @@ namespace Babylon::ShaderCompilerTraversers
 
         private:
             InvertYDerivativeOperandsTraverser(TIntermediate* intermediate)
-                : m_intermediate{ intermediate }
+                : m_intermediate{intermediate}
             {
             }
 
@@ -799,7 +800,7 @@ namespace Babylon::ShaderCompilerTraversers
         VertexVaryingInTraverserOpenGLMetal::Traverse(program, ids, replacementToOriginalName);
     }
 
-    void AssignLocationsAndNamesToVertexVaryingsD3D(TProgram & program, IdGenerator & ids, std::unordered_map<std::string, std::string> & replacementToOriginalName)
+    void AssignLocationsAndNamesToVertexVaryingsD3D(TProgram& program, IdGenerator& ids, std::unordered_map<std::string, std::string>& replacementToOriginalName)
     {
         VertexVaryingInTraverserD3D::Traverse(program, ids, replacementToOriginalName);
     }

--- a/Plugins/NativeEngine/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/NativeEngine/Source/ShaderCompilerTraversers.cpp
@@ -436,15 +436,9 @@ namespace Babylon::ShaderCompilerTraversers
         /// This traverser modifies all vertex attributes (position, UV, etc.) to conform to
         /// bgfx's expectations regarding name and location. It is currently required for
         /// DirectX, OpenGL, and Metal.
-        class VertexVaryingInTraverser final : private TIntermTraverser
+        class VertexVaryingInTraverser : private TIntermTraverser
         {
-        public:
-            static void Traverse(TProgram& program, IdGenerator& ids, std::unordered_map<std::string, std::string>& replacementToOriginalName)
-            {
-                Traverse(program.getIntermediate(EShLangVertex), ids, replacementToOriginalName);
-            }
-
-        private:
+        protected:
             virtual void visitSymbol(TIntermSymbol* symbol) override
             {
                 // Collect all vertex attributes, described by glslang as "varyings."
@@ -466,73 +460,13 @@ namespace Babylon::ShaderCompilerTraversers
                 }
             }
 
-#if __APPLE__ || APIOpenGL
-            // This table is a copy of the table bgfx uses for vertex attribute -> shader symbol association.
-            // copied from renderer_gl.cpp.
-            constexpr static const char* s_attribName[] =
+            virtual std::pair<unsigned int, const char*> GetVaryingLocationAndNewNameForName(const char* name)
             {
-                "a_position",
-                "a_normal",
-                "a_tangent",
-                "a_bitangent",
-                "a_color0",
-                "a_color1",
-                "a_color2",
-                "a_color3",
-                "a_indices",
-                "a_weight",
-                "a_texcoord0",
-                "a_texcoord1",
-                "a_texcoord2",
-                "a_texcoord3",
-                "a_texcoord4",
-                "a_texcoord5",
-                "a_texcoord6",
-                "a_texcoord7",
-            };
-            BX_STATIC_ASSERT(bgfx::Attrib::Count == BX_COUNTOF(s_attribName));
-#endif
-
-            std::pair<unsigned int, const char*> GetVaryingLocationAndNewNameForName(const char* name)
-            {
-#if __APPLE__ || APIOpenGL
-                // For OpenGL and Metal platforms, we have an issue where we have a hard limit on the number shader attributes supported.
-                // To work around this issue, instead of mapping our attributes to the most similar bgfx::attribute, instead replace
-                // the first attribute encountered with the symbol bgfx uses for attribute 0 and increment for each subsequent attribute encountered.
-                // This will cause our shader to have nonsensical naming, but will allow us to efficiently "pack" the attributes.
-                UNUSED(name);
-                m_genericAttributesRunningCount++;
-                if (m_genericAttributesRunningCount >= static_cast<unsigned int>(bgfx::Attrib::Count))
-                    throw std::runtime_error("Cannot support more than 18 vertex attributes.");
-
-                return {static_cast<unsigned int>(m_genericAttributesRunningCount-1), s_attribName[static_cast<unsigned int>(m_genericAttributesRunningCount-1)]};
-#else
-#define IF_NAME_RETURN_ATTRIB(varyingName, attrib, newName)  \
-    if (std::strcmp(name, varyingName) == 0)                 \
-    {                                                        \
-        return {static_cast<unsigned int>(attrib), newName}; \
-    }
-                IF_NAME_RETURN_ATTRIB("position", bgfx::Attrib::Position, "a_position")
-                IF_NAME_RETURN_ATTRIB("normal", bgfx::Attrib::Normal, "a_normal")
-                IF_NAME_RETURN_ATTRIB("tangent", bgfx::Attrib::Tangent, "a_tangent")
-                IF_NAME_RETURN_ATTRIB("uv", bgfx::Attrib::TexCoord0, "a_texcoord0")
-                IF_NAME_RETURN_ATTRIB("uv2", bgfx::Attrib::TexCoord1, "a_texcoord1")
-                IF_NAME_RETURN_ATTRIB("uv3", bgfx::Attrib::TexCoord2, "a_texcoord2")
-                IF_NAME_RETURN_ATTRIB("uv4", bgfx::Attrib::TexCoord3, "a_texcoord3")
-                IF_NAME_RETURN_ATTRIB("color", bgfx::Attrib::Color0, "a_color0")
-                IF_NAME_RETURN_ATTRIB("matricesIndices", bgfx::Attrib::Indices, "a_indices")
-                IF_NAME_RETURN_ATTRIB("matricesWeights", bgfx::Attrib::Weight, "a_weight")
-#undef IF_NAME_RETURN_ATTRIB
-                const unsigned int attributeLocation = FIRST_GENERIC_ATTRIBUTE_LOCATION + m_genericAttributesRunningCount++;
-                if (attributeLocation >= static_cast<unsigned int>(bgfx::Attrib::Count))
-                    throw std::runtime_error("Cannot support more than 18 vertex attributes.");
-                return {attributeLocation, name};
-#endif
+                return {0, name};
             }
 
-            static void Traverse(TIntermediate* intermediate, IdGenerator& ids, std::unordered_map<std::string, std::string>& replacementToOriginalName)
+            static void Traverse(TIntermediate* intermediate, IdGenerator& ids, std::unordered_map<std::string, std::string>& replacementToOriginalName, VertexVaryingInTraverser traverser)
             {
-                VertexVaryingInTraverser traverser{};
                 intermediate->getTreeRoot()->traverse(&traverser);
 
                 std::map<std::string, TIntermTyped*> originalNameToReplacement{};
@@ -543,18 +477,6 @@ namespace Babylon::ShaderCompilerTraversers
                 TPublicType publicType{};
                 publicType.qualifier.clearLayout();
 
-#if !(__APPLE__ || APIOpenGL)
-                // UVs are effectively a special kind of generic attribute since they both use
-                // are implemented using texture coordinates, so we preprocess to pre-count the
-                // number of UV coordinate variables to prevent collisions.
-                for (const auto& [name, symbol] : traverser.m_varyingNameToSymbol)
-                {
-                    if (name.size() >= 2 && name[0] == 'u' && name[1] == 'v')
-                    {
-                        traverser.m_genericAttributesRunningCount++;
-                    }
-                }
-#endif
                 // Create the new symbols with which to replace all of the original varying
                 // symbols. The primary purpose of these new symbols is to contain the required
                 // name and location.
@@ -586,12 +508,100 @@ namespace Babylon::ShaderCompilerTraversers
 
                 MakeReplacements(originalNameToReplacement, traverser.m_symbolsToParents);
             }
-# if !(__APPLE__ || APIOpenGL)
-            const unsigned int FIRST_GENERIC_ATTRIBUTE_LOCATION{10};
-# endif
             unsigned int m_genericAttributesRunningCount{0};
             std::map<std::string, TIntermSymbol*> m_varyingNameToSymbol{};
             std::vector<std::pair<TIntermSymbol*, TIntermNode*>> m_symbolsToParents{};
+        };
+
+        class VertexVaryingInTraverserOpenGLMetal final : private VertexVaryingInTraverser
+        {
+        public:
+            static void Traverse(TProgram& program, IdGenerator& ids, std::unordered_map<std::string, std::string>& replacementToOriginalName)
+            {
+                VertexVaryingInTraverserOpenGLMetal traverser{};
+                // UVs are effectively a special kind of generic attribute since they both use
+                // are implemented using texture coordinates, so we preprocess to pre-count the
+                // number of UV coordinate variables to prevent collisions.
+                for (const auto& [name, symbol] : traverser.m_varyingNameToSymbol)
+                {
+                    if (name.size() >= 2 && name[0] == 'u' && name[1] == 'v')
+                    {
+                        traverser.m_genericAttributesRunningCount++;
+                    }
+                }
+                VertexVaryingInTraverser::Traverse(program.getIntermediate(EShLangVertex), ids, replacementToOriginalName, traverser);
+            }
+        private:
+            constexpr static const char* s_attribName[] =
+            {
+                "a_position",
+                "a_normal",
+                "a_tangent",
+                "a_bitangent",
+                "a_color0",
+                "a_color1",
+                "a_color2",
+                "a_color3",
+                "a_indices",
+                "a_weight",
+                "a_texcoord0",
+                "a_texcoord1",
+                "a_texcoord2",
+                "a_texcoord3",
+                "a_texcoord4",
+                "a_texcoord5",
+                "a_texcoord6",
+                "a_texcoord7",
+            };
+            BX_STATIC_ASSERT(bgfx::Attrib::Count == BX_COUNTOF(s_attribName));
+            std::pair<unsigned int, const char*> GetVaryingLocationAndNewNameForName(const char* name)
+            {
+                // For OpenGL and Metal platforms, we have an issue where we have a hard limit on the number shader attributes supported.
+                // To work around this issue, instead of mapping our attributes to the most similar bgfx::attribute, instead replace
+                // the first attribute encountered with the symbol bgfx uses for attribute 0 and increment for each subsequent attribute encountered.
+                // This will cause our shader to have nonsensical naming, but will allow us to efficiently "pack" the attributes.
+                UNUSED(name);
+                m_genericAttributesRunningCount++;
+                if (m_genericAttributesRunningCount >= static_cast<unsigned int>(bgfx::Attrib::Count))
+                    throw std::runtime_error("Cannot support more than 18 vertex attributes.");
+
+                return {static_cast<unsigned int>(m_genericAttributesRunningCount-1), s_attribName[static_cast<unsigned int>(m_genericAttributesRunningCount-1)]};
+            }
+        };
+
+        class VertexVaryingInTraverserD3D final : private VertexVaryingInTraverser
+        {
+        public:
+            static void Traverse(TProgram& program, IdGenerator& ids, std::unordered_map<std::string, std::string>& replacementToOriginalName)
+            {
+                VertexVaryingInTraverserD3D traverser{};
+                VertexVaryingInTraverser::Traverse(program.getIntermediate(EShLangVertex), ids, replacementToOriginalName, traverser);
+            }
+        private:
+            std::pair<unsigned int, const char*> GetVaryingLocationAndNewNameForName(const char* name)
+            {
+                #define IF_NAME_RETURN_ATTRIB(varyingName, attrib, newName)  \
+                    if (std::strcmp(name, varyingName) == 0)                 \
+                    {                                                        \
+                        return {static_cast<unsigned int>(attrib), newName}; \
+                    }
+                    IF_NAME_RETURN_ATTRIB("position", bgfx::Attrib::Position, "a_position")
+                    IF_NAME_RETURN_ATTRIB("normal", bgfx::Attrib::Normal, "a_normal")
+                    IF_NAME_RETURN_ATTRIB("tangent", bgfx::Attrib::Tangent, "a_tangent")
+                    IF_NAME_RETURN_ATTRIB("uv", bgfx::Attrib::TexCoord0, "a_texcoord0")
+                    IF_NAME_RETURN_ATTRIB("uv2", bgfx::Attrib::TexCoord1, "a_texcoord1")
+                    IF_NAME_RETURN_ATTRIB("uv3", bgfx::Attrib::TexCoord2, "a_texcoord2")
+                    IF_NAME_RETURN_ATTRIB("uv4", bgfx::Attrib::TexCoord3, "a_texcoord3")
+                    IF_NAME_RETURN_ATTRIB("color", bgfx::Attrib::Color0, "a_color0")
+                    IF_NAME_RETURN_ATTRIB("matricesIndices", bgfx::Attrib::Indices, "a_indices")
+                    IF_NAME_RETURN_ATTRIB("matricesWeights", bgfx::Attrib::Weight, "a_weight")
+                #undef IF_NAME_RETURN_ATTRIB
+                const unsigned int attributeLocation = FIRST_GENERIC_ATTRIBUTE_LOCATION + m_genericAttributesRunningCount++;
+                if (attributeLocation >= static_cast<unsigned int>(bgfx::Attrib::Count))
+                    throw std::runtime_error("Cannot support more than 18 vertex attributes.");
+                return {attributeLocation, name};
+            }
+            const unsigned int FIRST_GENERIC_ATTRIBUTE_LOCATION{10};
         };
 
         /// <summary>
@@ -779,9 +789,14 @@ namespace Babylon::ShaderCompilerTraversers
         return UniformTypeChangeTraverser::Traverse(program, ids);
     }
 
-    void AssignLocationsAndNamesToVertexVaryings(TProgram& program, IdGenerator& ids, std::unordered_map<std::string, std::string>& replacementToOriginalName)
+    void AssignLocationsAndNamesToVertexVaryingsOpenGLMetal(TProgram& program, IdGenerator& ids, std::unordered_map<std::string, std::string>& replacementToOriginalName)
     {
-        VertexVaryingInTraverser::Traverse(program, ids, replacementToOriginalName);
+        VertexVaryingInTraverserOpenGLMetal::Traverse(program, ids, replacementToOriginalName);
+    }
+
+    void AssignLocationsAndNamesToVertexVaryingsD3D(TProgram & program, IdGenerator & ids, std::unordered_map<std::string, std::string> & replacementToOriginalName)
+    {
+        VertexVaryingInTraverserD3D::Traverse(program, ids, replacementToOriginalName);
     }
 
     void SplitSamplersIntoSamplersAndTextures(TProgram& program, IdGenerator& ids)

--- a/Plugins/NativeEngine/Source/ShaderCompilerTraversers.h
+++ b/Plugins/NativeEngine/Source/ShaderCompilerTraversers.h
@@ -67,7 +67,8 @@ namespace Babylon::ShaderCompilerTraversers
 
     /// Changes the names and locations of varying attributes in the vertex shader to
     /// match bgfx's expectations.
-    void AssignLocationsAndNamesToVertexVaryings(glslang::TProgram& program, IdGenerator& ids, std::unordered_map<std::string, std::string>& vertexAttributeRenaming);
+    void AssignLocationsAndNamesToVertexVaryingsOpenGLMetal(glslang::TProgram& program, IdGenerator& ids, std::unordered_map<std::string, std::string>& vertexAttributeRenaming);
+    void AssignLocationsAndNamesToVertexVaryingsD3D(glslang::TProgram& program, IdGenerator& ids, std::unordered_map<std::string, std::string>& vertexAttributeRenaming);
 
     /// WebGL (and therefore Babylon.js) treats texture samplers as a single variable.
     /// Native platforms expect them to be two separate variables -- a texture and a


### PR DESCRIPTION
This PR is a first pass at cleaning up the shader compiler code. The main change is to remove the preprocessor directives for VertexVaryingInTraverser, and replace them with separate subclasses classes. Since OpenGL and Metal use the same logic, they both share a subclass, while DirectX has it's own.

This approach seemed like the best way to get rid of preprocessors while still minimizing code duplication.

I left the IF_NAME_RETURN_ATTRIB macro in because there didn't seem to be much benefit to factoring it out; I could have rewritten it with a list and iterated over that, but I think the current solution is pretty readable as is.

(Also, sorry about the messy commit history; this branch diverged a bit from master and rebasing seems to have left a bunch of extraneous commits)

Resolves #914