### PR TITLE
Clear XR render target on OpenXR

### DIFF
--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -229,6 +229,7 @@ namespace xr
                     float DepthFarZ{};
 
                     bool IsFirstPersonObserver{ false };
+                    bool RequiresAppClear{ false };
                 };
 
                 struct InputSource

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -867,6 +867,7 @@ namespace xr
             view.DepthTextureSize.Depth = depthSwapchain.ArraySize;
             view.DepthNearZ = sessionImpl.DepthNearZ;
             view.DepthFarZ = sessionImpl.DepthFarZ;
+            view.RequiresAppClear = true;
 
             PopulateProjectionMatrix(cachedView, view);
         }

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -684,7 +684,7 @@ namespace Babylon
 
                     auto requiresAppClear = view.RequiresAppClear;
 
-                    arcana::make_task(m_sessionState->GraphicsImpl.AfterRenderScheduler(), arcana::cancellation::none(), [colorTexture, depthTexture, requiresAppClear, &viewConfig]() {
+                    arcana::make_task(m_sessionState->GraphicsImpl.AfterRenderScheduler(), arcana::cancellation::none(), [colorTexture, depthTexture, &viewConfig]() {
                         bgfx::overrideInternal(colorTexture, reinterpret_cast<uintptr_t>(viewConfig.ColorTexturePointer));
                         bgfx::overrideInternal(depthTexture, reinterpret_cast<uintptr_t>(viewConfig.DepthTexturePointer));
                     }).then(m_runtimeScheduler, m_sessionState->CancellationSource, [this, thisRef{shared_from_this()}, colorTexture, depthTexture, requiresAppClear, &viewConfig]() {

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -682,10 +682,12 @@ namespace Babylon
                     auto depthTexture = bgfx::createTexture2D(textureWidth, textureHeight, false, textureLayers, depthTextureFormat, BGFX_TEXTURE_RT);
                     m_sessionState->GraphicsImpl.AddTexture(depthTexture, textureWidth, textureHeight, false, textureLayers, depthTextureFormat);
 
-                    arcana::make_task(m_sessionState->GraphicsImpl.AfterRenderScheduler(), arcana::cancellation::none(), [colorTexture, depthTexture, &viewConfig]() {
+                    auto requiresAppClear = view.RequiresAppClear;
+
+                    arcana::make_task(m_sessionState->GraphicsImpl.AfterRenderScheduler(), arcana::cancellation::none(), [colorTexture, depthTexture, requiresAppClear, &viewConfig]() {
                         bgfx::overrideInternal(colorTexture, reinterpret_cast<uintptr_t>(viewConfig.ColorTexturePointer));
                         bgfx::overrideInternal(depthTexture, reinterpret_cast<uintptr_t>(viewConfig.DepthTexturePointer));
-                    }).then(m_runtimeScheduler, m_sessionState->CancellationSource, [this, thisRef{shared_from_this()}, colorTexture, depthTexture, &viewConfig]() {
+                    }).then(m_runtimeScheduler, m_sessionState->CancellationSource, [this, thisRef{shared_from_this()}, colorTexture, depthTexture, requiresAppClear, &viewConfig]() {
                         const auto eyeCount = std::max(static_cast<uint16_t>(1), static_cast<uint16_t>(viewConfig.ViewTextureSize.Depth));
                         // TODO (rgerd): Remove old framebuffers from resource table?
                         viewConfig.FrameBuffers.resize(eyeCount);
@@ -718,6 +720,12 @@ namespace Babylon
                             auto jsHeight{Napi::Value::From(m_env, viewConfig.ViewTextureSize.Height)};
                             auto jsFrameBuffer{Napi::Pointer<FrameBuffer>::Create(m_env, frameBufferPtr, Napi::NapiPointerDeleter(frameBufferPtr))};
                             viewConfig.JsTextures[frameBufferPtr] = Napi::Persistent(m_sessionState->CreateRenderTexture.Call({jsWidth, jsHeight, jsFrameBuffer}).As<Napi::Object>());
+                            // OpenXR doesn't pre-clear textures, and so we need to make sure the render target gets cleared before rendering the scene.
+                            // ARCore and ARKit effectively pre-clear by pre-compositing the camera feed.
+                            if (requiresAppClear)
+                            {
+                                viewConfig.JsTextures[frameBufferPtr].Set("skipInitialClear", false);
+                            }
                         }
                         viewConfig.Initialized = true;
                     }).then(arcana::inline_scheduler, m_sessionState->CancellationSource, [env{m_env}](const arcana::expected<void, std::exception_ptr>& result) {


### PR DESCRIPTION
Rendering on OpenXR has been broken since [this change](https://github.com/BabylonJS/Babylon.js/pull/11042/files#diff-2a17806b7914d19ec3d0ae6759b133ae7d34f4b5f3a54e990a5f0eb697a17501R453) because OpenXR doesn't pre-clear textures handed to the application, whereas our ARCore and ARKit XR implementations do pre-clear the textures handed to the application by blitting the camera feed texture prior to app rendering.

fixes #933 