### PR TITLE
Tear down XrInput before OpenXR context is reset

### DIFF
--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -362,6 +362,8 @@ namespace xr
 
         ~Impl()
         {
+            // Dispose the input manager and its XR resources. 
+            // This needs to happen before resetting the OpenXR context.
             InputManager.reset();
             // Reset OpenXR Context to release session handle and exit immersive mode
             XrRegistry::Reset();

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -318,13 +318,14 @@ namespace xr
             std::vector<FeaturePoint> FeaturePointCloud{};
         } ActionResources{};
 
-        const XrInput InputManager;
+        std::unique_ptr<XrInput> InputManager;
 
         float DepthNearZ{ DEFAULT_DEPTH_NEAR_Z };
         float DepthFarZ{ DEFAULT_DEPTH_FAR_Z };
 
         Impl(System::Impl& hmdImpl, void* graphicsContext)
             : HmdImpl{ hmdImpl }
+            , InputManager{ std::make_unique<XrInput>() }
         {
             assert(HmdImpl.IsInitialized());
             const auto& context = HmdImpl.Context;
@@ -361,6 +362,7 @@ namespace xr
 
         ~Impl()
         {
+            InputManager.reset();
             // Reset OpenXR Context to release session handle and exit immersive mode
             XrRegistry::Reset();
         }
@@ -529,7 +531,7 @@ namespace xr
                 handTrackingSystemProperties,
                 eyeTrackingSystemProperties
             };
-            InputManager.Initialize(inputInitOptions);
+            InputManager->Initialize(inputInitOptions);
 
             const XrViewConfigurationType primaryType = HmdImpl.PrimaryViewConfigurationType;
             auto& primaryRenderResource = RenderResources.ResourceMap[primaryType];
@@ -705,7 +707,7 @@ namespace xr
                     ProcessSessionState(exitRenderLoop, requestRestart);
                     break;
                 case XR_TYPE_EVENT_DATA_INTERACTION_PROFILE_CHANGED:
-                    InputManager.RefreshInputSources(
+                    InputManager->RefreshInputSources(
                         HmdImpl.Context.Instance(), 
                         HmdImpl.Context.Session(), 
                         ActionResources.ActiveInputSources);
@@ -1050,7 +1052,7 @@ namespace xr
                 InputSources,
                 EyeTrackerSpace
             };
-            sessionImpl.InputManager.UpdateFrame(inputUpdateArgs);
+            sessionImpl.InputManager->UpdateFrame(inputUpdateArgs);
         }
     }
 

--- a/Dependencies/xr/Source/OpenXR/XrInput.cpp
+++ b/Dependencies/xr/Source/OpenXR/XrInput.cpp
@@ -231,7 +231,6 @@ namespace xr
             HandData.SupportsArticulatedHandTracking = args.HandTrackingInteractionProps.supportsHandTracking && args.Extensions.HandTrackingSupported;
             InitializeHandResources(args.Session, args.Extensions);
 
-            // It's ok to do this because the context will outlive this module
             m_destroyHandTrackers = [this, extensions = args.Extensions]() {
                 if (HandData.HandTrackersInitialized)
                 {


### PR DESCRIPTION
There's an issue that shows up when tearing down the XR session with BabylonReactNative on windows where the input manager resources aren't disposed before the OpenXR context is reset.