### PR TITLE
Rename DeviceType to DeviceT and TextureType to TextureT

### DIFF
--- a/Core/Graphics/Include/RendererType/D3D11/Babylon/Graphics/RendererType.h
+++ b/Core/Graphics/Include/RendererType/D3D11/Babylon/Graphics/RendererType.h
@@ -4,12 +4,12 @@
 
 namespace Babylon::Graphics
 {
-    using DeviceType = ID3D11Device*;
-    using TextureType = ID3D11Texture2D*;
+    using DeviceT = ID3D11Device*;
+    using TextureT = ID3D11Texture2D*;
 
     struct DeviceConfiguration
     {
-        DeviceType Device;
+        DeviceT Device;
         float DevicePixelRatio{1.f};
     };
 }

--- a/Core/Graphics/Include/RendererType/D3D12/Babylon/Graphics/RendererType.h
+++ b/Core/Graphics/Include/RendererType/D3D12/Babylon/Graphics/RendererType.h
@@ -4,13 +4,12 @@
 
 namespace Babylon::Graphics
 {
-    using DeviceType = ID3D12Device*;
-
-    using TextureType = ID3D12Resource*;
+    using DeviceT = ID3D12Device*;
+    using TextureT = ID3D12Resource*;
 
     struct DeviceConfiguration
     {
-        DeviceType Device;
+        DeviceT Device;
         float DevicePixelRatio{1.f};
     };
 }

--- a/Core/Graphics/Include/RendererType/Metal/Babylon/Graphics/RendererType.h
+++ b/Core/Graphics/Include/RendererType/Metal/Babylon/Graphics/RendererType.h
@@ -4,12 +4,12 @@
 
 namespace Babylon::Graphics
 {
-    using DeviceType = id<MTLDevice>;
-    using TextureType = id<MTLTexture>;
+    using DeviceT = id<MTLDevice>;
+    using TextureT = id<MTLTexture>;
 
     struct DeviceConfiguration
     {
-        DeviceType Device;
+        DeviceT Device;
         float DevicePixelRatio{1.f};
     };
 }

--- a/Core/Graphics/Include/RendererType/OpenGL/Babylon/Graphics/RendererType.h
+++ b/Core/Graphics/Include/RendererType/OpenGL/Babylon/Graphics/RendererType.h
@@ -4,12 +4,12 @@
 
 namespace Babylon::Graphics
 {
-    using DeviceType = EGLContext;
-    using TextureType = unsigned int;
+    using DeviceT = EGLContext;
+    using TextureT = unsigned int;
 
     struct DeviceConfiguration
     {
-        DeviceType Device;
+        DeviceT Device;
         float DevicePixelRatio{1.f};
     };
 }

--- a/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
+++ b/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
@@ -11,7 +11,7 @@ namespace Babylon::Graphics
 {
     struct PlatformInfo
     {
-        DeviceType Device;
+        DeviceT Device;
     };
 
     class Device;

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -417,6 +417,6 @@ namespace Babylon::Graphics
 
     PlatformInfo DeviceImpl::GetPlatformInfo() const
     {
-        return {static_cast<DeviceType>(bgfx::getInternalData()->context)};
+        return {static_cast<DeviceT>(bgfx::getInternalData()->context)};
     }
 }

--- a/Plugins/ExternalTexture/Include/Babylon/Plugins/ExternalTexture.h
+++ b/Plugins/ExternalTexture/Include/Babylon/Plugins/ExternalTexture.h
@@ -11,7 +11,7 @@ namespace Babylon::Plugins
     class ExternalTexture
     {
     public:
-        ExternalTexture(Babylon::Graphics::TextureType nativeTexture);
+        ExternalTexture(Babylon::Graphics::TextureT nativeTexture);
         ~ExternalTexture();
 
         Napi::Promise AddToContext(Napi::Env&) const;
@@ -28,6 +28,6 @@ namespace Babylon::Plugins
         uint32_t m_format{};
         uint64_t m_flags{};
 
-        void ReadPropertiesFromNativeTexture(Babylon::Graphics::TextureType nativeTexture);
+        void ReadPropertiesFromNativeTexture(Babylon::Graphics::TextureT nativeTexture);
     };
 }

--- a/Plugins/ExternalTexture/Source/ExternalTexture.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture.cpp
@@ -8,7 +8,7 @@
 
 namespace Babylon::Plugins
 {
-    ExternalTexture::ExternalTexture(Babylon::Graphics::TextureType nativeTexture)
+    ExternalTexture::ExternalTexture(Babylon::Graphics::TextureT nativeTexture)
         : m_nativeTexture{(uintptr_t)(nativeTexture)}
     {
         ReadPropertiesFromNativeTexture(nativeTexture);

--- a/Plugins/ExternalTexture/Source/ExternalTexture_D3D11.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_D3D11.cpp
@@ -187,7 +187,7 @@ namespace Babylon::Plugins
         }
     }
 
-    void ExternalTexture::ReadPropertiesFromNativeTexture(Babylon::Graphics::TextureType nativeTexture) 
+    void ExternalTexture::ReadPropertiesFromNativeTexture(Babylon::Graphics::TextureT nativeTexture) 
     {
         D3D11_TEXTURE2D_DESC desc;
         nativeTexture->GetDesc(&desc);

--- a/Plugins/ExternalTexture/Source/ExternalTexture_D3D12.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_D3D12.cpp
@@ -187,7 +187,7 @@ namespace Babylon::Plugins
         }
     }
 
-    void ExternalTexture::ReadPropertiesFromNativeTexture(Babylon::Graphics::TextureType nativeTexture) 
+    void ExternalTexture::ReadPropertiesFromNativeTexture(Babylon::Graphics::TextureT nativeTexture) 
     {
         D3D12_RESOURCE_DESC  desc =  nativeTexture->GetDesc();
         uint64_t flags = 0Ui64;

--- a/Plugins/ExternalTexture/Source/ExternalTexture_Metal.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Metal.cpp
@@ -5,9 +5,9 @@
 
 namespace Babylon::Plugins
 {
-    void ExternalTexture::ReadPropertiesFromNativeTexture(Babylon::Graphics::TextureType) 
+    void ExternalTexture::ReadPropertiesFromNativeTexture(Babylon::Graphics::TextureT) 
     {
-        //TODO: Add support for Metal external textures.
-        throw std::runtime_error{"External textures is not currenlty supported for Metal."};
+        // TODO: Add support for Metal external textures.
+        throw std::runtime_error{"External textures is not currently supported for Metal."};
     }
 }

--- a/Plugins/ExternalTexture/Source/ExternalTexture_OpenGL.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_OpenGL.cpp
@@ -5,9 +5,9 @@
 
 namespace Babylon::Plugins
 {
-    void ExternalTexture::ReadPropertiesFromNativeTexture(Babylon::Graphics::TextureType) 
+    void ExternalTexture::ReadPropertiesFromNativeTexture(Babylon::Graphics::TextureT) 
     {
-        //TODO: Add support for OpenGL external textures.
-        throw std::runtime_error{"External textures is not currenlty supported for OpenGL."};
+        // TODO: Add support for OpenGL external textures.
+        throw std::runtime_error{"External textures is not currently supported for OpenGL."};
     }
 }


### PR DESCRIPTION
Renaming `DeviceType` to `DeviceT` and `TextureType` to `TextureT` to avoid confusion with enums.