### PR TITLE
Alpha premultiplied backbuffer

### DIFF
--- a/Core/Graphics/Include/Platform/Android/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/Android/Babylon/Graphics/Platform.h
@@ -14,5 +14,7 @@ namespace Babylon::Graphics
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
         uint8_t MSAASamples{};
+        // When enabled, back buffer will be premultiplied with alpha value
+        bool AlphaPremultiplied{};
     };
 }

--- a/Core/Graphics/Include/Platform/UWP/CoreWindow/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/UWP/CoreWindow/Babylon/Graphics/Platform.h
@@ -14,5 +14,7 @@ namespace Babylon::Graphics
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
         uint8_t MSAASamples{};
+        // When enabled, back buffer will be premultiplied with alpha value
+        bool AlphaPremultiplied{};
     };
 }

--- a/Core/Graphics/Include/Platform/UWP/SwapChainPanel/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/UWP/SwapChainPanel/Babylon/Graphics/Platform.h
@@ -14,5 +14,7 @@ namespace Babylon::Graphics
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
         uint8_t MSAASamples{};
+        // When enabled, back buffer will be premultiplied with alpha value
+        bool AlphaPremultiplied{};
     };
 }

--- a/Core/Graphics/Include/Platform/Unix/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/Unix/Babylon/Graphics/Platform.h
@@ -14,5 +14,7 @@ namespace Babylon::Graphics
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
         uint8_t MSAASamples{};
+        // When enabled, back buffer will be premultiplied with alpha value
+        bool AlphaPremultiplied{};
     };
 }

--- a/Core/Graphics/Include/Platform/Win32/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/Win32/Babylon/Graphics/Platform.h
@@ -14,5 +14,7 @@ namespace Babylon::Graphics
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
         uint8_t MSAASamples{};
+        // When enabled, back buffer will be premultiplied with alpha value
+        bool AlphaPremultiplied{};
     };
 }

--- a/Core/Graphics/Include/Platform/iOS/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/iOS/Babylon/Graphics/Platform.h
@@ -13,7 +13,7 @@ namespace Babylon::Graphics
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
         uint8_t MSAASamples{};
-        // When enabled, back buffer will be premultiplied with alpha value
+        // When enabled, back buffer will be premultiplied with alpha value (Not implemented for Metal yet)
         bool AlphaPremultiplied{};
     };
 }

--- a/Core/Graphics/Include/Platform/iOS/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/iOS/Babylon/Graphics/Platform.h
@@ -13,5 +13,7 @@ namespace Babylon::Graphics
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
         uint8_t MSAASamples{};
+        // When enabled, back buffer will be premultiplied with alpha value
+        bool AlphaPremultiplied{};
     };
 }

--- a/Core/Graphics/Include/Platform/macOS/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/macOS/Babylon/Graphics/Platform.h
@@ -13,7 +13,7 @@ namespace Babylon::Graphics
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
         uint8_t MSAASamples{};
-        // When enabled, back buffer will be premultiplied with alpha value
+        // When enabled, back buffer will be premultiplied with alpha value (not implemented for Metal yet)
         bool AlphaPremultiplied{};
     };
 }

--- a/Core/Graphics/Include/Platform/macOS/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/macOS/Babylon/Graphics/Platform.h
@@ -13,5 +13,7 @@ namespace Babylon::Graphics
         size_t Height{};
         // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
         uint8_t MSAASamples{};
+        // When enabled, back buffer will be premultiplied with alpha value
+        bool AlphaPremultiplied{};
     };
 }

--- a/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
+++ b/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
@@ -76,6 +76,7 @@ namespace Babylon::Graphics
         void UpdateWindow(const WindowConfiguration& config);
         void UpdateSize(size_t width, size_t height);
         void UpdateMSAA(uint8_t value);
+        void UpdateAlphaPremultiplied(bool enabled);
 
         void AddToJavaScript(Napi::Env);
         Napi::Value CreateContext(Napi::Env);

--- a/Core/Graphics/Source/Device.cpp
+++ b/Core/Graphics/Source/Device.cpp
@@ -32,6 +32,7 @@ namespace Babylon::Graphics
         device->UpdateWindow(config);
         device->UpdateSize(config.Width, config.Height);
         device->UpdateMSAA(config.MSAASamples);
+        device->UpdateAlphaPremultiplied(config.AlphaPremultiplied);
         return device;
     }
 
@@ -50,6 +51,11 @@ namespace Babylon::Graphics
     void Device::UpdateMSAA(uint8_t value)
     {
         m_impl->SetMSAA(value);
+    }
+
+    void Device::UpdateAlphaPremultiplied(bool enabled)
+    {
+        m_impl->SetAlphaPremultiplied(enabled);
     }
 
     void Device::AddToJavaScript(Napi::Env env)

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -93,6 +93,22 @@ namespace Babylon::Graphics
         }
     }
 
+    void DeviceImpl::SetAlphaPremultiplied(bool enabled)
+    {
+        if (bgfx::getCaps()->supported & BGFX_CAPS_TRANSPARENT_BACKBUFFER)
+        {
+            std::scoped_lock lock{m_state.Mutex};
+            m_state.Bgfx.Dirty = true;
+            auto& init = m_state.Bgfx.InitState;
+            init.resolution.reset &= ~BGFX_CAPS_TRANSPARENT_BACKBUFFER;
+            init.resolution.reset |= enabled ? BGFX_CAPS_TRANSPARENT_BACKBUFFER : 0;
+        }
+        else
+        {
+            m_bgfxCallback.trace(__FILE__, __LINE__, "WARNING: BGFX_CAPS_TRANSPARENT_BACKBUFFER unsupported on this platform.");
+        }
+    }
+
     size_t DeviceImpl::GetWidth() const
     {
         return m_state.Resolution.Width;

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -95,18 +95,11 @@ namespace Babylon::Graphics
 
     void DeviceImpl::SetAlphaPremultiplied(bool enabled)
     {
-        if (bgfx::getCaps()->supported & BGFX_CAPS_TRANSPARENT_BACKBUFFER)
-        {
-            std::scoped_lock lock{m_state.Mutex};
-            m_state.Bgfx.Dirty = true;
-            auto& init = m_state.Bgfx.InitState;
-            init.resolution.reset &= ~BGFX_CAPS_TRANSPARENT_BACKBUFFER;
-            init.resolution.reset |= enabled ? BGFX_CAPS_TRANSPARENT_BACKBUFFER : 0;
-        }
-        else
-        {
-            m_bgfxCallback.trace(__FILE__, __LINE__, "WARNING: BGFX_CAPS_TRANSPARENT_BACKBUFFER unsupported on this platform.");
-        }
+        std::scoped_lock lock{m_state.Mutex};
+        m_state.Bgfx.Dirty = true;
+        auto& init = m_state.Bgfx.InitState;
+        init.resolution.reset &= ~BGFX_RESET_TRANSPARENT_BACKBUFFER;
+        init.resolution.reset |= enabled ? BGFX_RESET_TRANSPARENT_BACKBUFFER : 0;
     }
 
     size_t DeviceImpl::GetWidth() const

--- a/Core/Graphics/Source/DeviceImpl.h
+++ b/Core/Graphics/Source/DeviceImpl.h
@@ -40,6 +40,7 @@ namespace Babylon::Graphics
         void UpdateContext(const DeviceConfiguration& config);
         void Resize(size_t width, size_t height);
         void SetMSAA(uint8_t value);
+        void SetAlphaPremultiplied(bool enabled);
 
         void AddToJavaScript(Napi::Env);
         static DeviceImpl& GetFromJavaScript(Napi::Env);


### PR DESCRIPTION
This change concerns mostly UWP/swapchainpanel but is also available for other platforms as bgfx allows it.
More infos on the rendering side here : https://github.com/bkaradzic/bgfx/pull/2837

- API contract mimics the MSAA one.
- bgfx update to the latest
