### PR TITLE
Remove hack for cmake/android/ubuntu

### DIFF
--- a/.github/jobs/android.yml
+++ b/.github/jobs/android.yml
@@ -32,12 +32,6 @@ jobs:
         npm install
       displayName: 'Install JS engine NPMs'
       
-    - script: |
-        ls /usr/local/lib/android/sdk/cmake
-        rm -rf /usr/local/lib/android/sdk/cmake/3.22.1
-      condition: contains('${{ parameters.vmImage }}', 'ubuntu')
-      displayName: 'Uninstall SDK cmake'
-      
     - task: Gradle@2
       inputs:
           workingDirectory: 'Apps/Playground/Android'

--- a/Apps/Playground/Android/app/build.gradle
+++ b/Apps/Playground/Android/app/build.gradle
@@ -80,7 +80,7 @@ android {
 
     externalNativeBuild {
         cmake {
-            version '3.19.0+'
+            version '3.19.6'
             path 'CMakeLists.txt'
         }
     }

--- a/Apps/ValidationTests/Android/app/build.gradle
+++ b/Apps/ValidationTests/Android/app/build.gradle
@@ -75,7 +75,7 @@ android {
 
     externalNativeBuild {
         cmake {
-            version '3.19.0+'
+            version '3.19.6'
             path 'CMakeLists.txt'
         }
     }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,34 +16,21 @@ jobs:
 # Apple
   - template: .github/jobs/macos.yml
     parameters:
-      name: MacOS_Xcode12
-      vmImage: 'macOS-10.15'
-      xCodeVersion: 12.4
-
-  - template: .github/jobs/macos.yml
-    parameters:
       name: MacOS_Xcode13
-      vmImage: 'macOS-11'
+      vmImage: 'macOS-latest'
       xCodeVersion: 13.0
 
   - template: .github/jobs/ios.yml
     parameters:
-      name: iOS_Xcode12_iOS13
-      vmImage: 'macOS-10.15'
-      xCodeVersion: 12.4
-      deploymentTarget: 13
-
-  - template: .github/jobs/ios.yml
-    parameters:
       name: iOS_Xcode12_iOS14
-      vmImage: 'macOS-10.15'
+      vmImage: 'macOS-latest'
       xCodeVersion: 12.4
       deploymentTarget: 14
 
   - template: .github/jobs/ios.yml
     parameters:
       name: iOS_Xcode13_iOS15
-      vmImage: 'macOS-11'
+      vmImage: 'macOS-latest'
       xCodeVersion: 13.0
       deploymentTarget: 15
 
@@ -149,11 +136,11 @@ jobs:
   - template: .github/jobs/android.yml
     parameters:
       name: Android_MacOS_JSC
-      vmImage: 'macOS-10.15'
+      vmImage: 'macOS-latest'
       JSEngine: jsc
 
   - template: .github/jobs/android.yml
     parameters:
       name: Android_MacOS_V8
-      vmImage: 'macOS-10.15'
+      vmImage: 'macOS-latest'
       JSEngine: v8android


### PR DESCRIPTION
- Remove yesterday's hack (removing cmake 3.22.1 from Android toolchain)
- Set the CMake version to 3.19.6 instead of 3.19.0+
- set MacOS VM to latest instead of 10.15 so we will not realized 10.15 is removed when builds start failing
- Removed iOS 13 build
- Removed MacOS 10.15 build with xCode 12.4