### PR TITLE
Fix an issue with array buffer finalizers for napi/jsi implementation

### DIFF
--- a/Dependencies/napi/napi-jsi/include/napi/napi.h
+++ b/Dependencies/napi/napi-jsi/include/napi/napi.h
@@ -50,8 +50,6 @@ struct napi_env__ {
     , native_name{facebook::jsi::PropNameID::forAscii(rt, "__native__")}
     , array_buffer_ctor{rt.global().getPropertyAsFunction(rt, "ArrayBuffer")}
     , promise_ctor{rt.global().getPropertyAsFunction(rt, "Promise")}
-    , get_prototype_of_func(rt.global().getPropertyAsObject(rt, "Object").getPropertyAsFunction(rt, "getPrototypeOf"))
-    , set_prototype_of_func(rt.global().getPropertyAsObject(rt, "Object").getPropertyAsFunction(rt, "setPrototypeOf"))
     , typed_array_ctor{
         rt.global().getPropertyAsFunction(rt, "Int8Array"),
         rt.global().getPropertyAsFunction(rt, "Uint8Array"),
@@ -68,8 +66,6 @@ struct napi_env__ {
   facebook::jsi::PropNameID native_name;
   facebook::jsi::Function array_buffer_ctor;
   facebook::jsi::Function promise_ctor;
-  facebook::jsi::Function get_prototype_of_func;
-  facebook::jsi::Function set_prototype_of_func;
   facebook::jsi::Function typed_array_ctor[9];
 };
 
@@ -699,6 +695,8 @@ namespace Napi {
     size_t ByteLength() const; ///< Gets the length of the array buffer in bytes.
 
   private:
+    static jsi::ArrayBuffer FromExternal(napi_env env, void* externalData, size_t byteLength);
+
     std::optional<jsi::ArrayBuffer> _arrayBuffer;
   };
 


### PR DESCRIPTION
There is an issue with using jsi host objects as prototypes on react native windows. This change works around the problem by using a side property instead of chaining the prototype. Using prototype chaining is perhaps not a good idea anyways since it introduces another layer when accessing arraybuffer members.