### PR TITLE
Pattern change to work around memory leak

### DIFF
--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -235,6 +235,8 @@ namespace Babylon::Polyfills
         Internal::NativeCanvas::CreateInstance(env);
         Internal::NativeCanvasImage::CreateInstance(env);
 
+        Internal::Context::Initialize(env);
+
         return {impl};
     }
 

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -25,9 +25,9 @@ namespace Babylon::Polyfills::Internal
 {
     static constexpr auto JS_CONSTRUCTOR_NAME = "Context";
 
-    Napi::Value Context::CreateInstance(Napi::Env env, NativeCanvas* canvas)
+    void Context::Initialize(Napi::Env env)
     {
-        Napi::HandleScope scope{ env };
+        Napi::HandleScope scope{env};
 
         Napi::Function func = DefineClass(
             env,
@@ -74,6 +74,14 @@ namespace Babylon::Polyfills::Internal
                 InstanceAccessor("lineWidth", &Context::GetLineWidth, &Context::SetLineWidth),
                 InstanceAccessor("canvas", &Context::GetCanvas, nullptr)
             });
+        JsRuntime::NativeObject::GetFromJavaScript(env).Set(JS_CONSTRUCTOR_NAME, func);
+    }
+
+    Napi::Value Context::CreateInstance(Napi::Env env, NativeCanvas* canvas)
+    {
+        Napi::HandleScope scope{ env };
+
+        auto func = JsRuntime::NativeObject::GetFromJavaScript(env).Get(JS_CONSTRUCTOR_NAME).As<Napi::Function>();
         return func.New({ Napi::External<NativeCanvas>::New(env, canvas)});
     }
 

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -12,6 +12,7 @@ namespace Babylon::Polyfills::Internal
     class Context final : public Napi::ObjectWrap<Context>, Polyfills::Canvas::Impl::MonitoredResource
     {
     public:
+        static void Initialize(Napi::Env);
         static Napi::Value CreateInstance(Napi::Env env, NativeCanvas* canvas);
 
         explicit Context(const Napi::CallbackInfo& info);


### PR DESCRIPTION
Changed class definition pattern for native context to avoid apparent leak in `Napi::DefineClass` on certain JavaScript engines. Pertains to https://github.com/BabylonJS/BabylonReactNative/issues/394.