### PR TITLE
Fix NativeCamera/VideoTexture by returning a promise from the play function

### DIFF
--- a/Plugins/NativeCamera/Source/NativeVideo.cpp
+++ b/Plugins/NativeCamera/Source/NativeVideo.cpp
@@ -150,7 +150,7 @@ namespace Babylon::Plugins
         }
 
         auto deferred{Napi::Promise::Deferred::New(info.Env())};
-        deferred.Resolve(info.Env().Null());
+        deferred.Resolve(info.Env().Undefined());
         return deferred.Promise();
     }
 

--- a/Plugins/NativeCamera/Source/NativeVideo.cpp
+++ b/Plugins/NativeCamera/Source/NativeVideo.cpp
@@ -140,7 +140,7 @@ namespace Babylon::Plugins
         }
     }
 
-    void NativeVideo::Play(const Napi::CallbackInfo& /*info*/)
+    Napi::Value NativeVideo::Play(const Napi::CallbackInfo& info)
     {
         if (!m_IsPlaying)
         {
@@ -148,6 +148,10 @@ namespace Babylon::Plugins
             NativeCameraImpl->Open(m_width, m_height, m_frontCamera);
             RaiseEvent("playing");
         }
+
+        auto deferred{Napi::Promise::Deferred::New(info.Env())};
+        deferred.Resolve(info.Env().Null());
+        return deferred.Promise();
     }
 
     void NativeVideo::Pause(const Napi::CallbackInfo& /*info*/)

--- a/Plugins/NativeCamera/Source/NativeVideo.h
+++ b/Plugins/NativeCamera/Source/NativeVideo.h
@@ -24,7 +24,7 @@ namespace Babylon::Plugins
         void AddEventListener(const Napi::CallbackInfo& info);
         void RemoveEventListener(const Napi::CallbackInfo& info);
         void RaiseEvent(const char* eventType);
-        void Play(const Napi::CallbackInfo& info);
+        Napi::Value Play(const Napi::CallbackInfo& info);
         void Pause(const Napi::CallbackInfo& info);
         void SetVideoWidth(const Napi::CallbackInfo& info, const Napi::Value& value);
         Napi::Value GetVideoWidth(const Napi::CallbackInfo& info);


### PR DESCRIPTION
[`HTMLMediaElement.play`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) is supposed to return a `Promise`, but our native implementation returns void. After this was implemented, Babylon.js [was later changed](https://github.com/BabylonJS/Babylon.js/commit/8969aaea7994b562f4c1f0f1e524994ffa1e0da5) to observe any errors (via `.catch`) on the promise returned from `play`. This means now that code dies trying to call `catch` on `undefined`. With this change, `play` now returns a completed promise. I think this is probably wrong because as far as I can tell, `play` is supposed to return a rejected promise with an error of type `NotAllowedError` if the user has not granted camera permissions. So I think there is more that needs to be done here to fully fix this, but this quick fix puts us into a state that is no more broken than it was originally (by returning undefined).