### PR TITLE
Removed & operator from local vars in UWP

### DIFF
--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -270,8 +270,8 @@ void App::OnPointerPressed(CoreWindow^, PointerEventArgs^ args)
         const auto& deviceType = args->CurrentPoint->PointerDevice->PointerDeviceType;
         const auto& deviceSlot = args->CurrentPoint->PointerId;
         const auto& updateKind = args->CurrentPoint->Properties->PointerUpdateKind;
-        const auto& x = static_cast<int>(position.X);
-        const auto& y = static_cast<int>(position.Y);
+        const auto x = static_cast<int>(position.X);
+        const auto y = static_cast<int>(position.Y);
 
         if (deviceType == Windows::Devices::Input::PointerDeviceType::Mouse)
         {
@@ -292,8 +292,8 @@ void App::OnPointerReleased(CoreWindow^, PointerEventArgs^ args)
         const auto& deviceType = args->CurrentPoint->PointerDevice->PointerDeviceType;
         const auto& deviceSlot = args->CurrentPoint->PointerId;
         const auto& updateKind = args->CurrentPoint->Properties->PointerUpdateKind;
-        const auto& x = static_cast<int>(position.X);
-        const auto& y = static_cast<int>(position.Y);
+        const auto x = static_cast<int>(position.X);
+        const auto y = static_cast<int>(position.Y);
 
         if (deviceType == Windows::Devices::Input::PointerDeviceType::Mouse)
         {

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -240,9 +240,9 @@ void App::OnPointerMoved(CoreWindow^, PointerEventArgs^ args)
     if (m_nativeInput != nullptr)
     {
         const auto& position = args->CurrentPoint->RawPosition;
-        const auto& deviceType = args->CurrentPoint->PointerDevice->PointerDeviceType;
-        const auto& deviceSlot = args->CurrentPoint->PointerId;
-        const auto& updateKind = args->CurrentPoint->Properties->PointerUpdateKind;
+        const auto deviceType = args->CurrentPoint->PointerDevice->PointerDeviceType;
+        const auto deviceSlot = args->CurrentPoint->PointerId;
+        const auto updateKind = args->CurrentPoint->Properties->PointerUpdateKind;
         const auto x = static_cast<int>(position.X);
         const auto y = static_cast<int>(position.Y);
 
@@ -267,9 +267,9 @@ void App::OnPointerPressed(CoreWindow^, PointerEventArgs^ args)
     if (m_nativeInput != nullptr)
     {
         const auto& position = args->CurrentPoint->RawPosition;
-        const auto& deviceType = args->CurrentPoint->PointerDevice->PointerDeviceType;
-        const auto& deviceSlot = args->CurrentPoint->PointerId;
-        const auto& updateKind = args->CurrentPoint->Properties->PointerUpdateKind;
+        const auto deviceType = args->CurrentPoint->PointerDevice->PointerDeviceType;
+        const auto deviceSlot = args->CurrentPoint->PointerId;
+        const auto updateKind = args->CurrentPoint->Properties->PointerUpdateKind;
         const auto x = static_cast<int>(position.X);
         const auto y = static_cast<int>(position.Y);
 
@@ -289,9 +289,9 @@ void App::OnPointerReleased(CoreWindow^, PointerEventArgs^ args)
     if (m_nativeInput != nullptr)
     {
         const auto& position = args->CurrentPoint->RawPosition;
-        const auto& deviceType = args->CurrentPoint->PointerDevice->PointerDeviceType;
-        const auto& deviceSlot = args->CurrentPoint->PointerId;
-        const auto& updateKind = args->CurrentPoint->Properties->PointerUpdateKind;
+        const auto deviceType = args->CurrentPoint->PointerDevice->PointerDeviceType;
+        const auto deviceSlot = args->CurrentPoint->PointerId;
+        const auto updateKind = args->CurrentPoint->Properties->PointerUpdateKind;
         const auto x = static_cast<int>(position.X);
         const auto y = static_cast<int>(position.Y);
 
@@ -307,7 +307,7 @@ void App::OnPointerReleased(CoreWindow^, PointerEventArgs^ args)
 }
 void App::OnPointerWheelChanged(CoreWindow^, PointerEventArgs^ args)
 {
-    const auto& delta = args->CurrentPoint->Properties->MouseWheelDelta;
+    const auto delta = args->CurrentPoint->Properties->MouseWheelDelta;
     m_nativeInput->MouseWheel(Babylon::Plugins::NativeInput::MOUSEWHEEL_Y_ID, delta);
 }
 


### PR DESCRIPTION
In our UWP code, there were some local variables used in the input functions to store address refs for some `ints`.  Since using the addresses adds no benefits but increases the complexity, this PR will remove those ampersand operators.  Originally, this was brought up by @ryantrem but the PR was merged before all instances of the operators on `ints` were removed.

This change has been tested and verified to work with both mouse and touch on UWP.