### PR TITLE
Switch anchor pose for space

### DIFF
--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -82,6 +82,11 @@ namespace xr
         Vector4f Orientation;
     };
 
+    struct Space
+    {
+        Pose Pose;
+    };
+
     using NativeTrackablePtr = void*;
     struct HitResult
     {
@@ -98,7 +103,7 @@ namespace xr
     using NativeAnchorPtr = void*;
     struct Anchor
     {
-        Pose Pose{};
+        Space Space{};
         NativeAnchorPtr NativeAnchor{};
         bool IsValid{true};
     };
@@ -188,11 +193,6 @@ namespace xr
             class Frame
             {
             public:
-                struct Space
-                {
-                    Pose Pose;
-                };
-
                 struct JointSpace : Space
                 {
                     float PoseRadius{};

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -184,7 +184,7 @@ namespace xr
         std::vector<Frame::Plane> Planes{};
         std::vector<Frame::Mesh> Meshes{};
         std::vector<FeaturePoint> FeaturePointCloud{};
-        std::optional<Frame::Space> EyeTrackerSpace{};
+        std::optional<Space> EyeTrackerSpace{};
         float DepthNearZ{ DEFAULT_DEPTH_NEAR_Z };
         float DepthFarZ{ DEFAULT_DEPTH_FAR_Z };
         bool PlaneDetectionEnabled{ false };
@@ -711,7 +711,7 @@ namespace xr
 
             // Store the anchor the vector tracking currently allocated anchors, and pass back the result.
             arCoreAnchors.push_back(arAnchor);
-            return {pose, reinterpret_cast<NativeAnchorPtr>(arAnchor)};
+            return { { pose }, reinterpret_cast<NativeAnchorPtr>(arAnchor) };
         }
 
         Anchor DeclareAnchor(NativeAnchorPtr anchor)
@@ -728,7 +728,7 @@ namespace xr
             Pose pose{};
             RawToPose(rawPose, pose);
 
-            return {pose, reinterpret_cast<NativeAnchorPtr>(arAnchor)};
+            return { { pose }, reinterpret_cast<NativeAnchorPtr>(arAnchor)};
         };
 
         void UpdateAnchor(xr::Anchor& anchor)
@@ -751,7 +751,7 @@ namespace xr
                 ArAnchor_getPose(xrContext->Session, arAnchor, tempPose);
                 float rawPose[7]{};
                 ArPose_getPoseRaw(xrContext->Session, tempPose, rawPose);
-                RawToPose(rawPose, anchor.Pose);
+                RawToPose(rawPose, anchor.Space.Pose);
             }
             else if (trackingState == AR_TRACKING_STATE_STOPPED)
             {

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -671,7 +671,7 @@ namespace xr {
         std::vector<Frame::Plane> Planes{};
         std::vector<Frame::Mesh> Meshes{};
         std::vector<FeaturePoint> FeaturePointCloud{};
-        std::optional<Frame::Space> EyeTrackerSpace{};
+        std::optional<Space> EyeTrackerSpace{};
         float DepthNearZ{ DEFAULT_DEPTH_NEAR_Z };
         float DepthFarZ{ DEFAULT_DEPTH_FAR_Z };
         bool FeaturePointCloudEnabled{ false };
@@ -1009,7 +1009,7 @@ namespace xr {
             auto anchor = [[ARAnchor alloc] initWithTransform:poseTransform];
             [SystemImpl.XrContext->Session addAnchor:anchor];
             nativeAnchors.push_back(anchor);
-            return { pose, (__bridge NativeAnchorPtr)anchor };
+            return { { pose }, (__bridge NativeAnchorPtr)anchor };
         }
 
         /**
@@ -1020,7 +1020,7 @@ namespace xr {
             const auto arAnchor = (__bridge ARAnchor*)anchor;
             nativeAnchors.push_back(arAnchor);
             const auto pose{TransformToPose(arAnchor.transform)};
-            return { pose, anchor };
+            return { { pose }, anchor };
         }
         
         /**
@@ -1035,7 +1035,7 @@ namespace xr {
             }
 
             // Then update the anchor's pose based on its transform.
-            anchor.Pose = TransformToPose(arAnchor.transform);
+            anchor.Space.Pose = TransformToPose(arAnchor.transform);
         }
 
         /**

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -314,7 +314,7 @@ namespace xr
         struct
         {
             std::vector<System::Session::Frame::InputSource> ActiveInputSources{};
-            std::optional<System::Session::Frame::Space> EyeTrackerSpace{};
+            std::optional<Space> EyeTrackerSpace{};
             std::vector<FeaturePoint> FeaturePointCloud{};
         } ActionResources{};
 
@@ -492,7 +492,7 @@ namespace xr
 
             if (xr::math::Pose::IsPoseValid(spaceLocation)) 
             {
-                anchor.Pose = {
+                anchor.Space.Pose = {
                     spaceLocation.pose.position.x, spaceLocation.pose.position.y, spaceLocation.pose.position.z,
                     spaceLocation.pose.orientation.x, spaceLocation.pose.orientation.y, spaceLocation.pose.orientation.z, spaceLocation.pose.orientation.w 
                 };

--- a/Dependencies/xr/Source/OpenXR/XrInput.h
+++ b/Dependencies/xr/Source/OpenXR/XrInput.h
@@ -25,7 +25,7 @@ namespace xr
             const XrTime DisplayTime;
             const XrSupportedExtensions& Extensions;
             std::vector<System::Session::Frame::InputSource>& activeInputSources;
-            std::optional<System::Session::Frame::Space>& eyeTrackerSpace;
+            std::optional<Space>& eyeTrackerSpace;
         };
 
         XrInput();

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -53,7 +53,7 @@ namespace
     };
     // clang-format on
 
-    std::array<float, 16> CreateTransformMatrix(const xr::System::Session::Frame::Space& space, bool viewSpace = true)
+    std::array<float, 16> CreateTransformMatrix(const xr::Space& space, bool viewSpace = true)
     {
         auto& quat = space.Pose.Orientation;
         auto& pos = space.Pose.Position;
@@ -143,8 +143,8 @@ namespace
     void SetXRInputSourceData(Napi::Object& jsInputSource, xr::System::Session::Frame::InputSource& inputSource)
     {
         auto env = jsInputSource.Env();
-        jsInputSource.Set("targetRaySpace", Napi::External<xr::System::Session::Frame::Space>::New(env, &inputSource.AimSpace));
-        jsInputSource.Set("gripSpace", Napi::External<xr::System::Session::Frame::Space>::New(env, &inputSource.GripSpace));
+        jsInputSource.Set("targetRaySpace", Napi::External<xr::Space>::New(env, &inputSource.AimSpace));
+        jsInputSource.Set("gripSpace", Napi::External<xr::Space>::New(env, &inputSource.GripSpace));
 
         // Don't set hands up unless hand data is supported/available
         if (inputSource.HandTrackedThisFrame || inputSource.JointsTrackedThisFrame)
@@ -950,7 +950,7 @@ namespace Babylon
                 Update({transform->GetNativePose()}, false);
             }
 
-            void Update(const xr::System::Session::Frame::Space& space, bool isViewSpace)
+            void Update(const xr::Space& space, bool isViewSpace)
             {
                 auto position = m_position.Value();
                 position.Set("x", space.Pose.Position.X);
@@ -969,7 +969,7 @@ namespace Babylon
 
             void Update(const xr::Pose& pose)
             {
-                xr::System::Session::Frame::Space space{{pose}};
+                xr::Space space{{pose}};
                 Update(space, true);
             }
 
@@ -1041,7 +1041,7 @@ namespace Babylon
             {
             }
 
-            void Update(size_t eyeIdx, gsl::span<const float, 16> projectionMatrix, const xr::System::Session::Frame::Space& space, bool isFirstPersonObserver)
+            void Update(size_t eyeIdx, gsl::span<const float, 16> projectionMatrix, const xr::Space& space, bool isFirstPersonObserver)
             {
                 if (eyeIdx != m_eyeIdx)
                 {
@@ -1476,7 +1476,6 @@ namespace Babylon
                     env,
                     JS_CLASS_NAME,
                     {
-                        InstanceAccessor("anchorSpace", &XRAnchor::GetAnchorSpace, nullptr),
                         InstanceMethod("delete", &XRAnchor::Delete),
                     });
 
@@ -1490,7 +1489,10 @@ namespace Babylon
 
             XRAnchor(const Napi::CallbackInfo& info)
                 : Napi::ObjectWrap<XRAnchor>{info}
+                , m_jsAnchorSpace{Napi::External<xr::Space>::New(info.Env(), &m_nativeAnchor.Space)}
             {
+                auto jsThis = info.This().As<Napi::Object>();
+                jsThis.Set("anchorSpace", m_jsAnchorSpace);
             }
 
             xr::Anchor& GetNativeAnchor()
@@ -1504,16 +1506,6 @@ namespace Babylon
             }
 
         private:
-            Napi::Value GetAnchorSpace(const Napi::CallbackInfo& info)
-            {
-                Napi::Object napiTransform = XRRigidTransform::New(info);
-                XRRigidTransform* rigidTransform = XRRigidTransform::Unwrap(napiTransform);
-                rigidTransform->Update(m_nativeAnchor.Pose);
-
-                Napi::Object napiSpace = XRReferenceSpace::New(info.Env(), napiTransform);
-                return std::move(napiSpace);
-            }
-
             // Marks the anchor as no longer valid, and should be deleted on the next pass.
             void Delete(const Napi::CallbackInfo&)
             {
@@ -1522,6 +1514,7 @@ namespace Babylon
 
             // The native anchor which holds the current position of the anchor, and the native ref to the anchor.
             xr::Anchor m_nativeAnchor{};
+            Napi::External<xr::Space> m_jsAnchorSpace{};
         };
 
         // Implementation of the XRHitTestSource interface: https://immersive-web.github.io/hit-test/#hit-test-source-interface
@@ -2209,7 +2202,7 @@ namespace Babylon
             {
                 if (info[0].IsExternal())
                 {
-                    const auto& space = *info[0].As<Napi::External<xr::System::Session::Frame::Space>>().Data();
+                    const auto& space = *info[0].As<Napi::External<xr::Space>>().Data();
                     m_transform.Update(space, false);
                     return m_jsPose.Value();
                 }
@@ -2709,7 +2702,7 @@ namespace Babylon
                 if (frame.EyeTrackerSpace.has_value() && m_jsEyeTrackedSource.IsEmpty())
                 {
                     m_jsEyeTrackedSource = Napi::Persistent(Napi::Object::New(env));
-                    m_jsEyeTrackedSource.Set("gazeSpace", Napi::External<xr::System::Session::Frame::Space>::New(env, &frame.EyeTrackerSpace.value()));
+                    m_jsEyeTrackedSource.Set("gazeSpace", Napi::External<xr::Space>::New(env, &frame.EyeTrackerSpace.value()));
 
                     for (const auto& [name, callback] : m_eventNamesAndCallbacks)
                     {


### PR DESCRIPTION
Use spaces instead of plain poses on anchors to more closely match the XR API's we work with, remove the implication that a space is a frame-bound construct (the pose attached to the space is frame-bound), and allow us to store `anchorSpace` as a property on the anchor object rather than exposing it through an accessor function to improve performance.