### PR TITLE
Fixes for resizing windows in UWP for D3D11

### DIFF
--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -27,6 +27,7 @@ namespace Babylon::Graphics
         auto& init = m_state.Bgfx.InitState;
         init.type = s_bgfxRenderType;
         init.resolution.reset = BGFX_RESET_VSYNC | BGFX_RESET_MAXANISOTROPY;
+        init.resolution.maxFrameLatency = 1;
         if (s_bgfxFlipAfterRender) init.resolution.reset |= BGFX_RESET_FLIP_AFTER_RENDER;
 
         init.callback = &m_bgfxCallback;
@@ -323,6 +324,7 @@ namespace Babylon::Graphics
             auto& res = m_state.Bgfx.InitState.resolution;
             bgfx::reset(res.width, res.height, res.reset);
             bgfx::setViewRect(0, 0, 0, static_cast<uint16_t>(res.width), static_cast<uint16_t>(res.height));
+            bgfx::frame();
 
             m_state.Bgfx.Dirty = false;
         }

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1495,12 +1495,12 @@ namespace Babylon
 
     Napi::Value NativeEngine::GetRenderWidth(const Napi::CallbackInfo& info)
     {
-        return Napi::Value::From(info.Env(), bgfx::getStats()->width);
+        return Napi::Value::From(info.Env(), m_graphicsContext.GetWidth());
     }
 
     Napi::Value NativeEngine::GetRenderHeight(const Napi::CallbackInfo& info)
     {
-        return Napi::Value::From(info.Env(), bgfx::getStats()->height);
+        return Napi::Value::From(info.Env(), m_graphicsContext.GetHeight());
     }
 
     void NativeEngine::SetViewPort(const Napi::CallbackInfo& info)


### PR DESCRIPTION
- Update bgfx to include fixes for UWP
- Set max frame latency for bgfx init
- Use width and height from graphics instead of bgfx

#118