### PR TITLE
Clean up copy/move semantics declarations

### DIFF
--- a/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
+++ b/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
@@ -20,9 +20,10 @@ namespace Babylon::Graphics
     {
     public:
         DeviceUpdate(const DeviceUpdate&) = default;
-        DeviceUpdate(DeviceUpdate&&) = default;
         DeviceUpdate& operator=(const DeviceUpdate&) = default;
-        DeviceUpdate& operator=(DeviceUpdate&&) = default;
+
+        DeviceUpdate(DeviceUpdate&&) noexcept = default;
+        DeviceUpdate& operator=(DeviceUpdate&&) noexcept = default;
 
         void Start()
         {

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
@@ -32,7 +32,10 @@ namespace Babylon::Graphics
     {
     public:
         UpdateToken(const UpdateToken& other) = delete;
-        UpdateToken(UpdateToken&&) = default;
+        UpdateToken& operator=(const UpdateToken& other) = delete;
+
+        UpdateToken(UpdateToken&&) noexcept = default;
+        UpdateToken& operator=(UpdateToken&& other) noexcept = default;
 
         bgfx::Encoder* GetEncoder();
 

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/FrameBuffer.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/FrameBuffer.h
@@ -24,7 +24,7 @@ namespace Babylon::Graphics
         ~FrameBuffer();
 
         FrameBuffer(const FrameBuffer&) = delete;
-        FrameBuffer(FrameBuffer&&) = delete;
+        FrameBuffer& operator=(const FrameBuffer&) = delete;
 
         bgfx::FrameBufferHandle Handle() const;
         uint16_t Width() const;

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
@@ -13,9 +13,6 @@ namespace Babylon::Graphics
         Texture(const Texture&) = delete;
         Texture& operator=(const Texture&) = delete;
 
-        Texture(Texture&&) noexcept = delete;
-        Texture& operator=(Texture&&) noexcept = delete;
-
         void Dispose();
 
         bool IsValid() const;

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/continuation_scheduler.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/continuation_scheduler.h
@@ -12,8 +12,9 @@ namespace Babylon
             : m_dispatcher{dispatcher}
         {
         }
+
         continuation_scheduler(const continuation_scheduler&) = delete;
-        continuation_scheduler(continuation_scheduler&&) = delete;
+        continuation_scheduler& operator=(const continuation_scheduler&) = delete;
 
         template<typename CallableT>
         void operator()(CallableT&& callable)

--- a/Core/JsRuntime/Include/Babylon/JsRuntime.h
+++ b/Core/JsRuntime/Include/Babylon/JsRuntime.h
@@ -41,7 +41,7 @@ namespace Babylon
 
     protected:
         JsRuntime(const JsRuntime&) = delete;
-        JsRuntime(JsRuntime&&) = delete;
+        JsRuntime& operator=(const JsRuntime&) = delete;
 
     private:
         JsRuntime(Napi::Env, DispatchFunctionT);

--- a/Plugins/ChromeDevTools/Include/Babylon/Plugins/ChromeDevTools.h
+++ b/Plugins/ChromeDevTools/Include/Babylon/Plugins/ChromeDevTools.h
@@ -10,8 +10,10 @@ namespace Babylon::Plugins
         class Impl;
 
         ChromeDevTools(const ChromeDevTools&) = default;
-        ChromeDevTools(ChromeDevTools&&) = default;
-        ~ChromeDevTools() = default;
+        ChromeDevTools& operator=(const ChromeDevTools&) = default;
+
+        ChromeDevTools(ChromeDevTools&&) noexcept = default;
+        ChromeDevTools& operator=(ChromeDevTools&&) noexcept = default;
 
         bool SupportsInspector() const;
         void StartInspector(const unsigned short port, const std::string& appName) const;

--- a/Plugins/NativeCamera/Include/Babylon/Plugins/NativeCamera.h
+++ b/Plugins/NativeCamera/Include/Babylon/Plugins/NativeCamera.h
@@ -10,8 +10,10 @@ namespace Babylon::Plugins
         class Impl;
 
         Camera(const Camera& other) = default;
-        Camera(Camera&&) = default;
-        ~Camera() = default;
+        Camera& operator=(const Camera& other) = default;
+
+        Camera(Camera&&) noexcept = default;
+        Camera& operator=(Camera&&) noexcept = default;
 
         // Initialization with overrideCameraTexture set to true means the caller
         // is expected to override the camera source texture with a native texture.

--- a/Plugins/NativeEngine/Source/IndexBuffer.h
+++ b/Plugins/NativeEngine/Source/IndexBuffer.h
@@ -17,9 +17,6 @@ namespace Babylon
         IndexBuffer(const IndexBuffer&) = delete;
         IndexBuffer& operator=(const IndexBuffer&) = delete;
 
-        IndexBuffer(IndexBuffer&&) = delete;
-        IndexBuffer& operator=(IndexBuffer&&) = delete;
-
         void Dispose();
 
         void Update(Napi::Env env, gsl::span<uint8_t> bytes, uint32_t startIndex);

--- a/Plugins/NativeEngine/Source/NativeDataStream.h
+++ b/Plugins/NativeEngine/Source/NativeDataStream.h
@@ -44,9 +44,7 @@ namespace Babylon
         {
         public:
             Reader(const Reader&) = delete;
-            Reader(Reader&&) = delete;
             Reader operator=(const Reader&) = delete;
-            Reader operator=(const Reader&&) = delete;
 
             bool CanRead() const
             {

--- a/Plugins/NativeEngine/Source/VertexArray.h
+++ b/Plugins/NativeEngine/Source/VertexArray.h
@@ -15,9 +15,6 @@ namespace Babylon
         VertexArray(const VertexArray&) = delete;
         VertexArray& operator=(const VertexArray&) = delete;
 
-        VertexArray(VertexArray&&) = delete;
-        VertexArray& operator=(VertexArray&&) = delete;
-
         void Dispose();
 
         bool RecordIndexBuffer(IndexBuffer* indexBuffer);

--- a/Plugins/NativeEngine/Source/VertexBuffer.h
+++ b/Plugins/NativeEngine/Source/VertexBuffer.h
@@ -17,9 +17,6 @@ namespace Babylon
         VertexBuffer(const VertexBuffer&) = delete;
         VertexBuffer& operator=(const VertexBuffer&) = delete;
 
-        VertexBuffer(VertexBuffer&&) = delete;
-        VertexBuffer& operator=(VertexBuffer&&) = delete;
-
         void Dispose();
 
         void Update(Napi::Env env, gsl::span<uint8_t> bytes, size_t byteOffset);

--- a/Plugins/NativeInput/Include/Babylon/Plugins/NativeInput.h
+++ b/Plugins/NativeInput/Include/Babylon/Plugins/NativeInput.h
@@ -28,8 +28,10 @@ namespace Babylon::Plugins
 
     private:
         NativeInput(const NativeInput&) = delete;
-        NativeInput(NativeInput&&) = delete;
+        NativeInput& operator=(const NativeInput&) = delete;
+
         NativeInput(Napi::Env);
+
         class Impl;
         std::unique_ptr<Impl> m_impl{};
     };

--- a/Plugins/NativeXr/Include/Babylon/Plugins/NativeXr.h
+++ b/Plugins/NativeXr/Include/Babylon/Plugins/NativeXr.h
@@ -10,7 +10,11 @@ namespace Babylon::Plugins
         class Impl;
 
         NativeXr(const NativeXr& other) = default;
-        NativeXr(NativeXr&&) = default;
+        NativeXr& operator=(const NativeXr& other) = default;
+
+        NativeXr(NativeXr&&) noexcept = default;
+        NativeXr& operator=(NativeXr&&) noexcept = default;
+
         ~NativeXr();
 
         static NativeXr Initialize(Napi::Env env);

--- a/Polyfills/Canvas/Include/Babylon/Polyfills/Canvas.h
+++ b/Polyfills/Canvas/Include/Babylon/Polyfills/Canvas.h
@@ -10,7 +10,11 @@ namespace Babylon::Polyfills
         class Impl;
 
         Canvas(const Canvas& other) = default;
-        Canvas(Canvas&&) = default;
+        Canvas& operator=(const Canvas& other) = default;
+
+        Canvas(Canvas&&) noexcept = default;
+        Canvas& operator=(Canvas&&) noexcept = default;
+
         ~Canvas();
 
         // This instance must live as long as the JS Runtime.


### PR DESCRIPTION
I originally just wanted to make sure we mark move semantics with `noexcept`, but then I did some more reading and found that it is probably best to remove explicitly deleting of move semantics if copy semantics are already deleted. If copy semantics are defined, C++ automatically removes move semantics.

Some interesting reads:
- https://stackoverflow.com/questions/48864976/most-concise-way-to-disable-copy-and-move-semantics
- https://stackoverflow.com/questions/23771194/why-should-i-delete-move-constructor-and-move-assignment-operator-in-a-singleton
- https://stackoverflow.com/questions/37092864/should-i-delete-the-move-constructor-and-the-move-assignment-of-a-smart-pointer/38820178#38820178
