### PR TITLE
Fix crash on smooth shading for meshes with no index buffers.

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -608,6 +608,12 @@ namespace Babylon
     void NativeEngine::RecordVertexBuffer(const Napi::CallbackInfo& info)
     {
         VertexArray* vertexArray = info[0].As<Napi::Pointer<VertexArray>>().Get();
+        
+        auto vertexBufferValue = info[1];
+        
+        if (vertexBufferValue.IsUndefined())
+            return;
+
         VertexBuffer* vertexBuffer = info[1].As<Napi::Pointer<VertexBuffer>>().Get();
         const uint32_t location = info[2].As<Napi::Number>().Uint32Value();
         const uint32_t byteOffset = info[3].As<Napi::Number>().Uint32Value();

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -614,7 +614,7 @@ namespace Babylon
         if (vertexBufferValue.IsUndefined())
             return;
 
-        VertexBuffer* vertexBuffer = info[1].As<Napi::Pointer<VertexBuffer>>().Get();
+        VertexBuffer* vertexBuffer = vertexBufferValue.As<Napi::Pointer<VertexBuffer>>().Get();
         const uint32_t location = info[2].As<Napi::Number>().Uint32Value();
         const uint32_t byteOffset = info[3].As<Napi::Number>().Uint32Value();
         const uint32_t byteStride = info[4].As<Napi::Number>().Uint32Value();


### PR DESCRIPTION
## Overview 

When forceSharedVertices is called on a mesh that does not have a index buffer, the forceSharedVertices will create empty arrays for its positions and normals vertex attributes. This will result in a NativeEngine::RecordVertexBuffer been called with undefined arguments been passed as VertexBuffer* argument. 

A similar behavior happens on the Web engine; however, the web engine creates vertex attribute arrays of size zero, which results in no rendering for those meshes. By simply returning from NativeEngine::RecordVertexBuffer we get the same behavior on the Native engine.  

## Issues
- Fixes #1108 