### PR TITLE
Fix Metal Validation with Stencil in Canvas

### DIFF
--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -108,9 +108,18 @@ namespace Babylon::Polyfills::Internal
     {
         if (m_dirty)
         {
-            auto handle = bgfx::createFrameBuffer(static_cast<uint16_t>(m_width), static_cast<uint16_t>(m_height), bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT);
+            std::array<bgfx::TextureHandle, 2> textures{
+                bgfx::createTexture2D(static_cast<uint16_t>(m_width), static_cast<uint16_t>(m_height), false, 1, bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT),
+                bgfx::createTexture2D(static_cast<uint16_t>(m_width), static_cast<uint16_t>(m_height), false, 1, bgfx::TextureFormat::D24S8, BGFX_TEXTURE_RT)};
+
+            std::array<bgfx::Attachment, textures.size()> attachments{};
+            for (size_t idx = 0; idx < attachments.size(); ++idx)
+            {
+                attachments[idx].init(textures[idx]);
+            }
+            auto handle = bgfx::createFrameBuffer(static_cast<uint8_t>(attachments.size()), attachments.data(), true);
             assert(handle.idx != bgfx::kInvalidHandle);
-            m_frameBuffer = std::make_unique<FrameBuffer>(m_graphicsImpl, handle, static_cast<uint16_t>(m_width), static_cast<uint16_t>(m_height), false, false, false);
+            m_frameBuffer = std::make_unique<FrameBuffer>(m_graphicsImpl, handle, static_cast<uint16_t>(m_width), static_cast<uint16_t>(m_height), false, true, true);
             m_dirty = false;
 
             if (m_textureData)

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -363,7 +363,7 @@ namespace Babylon::Polyfills::Internal
                 frameBuffer.Bind(*encoder);
                 if (needClear)
                 {
-                    frameBuffer.Clear(*encoder, BGFX_CLEAR_COLOR, 0, 1.f, 0);
+                    frameBuffer.Clear(*encoder, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH | BGFX_CLEAR_STENCIL, 0, 1.f, 0);
                 }
                 frameBuffer.SetViewPort(*encoder, 0.f, 0.f, 1.f, 1.f);
                 const auto width = m_canvas->GetWidth();


### PR DESCRIPTION
fixes #996 
For some 2D shapes, stencil is needed. As it was used without a rendertarget supporting it, it brought a Metal validation error.
Adding a Depth/Stencil for Canvas.