### PR TITLE
Android UrlLib: throw if scheme is null

### DIFF
--- a/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
@@ -46,6 +46,12 @@ namespace UrlLib
         {
             m_method = method;
             Uri uri{Uri::Parse(url.data())};
+            // If the URL string doesn't contain a scheme, the URI object's scheme will be null. We throw in this case
+            // The path is never null, even if it's empty it will be an empty string
+            if ((jstring)uri.getScheme() == nullptr)
+            {
+                throw std::runtime_error("Cannot parse a URI without a scheme");
+            }
             if ((std::string)uri.getScheme() == "app")
             {
                 m_schemeIsApp = true;


### PR DESCRIPTION
In response to this thread: https://forum.babylonjs.com/t/error-cannot-load-cubemap-because-6-files-were-not-defined/24852/50

Throws a clearer error message if you try to open a URL without a scheme