### PR TITLE
XRRay object Check

### DIFF
--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -929,12 +929,11 @@ namespace Babylon
 
         class XRRigidTransform : public Napi::ObjectWrap<XRRigidTransform>
         {
+            static constexpr auto JS_CLASS_NAME = "XRRigidTransform";
             // static constexpr size_t VECTOR_SIZE = 4;
             static constexpr size_t MATRIX_SIZE = 16;
 
         public:
-            static constexpr auto JS_CLASS_NAME = "XRRigidTransform";
-
             static void Initialize(Napi::Env env)
             {
                 Napi::HandleScope scope{env};
@@ -1339,9 +1338,8 @@ namespace Babylon
                 {
                     auto argumentObject{info[0].As<Napi::Object>()};
 
-                    const auto XRRigidTransformFunction = Env().Global().Get(XRRigidTransform::JS_CLASS_NAME).As<Napi::Function>();
-
-                    if (argumentObject.InstanceOf(XRRigidTransformFunction))
+                    // check properties of XRRigidTransform are present
+                    if (argumentObject.Has("position") && argumentObject.Has("orientation") && argumentObject.Has("matrix"))
                     {
                         XRRigidTransform* transform{XRRigidTransform::Unwrap(argumentObject)};
                         // The value passed in to the constructor is an XRRigidTransform

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -929,11 +929,12 @@ namespace Babylon
 
         class XRRigidTransform : public Napi::ObjectWrap<XRRigidTransform>
         {
-            static constexpr auto JS_CLASS_NAME = "XRRigidTransform";
             // static constexpr size_t VECTOR_SIZE = 4;
             static constexpr size_t MATRIX_SIZE = 16;
 
         public:
+            static constexpr auto JS_CLASS_NAME = "XRRigidTransform";
+
             static void Initialize(Napi::Env env)
             {
                 Napi::HandleScope scope{env};
@@ -1338,9 +1339,11 @@ namespace Babylon
                 {
                     auto argumentObject{info[0].As<Napi::Object>()};
 
-                    XRRigidTransform* transform{XRRigidTransform::Unwrap(argumentObject)};
-                    if (transform != nullptr)
+                    const auto XRRigidTransformFunction = Env().Global().Get(XRRigidTransform::JS_CLASS_NAME).As<Napi::Function>();
+
+                    if (argumentObject.InstanceOf(XRRigidTransformFunction))
                     {
+                        XRRigidTransform* transform{XRRigidTransform::Unwrap(argumentObject)};
                         // The value passed in to the constructor is an XRRigidTransform
                         xr::Pose pose{transform->GetNativePose()};
                         tempVals.Origin = pose.Position;


### PR DESCRIPTION
fixes #997 

It was broken for every platforms. It didn't check the napi object could be unwrapped (exception) .