### PR TITLE
Fix my goofy order-of-operations gaffe in iOS Playground

### DIFF
--- a/Apps/Playground/iOS/LibNativeBridge.mm
+++ b/Apps/Playground/iOS/LibNativeBridge.mm
@@ -105,10 +105,10 @@ bool g_isXrActive{};
 {
     if (graphics)
     {
-        update->Start();
         graphics->StartRenderingCurrentFrame();
-        graphics->FinishRenderingCurrentFrame();
+        update->Start();
         update->Finish();
+        graphics->FinishRenderingCurrentFrame();
     }
 }
 


### PR DESCRIPTION
Fixes #951.