### PR TITLE
Root package.json

### DIFF
--- a/.github/jobs/android.yml
+++ b/.github/jobs/android.yml
@@ -18,6 +18,7 @@ jobs:
     - task: Npm@1
       inputs:
         command: 'install'
+        workingDir: './'
       displayName: 'Install Babylon.js NPM packages'
 
     - template: cmake.yml

--- a/.github/jobs/android.yml
+++ b/.github/jobs/android.yml
@@ -18,7 +18,6 @@ jobs:
     - task: Npm@1
       inputs:
         command: 'install'
-        workingDir: 'Apps'
       displayName: 'Install Babylon.js NPM packages'
 
     - template: cmake.yml

--- a/.github/jobs/ios.yml
+++ b/.github/jobs/ios.yml
@@ -19,6 +19,7 @@ jobs:
     - task: Npm@1
       inputs:
         command: 'install'
+        workingDir: './'
       displayName: 'Install Babylon.js NPM packages'
 
     - template: cmake.yml

--- a/.github/jobs/ios.yml
+++ b/.github/jobs/ios.yml
@@ -19,7 +19,6 @@ jobs:
     - task: Npm@1
       inputs:
         command: 'install'
-        workingDir: 'Apps'
       displayName: 'Install Babylon.js NPM packages'
 
     - template: cmake.yml

--- a/.github/jobs/linux.yml
+++ b/.github/jobs/linux.yml
@@ -23,6 +23,7 @@ jobs:
     - task: Npm@1
       inputs:
         command: 'install'
+        workingDir: './'
       displayName: 'Install Babylon.js NPM packages'
 
     - template: cmake.yml

--- a/.github/jobs/linux.yml
+++ b/.github/jobs/linux.yml
@@ -23,7 +23,6 @@ jobs:
     - task: Npm@1
       inputs:
         command: 'install'
-        workingDir: 'Apps'
       displayName: 'Install Babylon.js NPM packages'
 
     - template: cmake.yml

--- a/.github/jobs/macos.yml
+++ b/.github/jobs/macos.yml
@@ -18,6 +18,7 @@ jobs:
     - task: Npm@1
       inputs:
         command: 'install'
+        workingDir: './'
       displayName: 'Install Babylon.js NPM packages'
 
     - template: cmake.yml

--- a/.github/jobs/macos.yml
+++ b/.github/jobs/macos.yml
@@ -18,7 +18,6 @@ jobs:
     - task: Npm@1
       inputs:
         command: 'install'
-        workingDir: 'Apps'
       displayName: 'Install Babylon.js NPM packages'
 
     - template: cmake.yml

--- a/.github/jobs/uwp.yml
+++ b/.github/jobs/uwp.yml
@@ -34,7 +34,6 @@ jobs:
     - task: Npm@1
       inputs:
         command: 'install'
-        workingDir: 'Apps'
       displayName: 'Install Babylon.js NPM packages'
 
     - script: |

--- a/.github/jobs/uwp.yml
+++ b/.github/jobs/uwp.yml
@@ -34,6 +34,7 @@ jobs:
     - task: Npm@1
       inputs:
         command: 'install'
+        workingDir: './'
       displayName: 'Install Babylon.js NPM packages'
 
     - script: |

--- a/.github/jobs/win32.yml
+++ b/.github/jobs/win32.yml
@@ -37,7 +37,6 @@ jobs:
       - task: Npm@1
         inputs:
           command: 'install'
-          workingDir: 'Apps'
         displayName: 'Install Babylon.js NPM packages'
 
       - script: |

--- a/.github/jobs/win32.yml
+++ b/.github/jobs/win32.yml
@@ -37,6 +37,7 @@ jobs:
       - task: Npm@1
         inputs:
           command: 'install'
+          workingDir: './'
         displayName: 'Install Babylon.js NPM packages'
 
       - script: |

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "BabylonNative",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "cmake-windows": "mkdir build-win32 & cd build-win32 & cmake -G \"Visual Studio 16 2019\" -A x64 -DBGFX_CONFIG_MEMORY_TRACKING=ON -DBGFX_CONFIG_DEBUG=ON ..",
+    "cmake-ios": "mkdir build-ios & cd build-ios & cmake .. -G Xcode -DCMAKE_TOOLCHAIN_FILE=../Dependencies/ios-cmake/ios.toolchain.cmake -DPLATFORM=OS64COMBINED -DENABLE_ARC=0 -DDEPLOYMENT_TARGET='12' -DENABLE_GLSLANG_BINARIES=OFF -DSPIRV_CROSS_CLI=OFF",
+    "cmake-macos": "mkdir build-macos & cd build-macos & cmake .. -G Xcode",
+    "cmake-uwp": "mkdir build-uwp & cd build-uwp & cmake .. -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0 -A x64",
+    "postinstall": "cd Apps & npm install"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "cmake-windows": "mkdir build-win32 & cd build-win32 & cmake -G \"Visual Studio 16 2019\" -A x64 -DBGFX_CONFIG_MEMORY_TRACKING=ON -DBGFX_CONFIG_DEBUG=ON ..",
-    "cmake-ios": "mkdir build-ios & cd build-ios & cmake .. -G Xcode -DCMAKE_TOOLCHAIN_FILE=../Dependencies/ios-cmake/ios.toolchain.cmake -DPLATFORM=OS64COMBINED -DENABLE_ARC=0 -DDEPLOYMENT_TARGET='12' -DENABLE_GLSLANG_BINARIES=OFF -DSPIRV_CROSS_CLI=OFF",
-    "cmake-macos": "mkdir build-macos & cd build-macos & cmake .. -G Xcode",
-    "cmake-uwp": "mkdir build-uwp & cd build-uwp & cmake .. -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0 -A x64",
-    "postinstall": "cd Apps & npm install"
+    "cmake-windows": "mkdir build-win32 && cd build-win32 && cmake -G \"Visual Studio 16 2019\" -A x64 -DBGFX_CONFIG_MEMORY_TRACKING=ON -DBGFX_CONFIG_DEBUG=ON ..",
+    "cmake-ios": "mkdir build-ios && cd build-ios && cmake .. -G Xcode -DCMAKE_TOOLCHAIN_FILE=../Dependencies/ios-cmake/ios.toolchain.cmake -DPLATFORM=OS64COMBINED -DENABLE_ARC=0 -DDEPLOYMENT_TARGET='12' -DENABLE_GLSLANG_BINARIES=OFF -DSPIRV_CROSS_CLI=OFF",
+    "cmake-macos": "mkdir build-macos && cd build-macos && cmake .. -G Xcode",
+    "cmake-uwp": "mkdir build-uwp && cd build-uwp && cmake .. -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0 -A x64",
+    "postinstall": "git submodule update --init --recursive && cd Apps && npm install"
   }
 }


### PR DESCRIPTION
Following discussion here : https://github.com/BabylonJS/BabylonNative/pull/927

I'm testing having a root package.json.
Build steps would be for ios:

1. git clone https://github.com/BabylonJS/BabylonNative.git
1. cd BabylonNative
1. npm install
1. npm run cmake-ios

Which, to me, looks much simpler.
For advanced use, user can cd to the build folder and re-run cmake with according flags. For 90-95% of times, when you want to test or develop with common parameters, this is super handy.

I suggest to replace build steps in readme.md for something less verbose and move cmake commands to a document in Documentation folder.

This PR is open to discussion/improvements/ideas.