### PR TITLE
Fix crash on hermes when calling Napi::Array::Set beyond length of array

### DIFF
--- a/Dependencies/napi/napi-jsi/include/napi/napi-inl.h
+++ b/Dependencies/napi/napi-jsi/include/napi/napi-inl.h
@@ -692,7 +692,12 @@ inline Value Object::Get(uint32_t index) const {
 template <typename ValueType>
 inline void Object::Set(uint32_t index, const ValueType& value) {
   // TODO: does this need to work for non-array objects?
-  _object->getArray(_env->rt).setValueAtIndex(_env->rt, static_cast<size_t>(index), static_cast<jsi::Value&&>(Value::From(_env, value)));
+  jsi::Array arrObj = _object->getArray(_env->rt);
+  if (arrObj.length(_env->rt) <= index) {
+      _object->setProperty(_env->rt, "length", static_cast<int>(index + 1));
+  }
+
+  arrObj.setValueAtIndex(_env->rt, static_cast<size_t>(index), static_cast<jsi::Value&&>(Value::From(_env, value)));
 }
 
 inline bool Object::Delete(uint32_t index) {


### PR DESCRIPTION
Native Hermes APIs have differing behavior from from JSC and V8 where attempting to set an index value >= the length of the array will throw an unhandled exception.  This PR changes the napi-jsi implementation to account for this by manually extending the length of the array before calling setValueAtIndex.