### PR TITLE
Dummy implementation for getImageTrackingResults

### DIFF
--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -2092,6 +2092,7 @@ namespace Babylon
                         InstanceMethod("getJointPose", &XRFrame::GetJointPose),
                         InstanceMethod("fillPoses", &XRFrame::FillPoses),
                         InstanceMethod("fillJointRadii", &XRFrame::FillJointRadii),
+                        InstanceMethod("getImageTrackingResults", &XRFrame::GetImageTrackingResults),
                         InstanceAccessor("trackedAnchors", &XRFrame::GetTrackedAnchors, nullptr),
                         InstanceAccessor("worldInformation", &XRFrame::GetWorldInformation, nullptr),
                         InstanceAccessor("featurePointCloud", &XRFrame::GetFeaturePointCloud, nullptr),
@@ -2312,6 +2313,11 @@ namespace Babylon
                 }
 
                 return Napi::Value::From(info.Env(), true);
+            }
+
+            Napi::Value GetImageTrackingResults (const Napi::CallbackInfo& info)
+            {
+                return info.Env().Undefined();
             }
 
             Napi::Value GetHitTestResults(const Napi::CallbackInfo& info)

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -2315,6 +2315,8 @@ namespace Babylon
                 return Napi::Value::From(info.Env(), true);
             }
 
+            // NativeXRFrame on the JS side expects getImageTrackingResults to be defined at XR initialization time.
+            // This dummy implementation is a placeholder until WebXR Image Tracking support is completed: https://github.com/BabylonJS/BabylonNative/issues/619
             Napi::Value GetImageTrackingResults (const Napi::CallbackInfo& info)
             {
                 return info.Env().Undefined();


### PR DESCRIPTION
My BabylonJS PR here: https://github.com/BabylonJS/Babylon.js/pull/12097/files

Changed the contract for nativeXRFrame to require an implementation for getImageTrackingResults.  I thought this would not block Babylon.JS upgrade as we should only actually call getImageTrackingResults during image tracking, which is currently not supported, but the line in NativeXRFrame will run during XR startup. 

This PR just defines a dummy implementation for getImageTrackingResults to unblock XR startup, which should be effectively dead code at runtime since XRImageTrackingResult is not defined, so we should never allow initialization of WebXR Image Tracking