### PR TITLE
NativeCamera - Don't access Graphics::DeviceContext from the constructor

### DIFF
--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
@@ -149,7 +149,7 @@ namespace Babylon::Plugins
 #endif
 
     Camera::Impl::Impl(Napi::Env env, bool overrideCameraTexture)
-        : m_deviceContext{Graphics::DeviceContext::GetFromJavaScript(env)}
+        : m_env{env}
         , m_overrideCameraTexture{overrideCameraTexture}
     {
 #if __ANDROID_API__ < 24
@@ -239,7 +239,7 @@ namespace Babylon::Plugins
                 auto id = GetCameraId(frontCamera);
                 ACameraManager_openCamera(m_cameraManager, id.c_str(), &cameraDeviceCallbacks, &m_cameraDevice);
 
-                m_textureWindow = ANativeWindow_fromSurface(GetEnvForCurrentThread(), surface);
+                m_textureWindow = ANativeWindow_fromSurface(m_env, surface);
 
                 // Prepare request for texture target
                 ACameraDevice_createCaptureRequest(m_cameraDevice, TEMPLATE_PREVIEW, &m_request);
@@ -323,7 +323,7 @@ namespace Babylon::Plugins
             throw std::runtime_error{"Unable to make current shared GL context for camera texture."};
         }
 
-        arcana::make_task(m_deviceContext.BeforeRenderScheduler(), arcana::cancellation::none(), [this, textureHandle] {
+        arcana::make_task(Graphics::DeviceContext::GetFromJavaScript(m_env).BeforeRenderScheduler(), arcana::cancellation::none(), [this, textureHandle] {
             bgfx::overrideInternal(textureHandle, m_cameraRGBATextureId);
         });
     }

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
@@ -149,7 +149,8 @@ namespace Babylon::Plugins
 #endif
 
     Camera::Impl::Impl(Napi::Env env, bool overrideCameraTexture)
-        : m_env{env}
+        : m_deviceContext{nullptr}
+        , m_env{env}
         , m_overrideCameraTexture{overrideCameraTexture}
     {
 #if __ANDROID_API__ < 24
@@ -166,6 +167,10 @@ namespace Babylon::Plugins
 
     void Camera::Impl::Open(uint32_t width, uint32_t height, bool frontCamera)
     {
+        if (!m_deviceContext){
+            m_deviceContext = &Graphics::DeviceContext::GetFromJavaScript(m_env);
+        }
+
         android::Permissions::CheckCameraPermissionAsync().then(arcana::inline_scheduler, arcana::cancellation::none(), [this, width, height, frontCamera]()
         {
             m_width = width;
@@ -239,7 +244,7 @@ namespace Babylon::Plugins
                 auto id = GetCameraId(frontCamera);
                 ACameraManager_openCamera(m_cameraManager, id.c_str(), &cameraDeviceCallbacks, &m_cameraDevice);
 
-                m_textureWindow = ANativeWindow_fromSurface(m_env, surface);
+                m_textureWindow = ANativeWindow_fromSurface(GetEnvForCurrentThread(), surface);
 
                 // Prepare request for texture target
                 ACameraDevice_createCaptureRequest(m_cameraDevice, TEMPLATE_PREVIEW, &m_request);
@@ -323,7 +328,7 @@ namespace Babylon::Plugins
             throw std::runtime_error{"Unable to make current shared GL context for camera texture."};
         }
 
-        arcana::make_task(Graphics::DeviceContext::GetFromJavaScript(m_env).BeforeRenderScheduler(), arcana::cancellation::none(), [this, textureHandle] {
+        arcana::make_task(m_deviceContext->BeforeRenderScheduler(), arcana::cancellation::none(), [this, textureHandle] {
             bgfx::overrideInternal(textureHandle, m_cameraRGBATextureId);
         });
     }

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
@@ -31,7 +31,7 @@ namespace Babylon::Plugins
 
     private:
 
-        Graphics::DeviceContext &m_deviceContext;
+        Napi::Env m_env;
 
         bool m_overrideCameraTexture;
 
@@ -51,7 +51,7 @@ namespace Babylon::Plugins
         ACaptureSessionOutput* m_textureOutput{};
         ACaptureSessionOutput* m_output{};
         ACaptureSessionOutputContainer* m_outputs{};
-        android::graphics::SurfaceTexture m_surfaceTexture;
+        android::graphics::SurfaceTexture m_surfaceTexture{};
 #endif
         GLuint m_cameraOESTextureId{};
         GLuint m_cameraRGBATextureId{};

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
@@ -31,6 +31,7 @@ namespace Babylon::Plugins
 
     private:
 
+        Graphics::DeviceContext* m_deviceContext;
         Napi::Env m_env;
 
         bool m_overrideCameraTexture;

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
@@ -21,7 +21,7 @@ namespace Babylon::Plugins
 
     private:
         Napi::Env m_env;
-        
+
         std::shared_ptr<ImplData> m_implData;
 
         bool m_overrideCameraTexture{};

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
@@ -20,6 +20,7 @@ namespace Babylon::Plugins
         void Close();
 
     private:
+        Graphics::DeviceContext* m_deviceContext;
         Napi::Env m_env;
 
         std::shared_ptr<ImplData> m_implData;

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
@@ -20,8 +20,8 @@ namespace Babylon::Plugins
         void Close();
 
     private:
-        Graphics::DeviceContext& m_deviceContext;
-
+        Napi::Env m_env;
+        
         std::shared_ptr<ImplData> m_implData;
 
         bool m_overrideCameraTexture{};

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -47,7 +47,7 @@ namespace Babylon::Plugins
         id <MTLTexture> textureBGRA{};
     };
     Camera::Impl::Impl(Napi::Env env, bool overrideCameraTexture)
-        : m_deviceContext{Graphics::DeviceContext::GetFromJavaScript(env)}
+        : m_env{env}
         , m_implData{std::make_unique<ImplData>()}
         , m_overrideCameraTexture{overrideCameraTexture}
     {
@@ -131,7 +131,7 @@ namespace Babylon::Plugins
 
     void Camera::Impl::UpdateCameraTexture(bgfx::TextureHandle textureHandle)
     {
-        arcana::make_task(m_deviceContext.BeforeRenderScheduler(), arcana::cancellation::none(), [this, textureHandle] {
+        arcana::make_task(Graphics::DeviceContext::GetFromJavaScript(m_env).BeforeRenderScheduler(), arcana::cancellation::none(), [this, textureHandle] {
             if (m_implData->textureBGRA)
             {
                 bgfx::overrideInternal(textureHandle, reinterpret_cast<uintptr_t>(m_implData->textureBGRA));

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -47,7 +47,8 @@ namespace Babylon::Plugins
         id <MTLTexture> textureBGRA{};
     };
     Camera::Impl::Impl(Napi::Env env, bool overrideCameraTexture)
-        : m_env{env}
+        : m_deviceContext{nullptr}
+        , m_env{env}
         , m_implData{std::make_unique<ImplData>()}
         , m_overrideCameraTexture{overrideCameraTexture}
     {
@@ -60,6 +61,10 @@ namespace Babylon::Plugins
     void Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool frontCamera)
     {
         auto metalDevice = (id<MTLDevice>)bgfx::getInternalData()->context;
+
+        if (!m_deviceContext) {
+            m_deviceContext = &Graphics::DeviceContext::GetFromJavaScript(m_env);
+        }
 
         dispatch_sync(dispatch_get_main_queue(), ^{
             
@@ -131,7 +136,7 @@ namespace Babylon::Plugins
 
     void Camera::Impl::UpdateCameraTexture(bgfx::TextureHandle textureHandle)
     {
-        arcana::make_task(Graphics::DeviceContext::GetFromJavaScript(m_env).BeforeRenderScheduler(), arcana::cancellation::none(), [this, textureHandle] {
+        arcana::make_task(m_deviceContext->BeforeRenderScheduler(), arcana::cancellation::none(), [this, textureHandle] {
             if (m_implData->textureBGRA)
             {
                 bgfx::overrideInternal(textureHandle, reinterpret_cast<uintptr_t>(m_implData->textureBGRA));


### PR DESCRIPTION
While adding the NativeCamera Plugin to Babylon React-Native I was hitting an issue where the plugin couldn't be initialized until after Graphics::DeviceContext had been initialized. The issue was that the plugin's constructor was saving off the current deviceContext reference to use later in the runtime. Because it was only using the deviceContext in one location I just removed it from the constructor and instead fetch it as needed later on when the plugin is used.