### PR TITLE
Fix VertexBuffer update

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -645,7 +645,7 @@ namespace Babylon
         const uint32_t byteOffset = info[2].As<Napi::Number>().Uint32Value();
         const uint32_t byteLength = info[3].As<Napi::Number>().Uint32Value();
 
-        vertexBuffer->Update(info.Env(), gsl::make_span(static_cast<uint8_t*>(bytes.Data()) + byteOffset, byteLength));
+        vertexBuffer->Update(info.Env(), gsl::make_span(static_cast<uint8_t*>(bytes.Data()), byteLength), byteOffset);
     }
 
     // Change VS output coordinate system

--- a/Plugins/NativeEngine/Source/VertexBuffer.cpp
+++ b/Plugins/NativeEngine/Source/VertexBuffer.cpp
@@ -75,7 +75,7 @@ namespace Babylon
         else
         {
             // Buffer hasn't been finalized yet, all that's necessary is to swap out the bytes.
-            if (m_bytes && !(*m_bytes).empty())
+            if (m_bytes && !m_bytes->empty())
             {
                 // update a portion of the vertex buffer bytes
                 memcpy((*m_bytes).data() + byteOffset, bytes.data(), bytes.size());

--- a/Plugins/NativeEngine/Source/VertexBuffer.cpp
+++ b/Plugins/NativeEngine/Source/VertexBuffer.cpp
@@ -60,7 +60,7 @@ namespace Babylon
         m_disposed = true;
     }
 
-    void VertexBuffer::Update(Napi::Env env, gsl::span<uint8_t> bytes)
+    void VertexBuffer::Update(Napi::Env env, gsl::span<uint8_t> bytes, size_t byteOffset)
     {
         if (!m_dynamic)
         {
@@ -75,7 +75,22 @@ namespace Babylon
         else
         {
             // Buffer hasn't been finalized yet, all that's necessary is to swap out the bytes.
-            m_bytes = {bytes.data(), bytes.data() + bytes.size()};
+            if (m_bytes && !(*m_bytes).empty())
+            {
+                // update a portion of the vertex buffer bytes
+                memcpy((*m_bytes).data() + byteOffset, bytes.data(), bytes.size());
+            }
+            else
+            {
+                if (byteOffset != 0)
+                {
+                    throw Napi::Error::New(env, "Cannot update a vertex buffer that has no data yet.");
+                }
+                else
+                {
+                    m_bytes = {bytes.data(), bytes.data() + bytes.size()};
+                }
+            }
         }
     }
 

--- a/Plugins/NativeEngine/Source/VertexBuffer.cpp
+++ b/Plugins/NativeEngine/Source/VertexBuffer.cpp
@@ -69,6 +69,10 @@ namespace Babylon
 
         if (bgfx::isValid(m_dynamicHandle))
         {
+            if (byteOffset)
+            {
+                throw Napi::Error::New(env, "Dynamic VertexBuffer Update: byte offset unimplemented.");
+            }
             // Buffer was already created, do a real update operation.
             bgfx::update(m_dynamicHandle, 0, bgfx::copy(bytes.data(), static_cast<uint32_t>(bytes.size())));
         }

--- a/Plugins/NativeEngine/Source/VertexBuffer.cpp
+++ b/Plugins/NativeEngine/Source/VertexBuffer.cpp
@@ -77,8 +77,12 @@ namespace Babylon
             // Buffer hasn't been finalized yet, all that's necessary is to swap out the bytes.
             if (m_bytes && !m_bytes->empty())
             {
+                if (byteOffset + bytes.size() > m_bytes->size())
+                {
+                    throw Napi::Error::New(env, "VertexBuffer Update: buffer overflow.");
+                }
                 // update a portion of the vertex buffer bytes
-                memcpy((*m_bytes).data() + byteOffset, bytes.data(), bytes.size());
+                memcpy(m_bytes->data() + byteOffset, bytes.data(), bytes.size());
             }
             else
             {

--- a/Plugins/NativeEngine/Source/VertexBuffer.h
+++ b/Plugins/NativeEngine/Source/VertexBuffer.h
@@ -16,7 +16,7 @@ namespace Babylon
 
         void Dispose();
 
-        void Update(Napi::Env env, gsl::span<uint8_t> bytes);
+        void Update(Napi::Env env, gsl::span<uint8_t> bytes, size_t byteOffset);
         bool CreateHandle(const bgfx::VertexLayout& layout);
         void PromoteToFloats(bgfx::AttribType::Enum attribType, uint32_t numElements, uint32_t byteOffset, uint32_t byteStride);
         void Set(bgfx::Encoder* encoder, uint8_t stream, uint32_t startVertex, uint32_t numVertices, bgfx::VertexLayoutHandle layoutHandle);


### PR DESCRIPTION
Issue reported by one partner when doing a ThinInstances buffer partial update.
byteOffset was not taken into account and buffer was forced to be the partial span.

