### PR TITLE
Android Pixel Density

### DIFF
--- a/Apps/Playground/Android/app/src/main/java/BabylonNative/BabylonView.java
+++ b/Apps/Playground/Android/app/src/main/java/BabylonNative/BabylonView.java
@@ -18,7 +18,7 @@ public class BabylonView extends FrameLayout implements SurfaceHolder.Callback2,
     private Activity mCurrentActivity;
     private final SurfaceView primarySurfaceView;
     private final SurfaceView xrSurfaceView;
-
+    private final float pixelDensityScale = getResources().getDisplayMetrics().density;
     public BabylonView(Context context, ViewDelegate viewDelegate) {
         this(context, viewDelegate, (Activity)viewDelegate);
     }
@@ -117,7 +117,7 @@ public class BabylonView extends FrameLayout implements SurfaceHolder.Callback2,
      * not normally called or subclassed by clients of BabylonView.
      */
     public void surfaceChanged(SurfaceHolder holder, int format, int w, int h) {
-        BabylonNative.Wrapper.surfaceChanged(w, h, holder.getSurface());
+        BabylonNative.Wrapper.surfaceChanged((int)(w / this.pixelDensityScale), (int)(h / this.pixelDensityScale), holder.getSurface());
     }
 
     public interface ViewDelegate {

--- a/Apps/Playground/Android/app/src/main/java/BabylonNative/BabylonView.java
+++ b/Apps/Playground/Android/app/src/main/java/BabylonNative/BabylonView.java
@@ -126,8 +126,8 @@ public class BabylonView extends FrameLayout implements SurfaceHolder.Callback2,
 
     @Override
     public boolean onTouch(View v, MotionEvent event) {
-        float mX = event.getX();
-        float mY = event.getY();
+        float mX = event.getX() / this.pixelDensityScale;
+        float mY = event.getY() / this.pixelDensityScale;
         switch (event.getAction()) {
             case MotionEvent.ACTION_DOWN:
                 BabylonNative.Wrapper.setTouchInfo(mX, mY, true, 1);


### PR DESCRIPTION
In browsers, the canvas size is divided by the pixel density.
On my iPhone 11 with a pixel density of 2, the canvas size is 414x640 instead of native resolution.
On my Android, the density is 3. The surface area is 1/9 of native res.

In Native:
On iOS, the system (via `contentScaleFactor`) handles everything. 
On Android, the view size is returned in pixels, without taking care of pixel density. This PR adds its support.
The surfaceView bounds are not changed but the OpenGL area is resized with density factor. At presentation time, 
https://github.com/bkaradzic/bgfx/blob/3d4bd88c0635b614b453aac1003cc56a11d1ccf0/src/glcontext_egl.cpp#L375
Is taking care of setting the native window size so it gets rescaled by the compositor into the surfaceView.