### PR TITLE
MSAA parameter exposed to users

### DIFF
--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -354,6 +354,7 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
     graphicsConfig.Window = window;
     graphicsConfig.Width = width;
     graphicsConfig.Height = height;
+    graphicsConfig.MSAASamples = 4;
     m_device = Babylon::Graphics::Device::Create(graphicsConfig);
     m_update = std::make_unique<Babylon::Graphics::DeviceUpdate>(m_device->GetUpdate("update"));
     m_device->StartRenderingCurrentFrame();

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -114,6 +114,7 @@ namespace
         graphicsConfig.Window = hWnd;
         graphicsConfig.Width = width;
         graphicsConfig.Height = height;
+        graphicsConfig.MSAASamples = 4;
 
         device = Babylon::Graphics::Device::Create(graphicsConfig);
         update = std::make_unique<Babylon::Graphics::DeviceUpdate>(device->GetUpdate("update"));

--- a/Apps/Playground/X11/App.cpp
+++ b/Apps/Playground/X11/App.cpp
@@ -71,6 +71,7 @@ namespace
         graphicsConfig.Window = window;
         graphicsConfig.Width = static_cast<size_t>(width);
         graphicsConfig.Height = static_cast<size_t>(height);
+        graphicsConfig.MSAASamples = 4;
 
         device = Babylon::Graphics::Device::Create(graphicsConfig);
         update = std::make_unique<Babylon::Graphics::DeviceUpdate>(device->GetUpdate("update"));

--- a/Apps/Playground/macOS/ViewController.mm
+++ b/Apps/Playground/macOS/ViewController.mm
@@ -89,6 +89,7 @@ std::unique_ptr<Babylon::Polyfills::Canvas> nativeCanvas{};
     graphicsConfig.Window = engineView;
     graphicsConfig.Width = width;
     graphicsConfig.Height = height;
+    graphicsConfig.MSAASamples = 4;
     device = Babylon::Graphics::Device::Create(graphicsConfig);
     update = std::make_unique<Babylon::Graphics::DeviceUpdate>(device->GetUpdate("update"));
 

--- a/Apps/ValidationTests/UWP/App.cpp
+++ b/Apps/ValidationTests/UWP/App.cpp
@@ -198,6 +198,7 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
     graphicsConfig.Window = window;
     graphicsConfig.Width = width;
     graphicsConfig.Height = height;
+    graphicsConfig.MSAASamples = 4;
     m_device = Babylon::Graphics::Device::Create(graphicsConfig);
     m_update = std::make_unique<Babylon::Graphics::DeviceUpdate>(m_device->GetUpdate("update"));
     m_device->StartRenderingCurrentFrame();

--- a/Apps/ValidationTests/Win32/App.cpp
+++ b/Apps/ValidationTests/Win32/App.cpp
@@ -66,6 +66,7 @@ namespace
         graphicsConfig.Window = hWnd;
         graphicsConfig.Width = static_cast<size_t>(TEST_WIDTH);
         graphicsConfig.Height = static_cast<size_t>(TEST_HEIGHT);
+        graphicsConfig.MSAASamples = 4;
 
         device = Babylon::Graphics::Device::Create(graphicsConfig);
         update = std::make_unique<Babylon::Graphics::DeviceUpdate>(device->GetUpdate("update"));

--- a/Apps/ValidationTests/X11/App.cpp
+++ b/Apps/ValidationTests/X11/App.cpp
@@ -70,7 +70,8 @@ namespace
         graphicsConfig.Window = window;
         graphicsConfig.Width = static_cast<size_t>(width);
         graphicsConfig.Height = static_cast<size_t>(height);
-
+        graphicsConfig.MSAASamples = 4;
+        
         device = Babylon::Graphics::Device::Create(graphicsConfig);
         update = std::make_unique<Babylon::Graphics::DeviceUpdate>(device->GetUpdate("update"));
         device->SetDiagnosticOutput([](const char* outputString) { printf("%s", outputString); fflush(stdout); });

--- a/Apps/ValidationTests/macOS/ViewController.mm
+++ b/Apps/ValidationTests/macOS/ViewController.mm
@@ -81,6 +81,7 @@ std::unique_ptr<Babylon::Polyfills::Canvas> nativeCanvas{};
     graphicsConfig.Window = engineView;
     graphicsConfig.Width = static_cast<size_t>(600);
     graphicsConfig.Height = static_cast<size_t>(400);
+    graphicsConfig.MSAASamples = 4;
     device = Babylon::Graphics::Device::Create(graphicsConfig);
     update = std::make_unique<Babylon::Graphics::DeviceUpdate>(device->GetUpdate("update"));
     device->StartRenderingCurrentFrame();

--- a/Core/Graphics/Include/Platform/Android/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/Android/Babylon/Graphics/Platform.h
@@ -11,5 +11,7 @@ namespace Babylon::Graphics
         WindowType Window{};
         size_t Width{};
         size_t Height{};
+        // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
+        unsigned char MSAASamples{};
     };
 }

--- a/Core/Graphics/Include/Platform/Android/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/Android/Babylon/Graphics/Platform.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <android/native_window.h>
+#include <stdint.h>
 
 namespace Babylon::Graphics
 {
@@ -12,6 +13,6 @@ namespace Babylon::Graphics
         size_t Width{};
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
-        unsigned char MSAASamples{};
+        uint8_t MSAASamples{};
     };
 }

--- a/Core/Graphics/Include/Platform/UWP/CoreWindow/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/UWP/CoreWindow/Babylon/Graphics/Platform.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <winrt/windows.ui.core.h>
+#include <stdint.h>
 
 namespace Babylon::Graphics
 {
@@ -12,6 +13,6 @@ namespace Babylon::Graphics
         size_t Width{};
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
-        unsigned char MSAASamples{};
+        uint8_t MSAASamples{};
     };
 }

--- a/Core/Graphics/Include/Platform/UWP/CoreWindow/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/UWP/CoreWindow/Babylon/Graphics/Platform.h
@@ -11,5 +11,7 @@ namespace Babylon::Graphics
         WindowType Window{};
         size_t Width{};
         size_t Height{};
+        // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
+        unsigned char MSAASamples{};
     };
 }

--- a/Core/Graphics/Include/Platform/UWP/SwapChainPanel/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/UWP/SwapChainPanel/Babylon/Graphics/Platform.h
@@ -11,5 +11,7 @@ namespace Babylon::Graphics
         WindowType Window{};
         size_t Width{};
         size_t Height{};
+        // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
+        unsigned char MSAASamples{};
     };
 }

--- a/Core/Graphics/Include/Platform/UWP/SwapChainPanel/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/UWP/SwapChainPanel/Babylon/Graphics/Platform.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <winrt/Windows.UI.Xaml.Controls.h>
+#include <stdint.h>
 
 namespace Babylon::Graphics
 {
@@ -12,6 +13,6 @@ namespace Babylon::Graphics
         size_t Width{};
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
-        unsigned char MSAASamples{};
+        uint8_t MSAASamples{};
     };
 }

--- a/Core/Graphics/Include/Platform/Unix/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/Unix/Babylon/Graphics/Platform.h
@@ -11,5 +11,7 @@ namespace Babylon::Graphics
         WindowType Window{};
         size_t Width{};
         size_t Height{};
+        // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
+        unsigned char MSAASamples{};
     };
 }

--- a/Core/Graphics/Include/Platform/Unix/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/Unix/Babylon/Graphics/Platform.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <X11/Xlib.h>
+#include <stdint.h>
 
 namespace Babylon::Graphics
 {
@@ -12,6 +13,6 @@ namespace Babylon::Graphics
         size_t Width{};
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
-        unsigned char MSAASamples{};
+        uint8_t MSAASamples{};
     };
 }

--- a/Core/Graphics/Include/Platform/Win32/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/Win32/Babylon/Graphics/Platform.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Windows.h>
+#include <stdint.h>
 
 namespace Babylon::Graphics
 {
@@ -12,6 +13,6 @@ namespace Babylon::Graphics
         size_t Width{};
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
-        unsigned char MSAASamples{};
+        uint8_t MSAASamples{};
     };
 }

--- a/Core/Graphics/Include/Platform/Win32/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/Win32/Babylon/Graphics/Platform.h
@@ -11,5 +11,7 @@ namespace Babylon::Graphics
         WindowType Window{};
         size_t Width{};
         size_t Height{};
+        // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
+        unsigned char MSAASamples{};
     };
 }

--- a/Core/Graphics/Include/Platform/iOS/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/iOS/Babylon/Graphics/Platform.h
@@ -11,5 +11,7 @@ namespace Babylon::Graphics
         WindowType Window{};
         size_t Width{};
         size_t Height{};
+        // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
+        unsigned char MSAASamples{};
     };
 }

--- a/Core/Graphics/Include/Platform/iOS/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/iOS/Babylon/Graphics/Platform.h
@@ -12,6 +12,6 @@ namespace Babylon::Graphics
         size_t Width{};
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
-        unsigned char MSAASamples{};
+        uint8_t MSAASamples{};
     };
 }

--- a/Core/Graphics/Include/Platform/macOS/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/macOS/Babylon/Graphics/Platform.h
@@ -11,5 +11,7 @@ namespace Babylon::Graphics
         WindowType Window{};
         size_t Width{};
         size_t Height{};
+        // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
+        unsigned char MSAASamples{};
     };
 }

--- a/Core/Graphics/Include/Platform/macOS/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/macOS/Babylon/Graphics/Platform.h
@@ -12,6 +12,6 @@ namespace Babylon::Graphics
         size_t Width{};
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
-        unsigned char MSAASamples{};
+        uint8_t MSAASamples{};
     };
 }

--- a/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
+++ b/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
@@ -74,7 +74,7 @@ namespace Babylon::Graphics
 
         void UpdateWindow(const WindowConfiguration& config);
         void UpdateSize(size_t width, size_t height);
-        void UpdateMSAA(uint8_t MSAASamples);
+        void UpdateMSAA(uint8_t value);
 
         void AddToJavaScript(Napi::Env);
         Napi::Value CreateContext(Napi::Env);

--- a/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
+++ b/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
@@ -74,6 +74,7 @@ namespace Babylon::Graphics
 
         void UpdateWindow(const WindowConfiguration& config);
         void UpdateSize(size_t width, size_t height);
+        void UpdateMSAA(uint8_t MSAASamples);
 
         void AddToJavaScript(Napi::Env);
         Napi::Value CreateContext(Napi::Env);

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/BgfxCallback.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/BgfxCallback.h
@@ -27,6 +27,7 @@ namespace Babylon::Graphics
 
         void AddScreenShotCallback(std::function<void(std::vector<uint8_t>)> callback);
         void SetDiagnosticOutput(std::function<void(const char* output)> outputFunction);
+        void trace(const char* _filePath, uint16_t _line, const char* _format, ...);
 
     protected:
         void fatal(const char* filePath, uint16_t line, bgfx::Fatal::Enum code, const char* str) override;
@@ -41,7 +42,6 @@ namespace Babylon::Graphics
         void captureBegin(uint32_t width, uint32_t height, uint32_t pitch, bgfx::TextureFormat::Enum format, bool yflip) override;
         void captureEnd() override;
         void captureFrame(const void* _data, uint32_t _size) override;
-        void trace(const char* _filePath, uint16_t _line, const char* _format, ...);
 
     private:
         std::function<void(const char* output)> m_outputFunction;

--- a/Core/Graphics/Source/Device.cpp
+++ b/Core/Graphics/Source/Device.cpp
@@ -31,6 +31,7 @@ namespace Babylon::Graphics
         std::unique_ptr<Device> device{new Device()};
         device->UpdateWindow(config);
         device->UpdateSize(config.Width, config.Height);
+        device->UpdateMSAA(config.MSAASamples);
         return device;
     }
 
@@ -44,6 +45,11 @@ namespace Babylon::Graphics
     void Device::UpdateSize(size_t width, size_t height)
     {
         m_impl->Resize(width, height);
+    }
+
+    void Device::UpdateMSAA(uint8_t MSAASamples)
+    {
+        m_impl->SetMSAA(MSAASamples);
     }
 
     void Device::AddToJavaScript(Napi::Env env)

--- a/Core/Graphics/Source/Device.cpp
+++ b/Core/Graphics/Source/Device.cpp
@@ -47,9 +47,9 @@ namespace Babylon::Graphics
         m_impl->Resize(width, height);
     }
 
-    void Device::UpdateMSAA(uint8_t MSAASamples)
+    void Device::UpdateMSAA(uint8_t value)
     {
-        m_impl->SetMSAA(MSAASamples);
+        m_impl->SetMSAA(value);
     }
 
     void Device::AddToJavaScript(Napi::Env env)

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -62,13 +62,13 @@ namespace Babylon::Graphics
         UpdateBgfxResolution();
     }
 
-    void DeviceImpl::SetMSAA(uint8_t MSAASamples)
+    void DeviceImpl::SetMSAA(uint8_t value)
     {
         std::scoped_lock lock{m_state.Mutex};
         m_state.Bgfx.Dirty = true;
         auto& init = m_state.Bgfx.InitState;
         init.resolution.reset &= ~BGFX_RESET_MSAA_MASK;
-        switch (MSAASamples)
+        switch (value)
         {
             case 2:
                 init.resolution.reset |= BGFX_RESET_MSAA_X2;

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -70,6 +70,10 @@ namespace Babylon::Graphics
         init.resolution.reset &= ~BGFX_RESET_MSAA_MASK;
         switch (value)
         {
+            case 0:
+            case 1:
+                // disable MSAA
+                break;
             case 2:
                 init.resolution.reset |= BGFX_RESET_MSAA_X2;
                 break;
@@ -81,6 +85,9 @@ namespace Babylon::Graphics
                 break;
             case 16:
                 init.resolution.reset |= BGFX_RESET_MSAA_X16;
+                break;
+            default:
+                m_bgfxCallback.trace(__FILE__, __LINE__,  "WARNING: Setting an incorrect value for SetMSAA (%d). Correct values are 0, 1 (disable MSAA) or 2, 4, 8, 16.", int(value));
                 break;
         }
     }

--- a/Core/Graphics/Source/DeviceImpl.h
+++ b/Core/Graphics/Source/DeviceImpl.h
@@ -39,7 +39,7 @@ namespace Babylon::Graphics
         void UpdateWindow(const WindowConfiguration& config);
         void UpdateContext(const DeviceConfiguration& config);
         void Resize(size_t width, size_t height);
-        void SetMSAA(uint8_t MSAASamples);
+        void SetMSAA(uint8_t value);
 
         void AddToJavaScript(Napi::Env);
         static DeviceImpl& GetFromJavaScript(Napi::Env);

--- a/Core/Graphics/Source/DeviceImpl.h
+++ b/Core/Graphics/Source/DeviceImpl.h
@@ -39,6 +39,7 @@ namespace Babylon::Graphics
         void UpdateWindow(const WindowConfiguration& config);
         void UpdateContext(const DeviceConfiguration& config);
         void Resize(size_t width, size_t height);
+        void SetMSAA(uint8_t MSAASamples);
 
         void AddToJavaScript(Napi::Env);
         static DeviceImpl& GetFromJavaScript(Napi::Env);


### PR DESCRIPTION
Default is no MSAA unless set in the `WindowConfiguration` or updated later with `UpdateMSAA`.
Desktop playground and ValidationTests app MSAA set to 4.
