### PR TITLE
Less gargantuan debug libraries

### DIFF
--- a/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
+++ b/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Babylon/JsRuntime.h>
-#include <Babylon/Graphics/Platform.h>
 #include <Babylon/Graphics/RendererType.h>
 
 #include <future>
@@ -9,6 +8,8 @@
 
 namespace Babylon::Graphics
 {
+    struct WindowConfiguration;
+
     struct PlatformInfo
     {
         DeviceT Device;
@@ -74,6 +75,7 @@ namespace Babylon::Graphics
 
         void UpdateWindow(const WindowConfiguration& config);
         void UpdateSize(size_t width, size_t height);
+        void UpdateSize(const WindowConfiguration& config);
 
         void AddToJavaScript(Napi::Env);
         Napi::Value CreateContext(Napi::Env);

--- a/Core/Graphics/Source/Device.cpp
+++ b/Core/Graphics/Source/Device.cpp
@@ -30,7 +30,7 @@ namespace Babylon::Graphics
     {
         std::unique_ptr<Device> device{new Device()};
         device->UpdateWindow(config);
-        device->UpdateSize(config.Width, config.Height);
+        device->UpdateSize(config);
         return device;
     }
 
@@ -44,6 +44,11 @@ namespace Babylon::Graphics
     void Device::UpdateSize(size_t width, size_t height)
     {
         m_impl->Resize(width, height);
+    }
+
+    void Device::UpdateSize(const WindowConfiguration& config)
+    {
+        m_impl->Resize(config);
     }
 
     void Device::AddToJavaScript(Napi::Env env)

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -70,6 +70,11 @@ namespace Babylon::Graphics
         UpdateBgfxResolution();
     }
 
+    void DeviceImpl::Resize(const WindowConfiguration& config)
+    {
+        Resize(config.Width, config.Height);
+    }
+    
     size_t DeviceImpl::GetWidth() const
     {
         return m_state.Resolution.Width;

--- a/Core/Graphics/Source/DeviceImpl.h
+++ b/Core/Graphics/Source/DeviceImpl.h
@@ -39,6 +39,7 @@ namespace Babylon::Graphics
         void UpdateWindow(const WindowConfiguration& config);
         void UpdateContext(const DeviceConfiguration& config);
         void Resize(size_t width, size_t height);
+        void Resize(const WindowConfiguration& config);
 
         void AddToJavaScript(Napi::Env);
         static DeviceImpl& GetFromJavaScript(Napi::Env);


### PR DESCRIPTION
fixes #1062 

Problem is `cppwinrt\winrt\Windows.UI.Xaml.Controls.h` defines a lot of template that gets compiled inside .obj and concatenated in the .lib.
The more .cpp including `<Babylon/Graphics/Platform.h>` the bigger the library.
There is no define ([WIN32_LEAN_AND_MEAN like) that will help. It looks like some build parameters with implicit templates might help but it doesn't cover our use case here.

Only solution is to limit the number of .cpp including it. That's what I did in this PR with forward reference and an added method `UpdateSize` so `WindowConfiguration` is forward until last moment in a .cpp that already includes the winrt header.

This way, **we get from 40+Mb to 18**. It's possible to shave off another 7Mb by removing Plaform.h inclusion from DeviceImpl but this line will produce an error:

`Resize(config.Width, config.Height);`

I have some thoughts that I leave to your appreciation:
- have a base struct `WindowConfigurationBase` that `WindowConfiguration` will inherit from. It will contain only Width and Height. So, it's possible to cast from a `WindowConfiguration` to a `WindowConfigurationBase` reference in DeviceImpl and only use Width/Height
- Try to do an amalgamated build for this project using cmake. Basically, cmake build a new temporary file that include every .cpp. Only this file will be compiled. So, template will only be instanciated once. On a large scale, this can help reduce build time for other projects too (I experience around 40% less time in other projects)

