### PR TITLE
NativeCamera Fixes and Improvements

### DIFF
--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -119,7 +119,7 @@ extern "C"
                 
                 g_nativeInput = &Babylon::Plugins::NativeInput::CreateForJavaScript(env);
 
-                Babylon::Plugins::Camera::Initialize(env, true);
+                Babylon::Plugins::Camera::Initialize(env);
                 Babylon::Polyfills::Window::Initialize(env);
 
                 Babylon::Polyfills::XMLHttpRequest::Initialize(env);

--- a/Plugins/NativeCamera/CMakeLists.txt
+++ b/Plugins/NativeCamera/CMakeLists.txt
@@ -22,9 +22,6 @@ target_include_directories(NativeCamera
 
 if(ANDROID)
     set(EXTENSIONS AndroidExtensions)
-    if(ANDROID_NATIVE_API_LEVEL GREATER_EQUAL 24)
-        set(EXTENSIONS ${EXTENSIONS} camera2ndk)
-    endif()
 elseif(APPLE)
     set(EXTENSIONS "-framework CoreMedia -framework AVFoundation")
 endif()

--- a/Plugins/NativeCamera/Source/Android/CameraWrappers.h
+++ b/Plugins/NativeCamera/Source/Android/CameraWrappers.h
@@ -13,7 +13,7 @@
 #undef __ANDROID_API__
 #define __ANDROID_API__ 24
 namespace API24 {
-#include <camera/NdkCameraManager.h>
+    #include <camera/NdkCameraManager.h>
     #include <camera/NdkCameraCaptureSession.h>
     #include <camera/NdkCameraDevice.h>
     #include <camera/NdkCameraError.h>
@@ -32,18 +32,18 @@ namespace API24 {
 
 namespace
 {
-    static const int API_LEVEL{ android_get_device_api_level() };
+    const int API_LEVEL{ android_get_device_api_level() };
 
     // Load the NDK camera lib dynamically. When running on OS 6.0 and below this will return nullptr,
     // on OS 7.0 and up this should return a pointer to access the library using dlsym. It is technically fine
     // to call dlopen when the API_LEVEL is below 24, but it's wasted effort on those devices.
-    static void* libCamera2NDK{ API_LEVEL >= 24 ? dlopen("libcamera2ndk.so", RTLD_NOW): nullptr };
+    void* libCamera2NDK{ API_LEVEL >= 24 ? dlopen("libcamera2ndk.so", RTLD_NOW): nullptr };
 
-    static std::map<std::string, void*> CameraDynamicFunctions{};
+    std::map<std::string, void*> CameraDynamicFunctions{};
 }
 
 namespace Babylon::Plugins {
-    static inline void* GetCameraDynamicFunction(const char* functionName) {
+    inline void* GetCameraDynamicFunction(const char* functionName) {
         if (!libCamera2NDK)
         {
             return nullptr;

--- a/Plugins/NativeCamera/Source/Android/CameraWrappers.h
+++ b/Plugins/NativeCamera/Source/Android/CameraWrappers.h
@@ -37,7 +37,7 @@ namespace
     // Load the NDK camera lib dynamically. When running on OS 6.0 and below this will return nullptr,
     // on OS 7.0 and up this should return a pointer to access the library using dlsym. It is technically fine
     // to call dlopen when the API_LEVEL is below 24, but it's wasted effort on those devices.
-    static void* libCamera2NDK{ API_LEVEL >= 24 ? dlopen("libcamera2ndk.so", RTLD_NOW | RTLD_LOCAL): nullptr };
+    static void* libCamera2NDK{ API_LEVEL >= 24 ? dlopen("libcamera2ndk.so", RTLD_NOW): nullptr };
 
     static std::map<std::string, void*> CameraDynamicFunctions{};
 }

--- a/Plugins/NativeCamera/Source/Android/CameraWrappers.h
+++ b/Plugins/NativeCamera/Source/Android/CameraWrappers.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <android/api-level.h>
-#include <arcana/macros.h>
 #include <dlfcn.h>
 #include <map>
 
@@ -29,7 +28,7 @@ namespace API24 {
 #undef __ORIG_ANDROID_API__
 
 // Helper macro to make calling camera NDK api's more type safe
-#define GET_CAMERA_FUNCTION(function) reinterpret_cast<decltype(&API24::function)>(GetCameraDynamicFunction(#function))
+#define GET_CAMERA_FUNCTION(function) reinterpret_cast<decltype(&API24::function)>(Babylon::Plugins::GetCameraDynamicFunction(#function))
 
 static const int API_LEVEL{ android_get_device_api_level() };
 
@@ -40,17 +39,18 @@ static void* libCamera2NDK{ API_LEVEL >= 24 ? dlopen("libcamera2ndk.so", RTLD_NO
 
 static std::map<std::string, void*> CameraDynamicFunctions{};
 
-static inline void* GetCameraDynamicFunction(const char* functionName)
-{
-    if (!libCamera2NDK)
-    {
-        return nullptr;
-    }
-    auto cameraDynamicFunctionIt{CameraDynamicFunctions.find(functionName)};
-    if (cameraDynamicFunctionIt == CameraDynamicFunctions.end())
-    {
-        cameraDynamicFunctionIt = CameraDynamicFunctions.emplace(functionName, dlsym(libCamera2NDK, functionName)).first;
-    }
+namespace Babylon::Plugins {
+    static inline void* GetCameraDynamicFunction(const char* functionName) {
+        if (!libCamera2NDK)
+        {
+            return nullptr;
+        }
+        auto cameraDynamicFunctionIt{CameraDynamicFunctions.find(functionName)};
+        if (cameraDynamicFunctionIt == CameraDynamicFunctions.end())
+        {
+            cameraDynamicFunctionIt = CameraDynamicFunctions.emplace(functionName, dlsym(libCamera2NDK, functionName)).first;
+        }
 
-    return cameraDynamicFunctionIt->second;
+        return cameraDynamicFunctionIt->second;
+    }
 }

--- a/Plugins/NativeCamera/Source/Android/CameraWrappers.h
+++ b/Plugins/NativeCamera/Source/Android/CameraWrappers.h
@@ -30,14 +30,17 @@ namespace API24 {
 // Helper macro to make calling camera NDK api's more type safe
 #define GET_CAMERA_FUNCTION(function) reinterpret_cast<decltype(&API24::function)>(Babylon::Plugins::GetCameraDynamicFunction(#function))
 
-static const int API_LEVEL{ android_get_device_api_level() };
+namespace
+{
+    static const int API_LEVEL{ android_get_device_api_level() };
 
-// Load the NDK camera lib dynamically. When running on OS 6.0 and below this will return nullptr,
-// on OS 7.0 and up this should return a pointer to access the library using dlsym. It is technically fine
-// to call dlopen when the API_LEVEL is below 24, but it's wasted effort on those devices.
-static void* libCamera2NDK{ API_LEVEL >= 24 ? dlopen("libcamera2ndk.so", RTLD_NOW | RTLD_LOCAL): nullptr };
+    // Load the NDK camera lib dynamically. When running on OS 6.0 and below this will return nullptr,
+    // on OS 7.0 and up this should return a pointer to access the library using dlsym. It is technically fine
+    // to call dlopen when the API_LEVEL is below 24, but it's wasted effort on those devices.
+    static void* libCamera2NDK{ API_LEVEL >= 24 ? dlopen("libcamera2ndk.so", RTLD_NOW | RTLD_LOCAL): nullptr };
 
-static std::map<std::string, void*> CameraDynamicFunctions{};
+    static std::map<std::string, void*> CameraDynamicFunctions{};
+}
 
 namespace Babylon::Plugins {
     static inline void* GetCameraDynamicFunction(const char* functionName) {

--- a/Plugins/NativeCamera/Source/Android/CameraWrappers.h
+++ b/Plugins/NativeCamera/Source/Android/CameraWrappers.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <android/api-level.h>
+#include <arcana/macros.h>
+#include <dlfcn.h>
+#include <map>
+
+// The camera API's in the NDK are only supported in API24 and higher. We
+// use dlopen and dlsym to link the camera lib at runtime only if the current
+// device supports it. In order to avoid redefining the type information the
+// below macro's forcefully import the camera header files as if the min supported
+// SDK was set to 24.
+#define __ORIG_ANDROID_API__ __ANDROID_API__
+#undef __ANDROID_API__
+#define __ANDROID_API__ 24
+namespace API24 {
+#include <camera/NdkCameraManager.h>
+    #include <camera/NdkCameraCaptureSession.h>
+    #include <camera/NdkCameraDevice.h>
+    #include <camera/NdkCameraError.h>
+    #include <camera/NdkCameraManager.h>
+    #include <camera/NdkCameraMetadata.h>
+    #include <camera/NdkCameraMetadataTags.h>
+    #include <camera/NdkCameraWindowType.h>
+    #include <camera/NdkCaptureRequest.h>
+}
+#undef __ANDROID_API__
+#define __ANDROID_API__ __ORIG_ANDROID_API__
+#undef __ORIG_ANDROID_API__
+
+// Helper macro to make calling camera NDK api's more type safe
+#define GET_CAMERA_FUNCTION(function) reinterpret_cast<decltype(&API24::function)>(GetCameraDynamicFunction(#function))
+
+static const int API_LEVEL{ android_get_device_api_level() };
+
+// Load the NDK camera lib dynamically. When running on OS 6.0 and below this will return nullptr,
+// on OS 7.0 and up this should return a pointer to access the library using dlsym. It is technically fine
+// to call dlopen when the API_LEVEL is below 24, but it's wasted effort on those devices.
+static void* libCamera2NDK{ API_LEVEL >= 24 ? dlopen("libcamera2ndk.so", RTLD_NOW | RTLD_LOCAL): nullptr };
+
+static std::map<std::string, void*> CameraDynamicFunctions{};
+
+static inline void* GetCameraDynamicFunction(const char* functionName)
+{
+    if (!libCamera2NDK)
+    {
+        return nullptr;
+    }
+    auto cameraDynamicFunctionIt{CameraDynamicFunctions.find(functionName)};
+    if (cameraDynamicFunctionIt == CameraDynamicFunctions.end())
+    {
+        cameraDynamicFunctionIt = CameraDynamicFunctions.emplace(functionName, dlsym(libCamera2NDK, functionName)).first;
+    }
+
+    return cameraDynamicFunctionIt->second;
+}

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
@@ -103,7 +103,9 @@ namespace Babylon::Plugins
 
         if (libCamera2NDK)
         {
-            return dlsym(libCamera2NDK, functionName);
+            auto functionPtr{dlsym(libCamera2NDK, functionName)};
+            m_cameraDynamicFunctions.emplace(functionName, functionPtr);
+            return functionPtr;
         }
 
         return nullptr;

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
@@ -2,6 +2,7 @@
 #include "NativeCamera.h"
 #include "NativeCameraImpl.h"
 #include <string>
+#include <android/api-level.h>
 #include <android/native_window_jni.h>
 #include <AndroidExtensions/Globals.h>
 #include <AndroidExtensions/Permissions.h>
@@ -14,6 +15,10 @@
 #include <arcana/threading/task_schedulers.h>
 #include <arcana/macros.h>
 #include <memory>
+#include <dlfcn.h>
+
+// Helper macro to make calling camera NDK api's more type safe
+#define GET_CAMERA_FUNCTION(function) reinterpret_cast<decltype(&API24::function)>(GetCameraDynamicFunction(#function))
 
 using namespace android;
 using namespace android::global;
@@ -39,8 +44,14 @@ namespace Babylon::Plugins
             oFragColor = texture(cameraTexture, cameraFrameUV);
         }
     )"};
-    
-#if __ANDROID_API__ >= 24
+
+    static const int API_LEVEL{ android_get_device_api_level() };
+
+    // Load the NDK camera lib dynamically. When running on OS 6.0 and below this will return nullptr,
+    // on OS 7.0 and up this should return a pointer to access the library using dlsym. It is technically fine
+    // to call dlopen when the API_LEVEL is below 24, but it's wasted effort on those devices.
+    static void* libCamera2NDK{ API_LEVEL >= 24 ? dlopen("libcamera2ndk.so", RTLD_NOW | RTLD_LOCAL): nullptr };
+
     GLuint Camera::Impl::GenerateOESTexture()
     {
         GLuint oesTexture;
@@ -54,8 +65,8 @@ namespace Babylon::Plugins
 
     std::string Camera::Impl::GetCameraId(bool frontCamera)
     {
-        ACameraIdList *cameraIds = nullptr;
-        ACameraManager_getCameraIdList(m_cameraManager, &cameraIds);
+        API24::ACameraIdList *cameraIds = nullptr;
+        GET_CAMERA_FUNCTION(ACameraManager_getCameraIdList)(m_cameraManager, &cameraIds);
 
         std::string cameraId{};
 
@@ -63,55 +74,70 @@ namespace Babylon::Plugins
         {
             const char *id = cameraIds->cameraIds[i];
 
-            ACameraMetadata *metadataObj;
-            ACameraManager_getCameraCharacteristics(m_cameraManager, id, &metadataObj);
+            API24::ACameraMetadata *metadataObj;
+            GET_CAMERA_FUNCTION(ACameraManager_getCameraCharacteristics)(m_cameraManager, id, &metadataObj);
 
-            ACameraMetadata_const_entry lensInfo = {};
-            ACameraMetadata_getConstEntry(metadataObj, ACAMERA_LENS_FACING, &lensInfo);
+            API24::ACameraMetadata_const_entry lensInfo = {};
+            GET_CAMERA_FUNCTION(ACameraMetadata_getConstEntry)(metadataObj, API24::ACAMERA_LENS_FACING, &lensInfo);
 
-            auto facing = static_cast<acamera_metadata_enum_android_lens_facing_t>(lensInfo.data.u8[0]);
+            auto facing = static_cast<API24::acamera_metadata_enum_android_lens_facing_t>(lensInfo.data.u8[0]);
 
             // Found a corresponding facing camera?
-            if (facing == (frontCamera ? ACAMERA_LENS_FACING_FRONT : ACAMERA_LENS_FACING_BACK))
+            if (facing == (frontCamera ? API24::ACAMERA_LENS_FACING_FRONT : API24::ACAMERA_LENS_FACING_BACK))
             {
                 cameraId = id;
                 break;
             }
         }
 
-        ACameraManager_deleteCameraIdList(cameraIds);
+        GET_CAMERA_FUNCTION(ACameraManager_deleteCameraIdList)(cameraIds);
         return cameraId;
     }
 
+    void* Camera::Impl::GetCameraDynamicFunction(const char* functionName)
+    {
+        if (m_cameraDynamicFunctions.count(functionName) > 0)
+        {
+            return m_cameraDynamicFunctions.at(functionName);
+        }
+
+        if (libCamera2NDK)
+        {
+            return dlsym(libCamera2NDK, functionName);
+        }
+
+        return nullptr;
+    }
+
     // device callbacks
-    static void onDisconnected(void* /*context*/, ACameraDevice* /*device*/)
+    static void onDisconnected(void* /*context*/, API24::ACameraDevice* /*device*/)
     {
     }
 
-    static void onError(void* /*context*/, ACameraDevice* /*device*/, int /*error*/)
+    static void onError(void* /*context*/, API24::ACameraDevice* /*device*/, int /*error*/)
     {
     }
 
-    static ACameraDevice_stateCallbacks cameraDeviceCallbacks = {
+    static API24::ACameraDevice_stateCallbacks cameraDeviceCallbacks = {
             .context = nullptr,
             .onDisconnected = onDisconnected,
             .onError = onError
     };
 
     // session callbacks
-    static void onSessionActive(void* /*context*/, ACameraCaptureSession* /*session*/)
+    static void onSessionActive(void* /*context*/, API24::ACameraCaptureSession* /*session*/)
     {
     }
 
-    static void onSessionReady(void* /*context*/, ACameraCaptureSession* /*session*/)
+    static void onSessionReady(void* /*context*/, API24::ACameraCaptureSession* /*session*/)
     {
     }
 
-    static void onSessionClosed(void* /*context*/, ACameraCaptureSession* /*session*/)
+    static void onSessionClosed(void* /*context*/, API24::ACameraCaptureSession* /*session*/)
     {
     }
 
-    static ACameraCaptureSession_stateCallbacks sessionStateCallbacks {
+    static API24::ACameraCaptureSession_stateCallbacks sessionStateCallbacks {
         .context = nullptr,
         .onClosed = onSessionClosed,
         .onReady = onSessionReady,
@@ -119,23 +145,23 @@ namespace Babylon::Plugins
     };
 
     // capture callbacks
-    static void onCaptureFailed(void* /*context*/, ACameraCaptureSession* /*session*/, ACaptureRequest* /*request*/, ACameraCaptureFailure* /*failure*/)
+    static void onCaptureFailed(void* /*context*/, API24::ACameraCaptureSession* /*session*/, API24::ACaptureRequest* /*request*/, API24::ACameraCaptureFailure* /*failure*/)
     {
     }
 
-    static void onCaptureSequenceCompleted(void* /*context*/, ACameraCaptureSession* /*session*/, int /*sequenceId*/, int64_t /*frameNumber*/)
+    static void onCaptureSequenceCompleted(void* /*context*/, API24::ACameraCaptureSession* /*session*/, int /*sequenceId*/, int64_t /*frameNumber*/)
     {
     }
 
-    static void onCaptureSequenceAborted(void* /*context*/, ACameraCaptureSession* /*session*/, int /*sequenceId*/)
+    static void onCaptureSequenceAborted(void* /*context*/, API24::ACameraCaptureSession* /*session*/, int /*sequenceId*/)
     {
     }
 
-    static void onCaptureCompleted (void* /*context*/, ACameraCaptureSession* /*session*/, ACaptureRequest* /*request*/, const ACameraMetadata* /*result*/)
+    static void onCaptureCompleted (void* /*context*/, API24::ACameraCaptureSession* /*session*/, API24::ACaptureRequest* /*request*/, const API24::ACameraMetadata* /*result*/)
     {
     }
 
-    static ACameraCaptureSession_captureCallbacks captureCallbacks {
+    static API24::ACameraCaptureSession_captureCallbacks captureCallbacks {
         .context = nullptr,
         .onCaptureStarted = nullptr,
         .onCaptureProgressed = nullptr,
@@ -146,32 +172,28 @@ namespace Babylon::Plugins
         .onCaptureBufferLost = nullptr,
     };
 
-#endif
-
     Camera::Impl::Impl(Napi::Env env, bool overrideCameraTexture)
         : m_deviceContext{nullptr}
         , m_env{env}
         , m_overrideCameraTexture{overrideCameraTexture}
     {
-#if __ANDROID_API__ < 24
-        if (!overrideCameraTexture)
+        if (API_LEVEL < 24 && !overrideCameraTexture)
         {
             throw std::runtime_error{"Android Platform level < 24. Only camera texture override is available."};
         }
-#endif
     }
 
     Camera::Impl::~Impl()
     {
     }
 
-    void Camera::Impl::Open(uint32_t width, uint32_t height, bool frontCamera)
+    arcana::task<void, std::exception_ptr> Camera::Impl::Open(uint32_t width, uint32_t height, bool frontCamera)
     {
         if (!m_deviceContext){
             m_deviceContext = &Graphics::DeviceContext::GetFromJavaScript(m_env);
         }
 
-        android::Permissions::CheckCameraPermissionAsync().then(arcana::inline_scheduler, arcana::cancellation::none(), [this, width, height, frontCamera]()
+        return android::Permissions::CheckCameraPermissionAsync().then(arcana::inline_scheduler, arcana::cancellation::none(), [this, width, height, frontCamera]()
         {
             m_width = width;
             m_height = height;
@@ -230,9 +252,7 @@ namespace Babylon::Plugins
 
             m_cameraShaderProgramId = android::OpenGLHelpers::CreateShaderProgram(CAMERA_VERT_SHADER, CAMERA_FRAG_SHADER);
 
-#if __ANDROID_API__ >= 24
-            if (!m_overrideCameraTexture)
-            {
+            if (API_LEVEL >= 24 && libCamera2NDK && !m_overrideCameraTexture) {
                 m_cameraOESTextureId = GenerateOESTexture();
 
                 // Create the surface and surface texture that will receive the camera preview
@@ -240,37 +260,43 @@ namespace Babylon::Plugins
                 android::view::Surface surface(m_surfaceTexture);
 
                 // open the front or back camera
-                m_cameraManager = ACameraManager_create();
+                m_cameraManager = GET_CAMERA_FUNCTION(ACameraManager_create)();
                 auto id = GetCameraId(frontCamera);
-                ACameraManager_openCamera(m_cameraManager, id.c_str(), &cameraDeviceCallbacks, &m_cameraDevice);
+                GET_CAMERA_FUNCTION(ACameraManager_openCamera)(m_cameraManager, id.c_str(),
+                                                               &cameraDeviceCallbacks,
+                                                               &m_cameraDevice);
 
-                m_textureWindow = ANativeWindow_fromSurface(GetEnvForCurrentThread(), surface);
+                m_textureWindow = reinterpret_cast<API24::ANativeWindow *>(ANativeWindow_fromSurface(
+                        GetEnvForCurrentThread(), surface));
 
                 // Prepare request for texture target
-                ACameraDevice_createCaptureRequest(m_cameraDevice, TEMPLATE_PREVIEW, &m_request);
+                GET_CAMERA_FUNCTION(ACameraDevice_createCaptureRequest)(m_cameraDevice,
+                                                                        API24::TEMPLATE_PREVIEW,
+                                                                        &m_request);
 
                 // Prepare outputs for session
-                ACaptureSessionOutput_create(m_textureWindow, &m_textureOutput);
-                ACaptureSessionOutputContainer_create(&m_outputs);
-                ACaptureSessionOutputContainer_add(m_outputs, m_textureOutput);
+                GET_CAMERA_FUNCTION(ACaptureSessionOutput_create)(m_textureWindow,
+                                                                  &m_textureOutput);
+                GET_CAMERA_FUNCTION(ACaptureSessionOutputContainer_create)(&m_outputs);
+                GET_CAMERA_FUNCTION(ACaptureSessionOutputContainer_add)(m_outputs, m_textureOutput);
 
                 // Prepare target surface
-                ANativeWindow_acquire(m_textureWindow);
-                ACameraOutputTarget_create(m_textureWindow, &m_textureTarget);
-                ACaptureRequest_addTarget(m_request, m_textureTarget);
+                GET_CAMERA_FUNCTION(ANativeWindow_acquire)(m_textureWindow);
+                GET_CAMERA_FUNCTION(ACameraOutputTarget_create)(m_textureWindow, &m_textureTarget);
+                GET_CAMERA_FUNCTION(ACaptureRequest_addTarget)(m_request, m_textureTarget);
 
                 // Create the session
-                ACameraDevice_createCaptureSession(m_cameraDevice, m_outputs, &sessionStateCallbacks, &m_textureSession);
+                GET_CAMERA_FUNCTION(ACameraDevice_createCaptureSession)(m_cameraDevice, m_outputs,
+                                                                        &sessionStateCallbacks,
+                                                                        &m_textureSession);
 
                 // Start capturing continuously
-                ACameraCaptureSession_setRepeatingRequest(m_textureSession, &captureCallbacks, 1, &m_request, nullptr);
+                GET_CAMERA_FUNCTION(ACameraCaptureSession_setRepeatingRequest)(m_textureSession,
+                                                                               &captureCallbacks,
+                                                                               1, &m_request,
+                                                                               nullptr);
             }
-#else
 
-            UNUSED(frontCamera);
-#pragma message("Warning: Android Platform level < 24. No HW Camera support. Only camera texture override is available.")
-
-#endif
             if (eglMakeCurrent(m_display, 0/*surface*/, 0/*surface*/, currentContext) == EGL_FALSE)
             {
                 throw std::runtime_error{"Unable to restore GL context for camera texture init."};
@@ -299,12 +325,11 @@ namespace Babylon::Plugins
             }
         }
 
-#if __ANDROID_API__ >= 24
-        if (!m_overrideCameraTexture)
+        if (API_LEVEL >= 24 && !m_overrideCameraTexture)
         {
             m_surfaceTexture.updateTexImage();
         }
-#endif
+
         glBindFramebuffer(GL_FRAMEBUFFER, m_frameBufferId);
         glViewport(0, 0, m_width, m_height);
         glUseProgram(m_cameraShaderProgramId);
@@ -335,23 +360,22 @@ namespace Babylon::Plugins
 
     void Camera::Impl::Close()
     {
-#if __ANDROID_API__ >= 24
-        if (!m_overrideCameraTexture)
+        if (API_LEVEL >= 24 && !m_overrideCameraTexture)
         {
             // Stop recording to SurfaceTexture and do some cleanup
-            ACameraCaptureSession_stopRepeating(m_textureSession);
-            ACameraCaptureSession_close(m_textureSession);
-            ACaptureSessionOutputContainer_free(m_outputs);
-            ACaptureSessionOutput_free(m_output);
+            GET_CAMERA_FUNCTION(ACameraCaptureSession_stopRepeating)(m_textureSession);
+            GET_CAMERA_FUNCTION(ACameraCaptureSession_close)(m_textureSession);
+            GET_CAMERA_FUNCTION(ACaptureSessionOutputContainer_free)(m_outputs);
+            GET_CAMERA_FUNCTION(ACaptureSessionOutput_free)(m_output);
 
-            ACameraDevice_close(m_cameraDevice);
-            ACameraManager_delete(m_cameraManager);
+            GET_CAMERA_FUNCTION(ACameraDevice_close)(m_cameraDevice);
+            GET_CAMERA_FUNCTION(ACameraManager_delete)(m_cameraManager);
 
             // Capture request for SurfaceTexture
             ANativeWindow_release(m_textureWindow);
-            ACaptureRequest_free(m_request);
+            GET_CAMERA_FUNCTION(ACaptureRequest_free)(m_request);
         }
-#endif
+
         if (m_context != EGL_NO_CONTEXT)
         {
             eglDestroyContext(m_display, m_context);

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
@@ -1,14 +1,27 @@
 #pragma once
 
-#include <camera/NdkCameraManager.h>
-#include <camera/NdkCameraCaptureSession.h>
-#include <camera/NdkCameraDevice.h>
-#include <camera/NdkCameraError.h>
-#include <camera/NdkCameraManager.h>
-#include <camera/NdkCameraMetadata.h>
-#include <camera/NdkCameraMetadataTags.h>
-#include <camera/NdkCameraWindowType.h>
-#include <camera/NdkCaptureRequest.h>
+// The camera API's in the NDK are only supported in API24 and higher. We
+// use dlopen and dlsym to link the camera lib at runtime only if the current
+// device supports it. In order to avoid redefining the type information the
+// below macro's forcefully import the camera header files as if the min supported
+// SDK was set to 24.
+#define __ORIG_ANDROID_API__ __ANDROID_API__
+#undef __ANDROID_API__
+#define __ANDROID_API__ 24
+namespace API24 {
+    #include <camera/NdkCameraManager.h>
+    #include <camera/NdkCameraCaptureSession.h>
+    #include <camera/NdkCameraDevice.h>
+    #include <camera/NdkCameraError.h>
+    #include <camera/NdkCameraManager.h>
+    #include <camera/NdkCameraMetadata.h>
+    #include <camera/NdkCameraMetadataTags.h>
+    #include <camera/NdkCameraWindowType.h>
+    #include <camera/NdkCaptureRequest.h>
+}
+#undef __ANDROID_API__
+#define __ANDROID_API__ __ORIG_ANDROID_API__
+
 #include <media/NdkImageReader.h>
 #include <bgfx/bgfx.h>
 #include <napi/napi.h>
@@ -16,6 +29,7 @@
 #include <Babylon/Graphics/DeviceContext.h>
 #include <AndroidExtensions/OpenGLHelpers.h>
 #include <AndroidExtensions/JavaWrappers.h>
+#include <arcana/threading/task.h>
 
 namespace Babylon::Plugins
 {
@@ -24,7 +38,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        void Open(uint32_t width, uint32_t height, bool frontCamera);
+        arcana::task<void, std::exception_ptr> Open(uint32_t width, uint32_t height, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();
@@ -39,21 +53,22 @@ namespace Babylon::Plugins
         uint32_t m_width{};
         uint32_t m_height{};
 
-#if __ANDROID_API__ >= 24
         GLuint GenerateOESTexture();
         std::string GetCameraId(bool frontCamera);
+        void* GetCameraDynamicFunction(const char* functionName);
 
-        ACameraManager* m_cameraManager{};
-        ACameraDevice* m_cameraDevice{};
-        ACameraOutputTarget* m_textureTarget{};
-        ACaptureRequest* m_request{};
-        ANativeWindow* m_textureWindow{};
-        ACameraCaptureSession* m_textureSession{};
-        ACaptureSessionOutput* m_textureOutput{};
-        ACaptureSessionOutput* m_output{};
-        ACaptureSessionOutputContainer* m_outputs{};
+        std::map<std::string, void*> m_cameraDynamicFunctions{};
+        API24::ACameraManager* m_cameraManager{};
+        API24::ACameraDevice* m_cameraDevice{};
+        API24::ACameraOutputTarget* m_textureTarget{};
+        API24::ACaptureRequest* m_request{};
+        API24::ANativeWindow* m_textureWindow{};
+        API24::ACameraCaptureSession* m_textureSession{};
+        API24::ACaptureSessionOutput* m_textureOutput{};
+        API24::ACaptureSessionOutput* m_output{};
+        API24::ACaptureSessionOutputContainer* m_outputs{};
         android::graphics::SurfaceTexture m_surfaceTexture{};
-#endif
+
         GLuint m_cameraOESTextureId{};
         GLuint m_cameraRGBATextureId{};
         GLuint m_cameraShaderProgramId{};

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
@@ -1,27 +1,6 @@
 #pragma once
 
-// The camera API's in the NDK are only supported in API24 and higher. We
-// use dlopen and dlsym to link the camera lib at runtime only if the current
-// device supports it. In order to avoid redefining the type information the
-// below macro's forcefully import the camera header files as if the min supported
-// SDK was set to 24.
-#define __ORIG_ANDROID_API__ __ANDROID_API__
-#undef __ANDROID_API__
-#define __ANDROID_API__ 24
-namespace API24 {
-    #include <camera/NdkCameraManager.h>
-    #include <camera/NdkCameraCaptureSession.h>
-    #include <camera/NdkCameraDevice.h>
-    #include <camera/NdkCameraError.h>
-    #include <camera/NdkCameraManager.h>
-    #include <camera/NdkCameraMetadata.h>
-    #include <camera/NdkCameraMetadataTags.h>
-    #include <camera/NdkCameraWindowType.h>
-    #include <camera/NdkCaptureRequest.h>
-}
-#undef __ANDROID_API__
-#define __ANDROID_API__ __ORIG_ANDROID_API__
-
+#include "CameraWrappers.h"
 #include <media/NdkImageReader.h>
 #include <bgfx/bgfx.h>
 #include <napi/napi.h>
@@ -55,9 +34,7 @@ namespace Babylon::Plugins
 
         GLuint GenerateOESTexture();
         std::string GetCameraId(bool frontCamera);
-        void* GetCameraDynamicFunction(const char* functionName);
 
-        std::map<std::string, void*> m_cameraDynamicFunctions{};
         API24::ACameraManager* m_cameraManager{};
         API24::ACameraDevice* m_cameraDevice{};
         API24::ACameraOutputTarget* m_textureTarget{};

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
@@ -4,6 +4,7 @@
 #include <napi/napi.h>
 #include <NativeCamera.h>
 #include <Babylon/Graphics/DeviceContext.h>
+#include <arcana/threading/task.h>
 
 namespace Babylon::Plugins
 {
@@ -14,7 +15,7 @@ namespace Babylon::Plugins
         
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        void Open(uint32_t width, uint32_t height, bool frontCamera);
+        arcana::task<void, std::exception_ptr> Open(uint32_t width, uint32_t height, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -58,7 +58,7 @@ namespace Babylon::Plugins
     {
     }
 
-    void Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool frontCamera)
+    arcana::task<void, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool frontCamera)
     {
         auto metalDevice = (id<MTLDevice>)bgfx::getInternalData()->context;
 
@@ -123,6 +123,9 @@ namespace Babylon::Plugins
             [m_implData->avCaptureSession commitConfiguration];
             [m_implData->avCaptureSession startRunning];
         });
+        
+        // This should capture an actual task and return it... but we'll deal with that later
+        return arcana::task_from_result<std::exception_ptr>();
     }
 
     void Camera::Impl::SetTextureOverride(void* /*texturePtr*/)

--- a/Plugins/NativeCamera/Source/NativeVideo.h
+++ b/Plugins/NativeCamera/Source/NativeVideo.h
@@ -2,6 +2,7 @@
 #include <napi/napi.h>
 #include "NativeCameraImpl.h"
 #include <Babylon/JsRuntime.h>
+#include <Babylon/JsRuntimeScheduler.h>
 #include <Babylon/Graphics/DeviceContext.h>
 #include <vector>
 #include <algorithm>
@@ -35,6 +36,8 @@ namespace Babylon::Plugins
         Napi::Value IsNative(const Napi::CallbackInfo&);
         Napi::Value GetReadyState(const Napi::CallbackInfo& info);
         Napi::Value GetHaveCurrentData(const Napi::CallbackInfo& info);
+
+        JsRuntimeScheduler m_runtimeScheduler;
 
         std::unordered_map<std::string, std::vector<Napi::FunctionReference>> m_eventHandlerRefs{};
         uint32_t m_width{};

--- a/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.cpp
@@ -11,7 +11,7 @@ namespace Babylon::Plugins
     {
     }
 
-    void Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
+    arcana::task<void, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
     {
         throw std::runtime_error{ "HW Camera not implemented for this platform." };
     }

--- a/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.h
@@ -3,6 +3,7 @@
 #include <bgfx/bgfx.h>
 #include <napi/napi.h>
 #include <NativeCamera.h>
+#include <arcana/threading/task.h>
 
 namespace Babylon::Plugins
 {
@@ -11,7 +12,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        void Open(uint32_t width, uint32_t height, bool frontCamera);
+        arcana::task<void, std::exception_ptr> Open(uint32_t width, uint32_t height, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.cpp
@@ -11,7 +11,7 @@ namespace Babylon::Plugins
     {
     }
 
-    void Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
+    arcana::task<void, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
     {
         throw std::runtime_error{ "HW Camera not implemented for this platform." };
     }

--- a/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.h
@@ -3,6 +3,7 @@
 #include <bgfx/bgfx.h>
 #include <napi/napi.h>
 #include <NativeCamera.h>
+#include <arcana/threading/task.h>
 
 namespace Babylon::Plugins
 {
@@ -11,7 +12,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        void Open(uint32_t width, uint32_t height, bool frontCamera);
+        arcana::task<void, std::exception_ptr> Open(uint32_t width, uint32_t height, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.cpp
@@ -11,7 +11,7 @@ namespace Babylon::Plugins
     {
     }
 
-    void Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
+    arcana::task<void, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
     {
         throw std::runtime_error{ "HW Camera not implemented for this platform." };
     }

--- a/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.h
@@ -3,6 +3,7 @@
 #include <bgfx/bgfx.h>
 #include <napi/napi.h>
 #include <NativeCamera.h>
+#include <arcana/threading/task.h>
 
 namespace Babylon::Plugins
 {
@@ -11,7 +12,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        void Open(uint32_t width, uint32_t height, bool frontCamera);
+        arcana::task<void, std::exception_ptr> Open(uint32_t width, uint32_t height, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();


### PR DESCRIPTION
This PR addresses a couple issues with the NativeCamera implementation. The first issue was that the `NativeCamera::Open` method returned a promise in an already completed state. For iOS this doesn't seem to be a problem. On Android it works so long as the permissions to use the camera were previously granted leading to the function executing synchronously. On Android if the permission prompt was showing the call to update the texture would be called while the Open method was still initializing leading to an error thrown trying to access the graphic context member variable. The fix was to have the `NativeCamera::Open` method return a promise in an uncompleted state and only complete it after the internal async work has finished.

The second issue this PR address was that the NativeCameraImpl for Android was using if defs to access the NDK camera API which requires Android API 24 or higher. That means that the consumer can only use NativeCamera if they define their minimum supported API as 24 or higher. This poses problems for BabylonReactNative where the BabylonNative library is pre-compiled against API 21. Another curveball is that on Android all symbols for a library must be fulfilled at the time of loading. That means a library statically linked against a specific API often cannot be loaded on a device running an older API ([more info](https://developer.android.com/ndk/guides/sdk-versions#compilesdkversion)).

This PR changes from using pre-processor arguments to access the newer API's to using dynamic linking (`dlopen` and `dlsym`) to access the API at runtime. This means that the functionality requiring newer API support can still be accessed if the device OS supports it. Older devices still gracefully handle the scenario by using a runtime check to access the current devices API level support.

