### PR TITLE
DeviceInputSystem: Modify NativeInput to allow for negative integer values

### DIFF
--- a/Apps/Playground/macOS/ViewController.mm
+++ b/Apps/Playground/macOS/ViewController.mm
@@ -159,9 +159,7 @@ std::unique_ptr<Babylon::Polyfills::Canvas> nativeCanvas{};
 }
 
 - (CGFloat)getScreenHeight {
-    NSScreen *mainScreen = [NSScreen mainScreen];
-    CGFloat screenScale = mainScreen.backingScaleFactor;
-    return [self view].frame.size.height * screenScale;
+    return [self view].frame.size.height;
 }
 
 - (void)mouseDown:(NSEvent *) theEvent {

--- a/Plugins/NativeInput/Include/Babylon/Plugins/NativeInput.h
+++ b/Plugins/NativeInput/Include/Babylon/Plugins/NativeInput.h
@@ -12,12 +12,12 @@ namespace Babylon::Plugins
         static NativeInput& CreateForJavaScript(Napi::Env);
         static NativeInput& GetFromJavaScript(Napi::Env);
 
-        void MouseDown(uint32_t buttonIndex, uint32_t x, uint32_t y);
-        void MouseUp(uint32_t buttonIndex, uint32_t x, uint32_t y);
-        void MouseMove(uint32_t x, uint32_t y);
-        void TouchDown(uint32_t pointerId, uint32_t x, uint32_t y);
-        void TouchUp(uint32_t pointerId, uint32_t x, uint32_t y);
-        void TouchMove(uint32_t pointerId, uint32_t x, uint32_t y);
+        void MouseDown(uint32_t buttonIndex, int32_t x, int32_t y);
+        void MouseUp(uint32_t buttonIndex, int32_t x, int32_t y);
+        void MouseMove(int32_t x, int32_t y);
+        void TouchDown(uint32_t pointerId, int32_t x, int32_t y);
+        void TouchUp(uint32_t pointerId, int32_t x, int32_t y);
+        void TouchMove(uint32_t pointerId, int32_t x, int32_t y);
 
         static constexpr uint32_t LEFT_MOUSE_BUTTON_ID{ 0 };
         static constexpr uint32_t MIDDLE_MOUSE_BUTTON_ID{ 1 };

--- a/Plugins/NativeInput/Source/Shared/NativeInput.cpp
+++ b/Plugins/NativeInput/Source/Shared/NativeInput.cpp
@@ -42,32 +42,32 @@ namespace Babylon::Plugins
         return *env.Global().Get(JS_NATIVE_INPUT_NAME).As<Napi::External<NativeInput>>().Data();
     }
 
-    void NativeInput::MouseDown(uint32_t buttonIndex, uint32_t x, uint32_t y)
+    void NativeInput::MouseDown(uint32_t buttonIndex, int32_t x, int32_t y)
     {
         m_impl->MouseDown(buttonIndex, x, y);
     }
 
-    void NativeInput::MouseUp(uint32_t buttonIndex, uint32_t x, uint32_t y)
+    void NativeInput::MouseUp(uint32_t buttonIndex, int32_t x, int32_t y)
     {
         m_impl->MouseUp(buttonIndex, x, y);
     }
 
-    void NativeInput::MouseMove(uint32_t x, uint32_t y)
+    void NativeInput::MouseMove(int32_t x, int32_t y)
     {
         m_impl->MouseMove(x, y);
     }
 
-    void NativeInput::TouchDown(uint32_t pointerId, uint32_t x, uint32_t y)
+    void NativeInput::TouchDown(uint32_t pointerId, int32_t x, int32_t y)
     {
         m_impl->TouchDown(pointerId, x, y);
     }
 
-    void NativeInput::TouchUp(uint32_t pointerId, uint32_t x, uint32_t y)
+    void NativeInput::TouchUp(uint32_t pointerId, int32_t x, int32_t y)
     {
         m_impl->TouchUp(pointerId, x, y);
     }
 
-    void NativeInput::TouchMove(uint32_t pointerId, uint32_t x, uint32_t y)
+    void NativeInput::TouchMove(uint32_t pointerId, int32_t x, int32_t y)
     {
         m_impl->TouchMove(pointerId, x, y);
     }
@@ -85,37 +85,37 @@ namespace Babylon::Plugins
         }
     }
 
-    void NativeInput::Impl::MouseDown(uint32_t buttonIndex, uint32_t x, uint32_t y)
+    void NativeInput::Impl::MouseDown(uint32_t buttonIndex, int32_t x, int32_t y)
     {
         PointerDown(MOUSE_POINTER_ID, buttonIndex, x, y, DeviceType::Mouse);
     }
 
-    void NativeInput::Impl::MouseUp(uint32_t buttonIndex, uint32_t x, uint32_t y)
+    void NativeInput::Impl::MouseUp(uint32_t buttonIndex, int32_t x, int32_t y)
     {
         PointerUp(MOUSE_POINTER_ID, buttonIndex, x, y, DeviceType::Mouse);
     }
 
-    void NativeInput::Impl::MouseMove(uint32_t x, uint32_t y)
+    void NativeInput::Impl::MouseMove(int32_t x, int32_t y)
     {
         PointerMove(MOUSE_POINTER_ID, x, y, DeviceType::Mouse);
     }
 
-    void NativeInput::Impl::TouchDown(uint32_t pointerId, uint32_t x, uint32_t y)
+    void NativeInput::Impl::TouchDown(uint32_t pointerId, int32_t x, int32_t y)
     {
         PointerDown(pointerId, TOUCH_BUTTON_ID, x, y, DeviceType::Touch);
     }
 
-    void NativeInput::Impl::TouchUp(uint32_t pointerId, uint32_t x, uint32_t y)
+    void NativeInput::Impl::TouchUp(uint32_t pointerId, int32_t x, int32_t y)
     {
         PointerUp(pointerId, TOUCH_BUTTON_ID, x, y, DeviceType::Touch);
     }
 
-    void NativeInput::Impl::TouchMove(uint32_t pointerId, uint32_t x, uint32_t y)
+    void NativeInput::Impl::TouchMove(uint32_t pointerId, int32_t x, int32_t y)
     {
         PointerMove(pointerId, x, y, DeviceType::Touch);
     }
 
-    void NativeInput::Impl::PointerDown(uint32_t pointerId, uint32_t buttonIndex, uint32_t x, uint32_t y, DeviceType deviceType)
+    void NativeInput::Impl::PointerDown(uint32_t pointerId, uint32_t buttonIndex, int32_t x, int32_t y, DeviceType deviceType)
     {
         m_runtimeScheduler([pointerId, buttonIndex, x, y, deviceType, this]() {
             const uint32_t inputIndex{ GetPointerButtonInputIndex(buttonIndex) };
@@ -130,7 +130,7 @@ namespace Babylon::Plugins
         });
     }
 
-    void NativeInput::Impl::PointerUp(uint32_t pointerId, uint32_t buttonIndex, uint32_t x, uint32_t y, DeviceType deviceType)
+    void NativeInput::Impl::PointerUp(uint32_t pointerId, uint32_t buttonIndex, int32_t x, int32_t y, DeviceType deviceType)
     {
         m_runtimeScheduler([pointerId, buttonIndex, x, y, deviceType, this]() {
             const uint32_t inputIndex{ GetPointerButtonInputIndex(buttonIndex) };
@@ -163,7 +163,7 @@ namespace Babylon::Plugins
         });
     }
 
-    void NativeInput::Impl::PointerMove(uint32_t pointerId, uint32_t x, uint32_t y, DeviceType deviceType)
+    void NativeInput::Impl::PointerMove(uint32_t pointerId, int32_t x, int32_t y, DeviceType deviceType)
     {
         m_runtimeScheduler([pointerId, x, y, deviceType, this]() {
             std::vector<int32_t>& deviceInputs{ GetOrCreateInputMap(deviceType, pointerId, { POINTER_X_INPUT_INDEX, POINTER_Y_INPUT_INDEX }) };

--- a/Plugins/NativeInput/Source/Shared/NativeInput.h
+++ b/Plugins/NativeInput/Source/Shared/NativeInput.h
@@ -34,12 +34,12 @@ namespace Babylon::Plugins
 
         bool HasMouse();
 
-        void MouseDown(uint32_t buttonIndex, uint32_t x, uint32_t y);
-        void MouseUp(uint32_t buttonIndex, uint32_t x, uint32_t y);
-        void MouseMove(uint32_t x, uint32_t y);
-        void TouchDown(uint32_t pointerId, uint32_t x, uint32_t y);
-        void TouchUp(uint32_t pointerId, uint32_t x, uint32_t y);
-        void TouchMove(uint32_t pointerId, uint32_t x, uint32_t y);
+        void MouseDown(uint32_t buttonIndex, int32_t x, int32_t y);
+        void MouseUp(uint32_t buttonIndex, int32_t x, int32_t y);
+        void MouseMove(int32_t x, int32_t y);
+        void TouchDown(uint32_t pointerId, int32_t x, int32_t y);
+        void TouchUp(uint32_t pointerId, int32_t x, int32_t y);
+        void TouchMove(uint32_t pointerId, int32_t x, int32_t y);
 
         DeviceStatusChangedCallbackTicket AddDeviceConnectedCallback(DeviceStatusChangedCallback&& callback);
         DeviceStatusChangedCallbackTicket AddDeviceDisconnectedCallback(DeviceStatusChangedCallback&& callback);
@@ -58,9 +58,9 @@ namespace Babylon::Plugins
             }
         };
 
-        void PointerDown(uint32_t pointerId, uint32_t buttonIndex, uint32_t x, uint32_t y, DeviceType deviceType);
-        void PointerUp(uint32_t pointerId, uint32_t buttonIndex, uint32_t x, uint32_t y, DeviceType deviceType);
-        void PointerMove(uint32_t pointerId, uint32_t x, uint32_t y, DeviceType deviceType);
+        void PointerDown(uint32_t pointerId, uint32_t buttonIndex, int32_t x, int32_t y, DeviceType deviceType);
+        void PointerUp(uint32_t pointerId, uint32_t buttonIndex, int32_t x, int32_t y, DeviceType deviceType);
+        void PointerMove(uint32_t pointerId, int32_t x, int32_t y, DeviceType deviceType);
         std::vector<int32_t>& GetOrCreateInputMap(DeviceType deviceType, int32_t deviceSlot, const std::vector<uint32_t>& inputIndices);
         void RemoveInputMap(DeviceType deviceType, int32_t deviceSlot);
         void SetInputState(DeviceType deviceType, int32_t deviceSlot, uint32_t inputIndex, int32_t inputState, std::vector<int32_t>& deviceInputs, bool raiseEvents);


### PR DESCRIPTION
This PR contains some changes to the NativeInput code to allow for negative values to be transmitted to the DeviceInputSystem.  Additionally, a function was tweaked for the MacOS input code to more accurately provide pointer coordinates.