### PR TITLE
Handle selection node fixing repro for shader compilation bug.

### DIFF
--- a/Plugins/NativeEngine/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/NativeEngine/Source/ShaderCompilerTraversers.cpp
@@ -364,6 +364,21 @@ namespace Babylon::ShaderCompilerTraversers
                         {
                             unary->setOperand(shapeConversion);
                         }
+                        else if (auto* selection = parent->getAsSelectionNode())
+                        {
+                            if (selection->getCondition() == node)
+                            {
+                                selection->setCondition(shapeConversion);
+                            }
+                            else if (selection->getTrueBlock() == node)
+                            {
+                                selection->setTrueBlock(shapeConversion);
+                            }
+                            else
+                            {
+                                selection->setFalseBlock(shapeConversion);
+                            }
+                        }
                         else
                         {
                             throw std::runtime_error{"Cannot replace symbol: node type handler unimplemented"};


### PR DESCRIPTION
Fixes #959. Tested on Windows D3D11 using the repro described in the bug.