### PR TITLE
CI running on Windows 2019 image

### DIFF
--- a/.github/workflows/master_update.yml
+++ b/.github/workflows/master_update.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   dispatch:
     name: Dispatch ${{ github.sha }}
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         repo: ['BabylonJS/BabylonReactNative']

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Checkout

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,26 +49,26 @@ jobs:
   - template: .github/jobs/win32.yml
     parameters:
       name: Win32_x86_D3D11
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2019'
       platform: win32
 
   - template: .github/jobs/win32.yml
     parameters:
       name: Win32_x64_D3D11
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2019'
       platform: x64
 
   - template: .github/jobs/win32.yml
     parameters:
       name: Win32_x64_JSI_D3D11
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2019'
       platform: x64
       napiType: jsi
 
   - template: .github/jobs/win32.yml
     parameters:
       name: Win32_x64_D3D12
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2019'
       platform: x64
       graphics_api: D3D12
 
@@ -76,25 +76,25 @@ jobs:
   - template: .github/jobs/uwp.yml
     parameters:
       name: UWP_x86
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2019'
       platform: win32
 
   - template: .github/jobs/uwp.yml
     parameters:
       name: UWP_x64
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2019'
       platform: x64
 
   - template: .github/jobs/uwp.yml
     parameters:
       name: UWP_arm64
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2019'
       platform: arm64
 
   - template: .github/jobs/uwp.yml
     parameters:
       name: UWP_arm64_JSI
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2019'
       platform: arm64
       napiType: jsi
 


### PR DESCRIPTION
Nightly was broken because `windows-latest` now defaults to this image : https://github.com/actions/virtual-environments/blob/win22/20220207.1/images/win/Windows2022-Readme.md
Which uses cmake 3.22.2 and VisualStudio 2022
Forcing to use 2019 until we decide to move to 2022 image and VS