### PR TITLE
Improve resolution selection and orientation handling for Native Camera on iOS

### DIFF
--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -15,7 +15,7 @@ var xrFeaturePoints = false;
 var meshDetection = false;
 var text = false;
 var hololens = false;
-var cameraTexture = false;
+var cameraTexture = true;
 var imageTracking = false;
 const readPixels = false;
 
@@ -63,8 +63,11 @@ CreateBoxAsync(scene).then(function () {
 //BABYLON.SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ClearCoatTest/glTF/ClearCoatTest.gltf").then(function () {
     BABYLON.Tools.Log("Loaded");
 
-    scene.createDefaultCamera(true, true, true);
-    scene.activeCamera.alpha += Math.PI;
+    // This creates and positions a free camera (non-mesh)
+    var camera = new BABYLON.FreeCamera("camera1", new BABYLON.Vector3(0, 1, -10), scene);
+
+    // This targets the camera to scene origin
+    camera.setTarget(new BABYLON.Vector3(0, 1, 0));
 
     if (ibl) {
         scene.createDefaultEnvironment({ createGround: false, createSkybox: false });
@@ -74,14 +77,21 @@ CreateBoxAsync(scene).then(function () {
     }
 
     if (cameraTexture) {
-        var cameraBox = BABYLON.Mesh.CreateBox("box1", 0.25);
+        scene.meshes[0].setEnabled(false);
+        var plane = BABYLON.MeshBuilder.CreatePlane("plane", {size: 7, sideOrientation: BABYLON.Mesh.DOUBLESIDE});
+        plane.rotation.y = Math.PI;
+        plane.rotation.z = Math.PI;
+
+        plane.position.y = 1;
+        
         var mat = new BABYLON.StandardMaterial("mat", scene);
         mat.diffuseColor = BABYLON.Color3.Black();
 
-        BABYLON.VideoTexture.CreateFromWebCam(scene, function (videoTexture) {
+        var tex = BABYLON.VideoTexture.CreateFromWebCam(scene, function(videoTexture) {
             mat.emissiveTexture = videoTexture;
-            cameraBox.material = mat;
-        }, { maxWidth: 256, maxHeight: 256, facingMode: "environment" });
+            plane.material = mat;
+            console.log(videoTexture.getSize());
+        }, { minWidth: 1281, minHeight: 721, facingMode: 'user'});
     }
 
     if (readPixels) {

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -311,6 +311,7 @@ namespace Babylon::Plugins
 {
     if (self->orientationUpdated)
     {
+        connection.videoMirrored = true;
         connection.videoOrientation = self->videoOrientation;
         self->orientationUpdated = false;
     }

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -74,12 +74,12 @@ namespace Babylon::Plugins
             CVMetalTextureCacheCreate(NULL, NULL, metalDevice, NULL, &m_implData->textureCache);
             m_implData->cameraTextureDelegate = [[CameraTextureDelegate alloc]init:m_implData];
             m_implData->avCaptureSession = [[AVCaptureSession alloc] init];
-            NSArray* deviceTypes{NULL};
             
             // Loop over all available camera configurations to find a config that most closely matches the constraints.
             AVCaptureDevice* bestDevice{NULL};
             AVCaptureDeviceFormat* bestFormat{NULL};
             uint32_t bestDiff{UINT32_MAX};
+            NSArray* deviceTypes{NULL};
             if (@available(iOS 13.0, *))
             {
                 // Ordered list of cameras by general usage quality.
@@ -120,7 +120,7 @@ namespace Babylon::Plugins
                         continue;
                     }
                     
-                    // Calculate the resolution differential to use a heuristic.
+                    // Calculate the resolution differential for height + width to use as a simple heuristic.
                     uint32_t resolutionDiff = resolution.width - minWidth + resolution.height - minHeight;
                     if (bestDevice == NULL || resolutionDiff < bestDiff)
                     {
@@ -138,7 +138,7 @@ namespace Babylon::Plugins
                 return;
             }
                        
-            // Lock camera device send set up camera format. If there a problem initialising the camera it will give an error.
+            // Lock camera device and set up camera format. If there a problem initialising the camera it will give an error.
             NSError *error;
             [bestDevice lockForConfiguration:&error];
             if (error != nil)
@@ -151,7 +151,7 @@ namespace Babylon::Plugins
             AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:bestDevice error:&error];
             [bestDevice unlockForConfiguration];
 
-            // Check for failed init
+            // Check for failed initialisation.
             if (!input)
             {
                 taskCompletionSource.complete(arcana::make_unexpected(std::make_exception_ptr(std::runtime_error{"Error Getting Camera Input"})));

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -248,7 +248,7 @@ namespace Babylon::Plugins
     self->orientationUpdated = true;
 #else
     // Orientation not supported on these devices.
-    self->videoOrientation = AVCaptureVideoOrientationUnknown;
+    self->videoOrientation = AVCaptureVideoOrientationPortrait;
     self->orientationUpdated = false;
 #endif
 
@@ -264,7 +264,7 @@ namespace Babylon::Plugins
     UIInterfaceOrientation orientation{UIInterfaceOrientationUnknown};
 #if (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_13_0)
     UIScene* scene = [[[sharedApplication connectedScenes] allObjects] firstObject];
-    return [(UIWindowScene*)scene interfaceOrientation];
+    orienation = [(UIWindowScene*)scene interfaceOrientation];
 #else
     if (@available(iOS 13.0, *)) {
         orientation = [[[[sharedApplication windows] firstObject] windowScene] interfaceOrientation];

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -80,17 +80,17 @@ namespace Babylon::Plugins
         __block arcana::task_completion_source<void, std::exception_ptr> taskCompletionSource{};
 
         dispatch_sync(dispatch_get_main_queue(), ^{
-            CVMetalTextureCacheCreate(NULL, NULL, metalDevice, NULL, &m_implData->textureCache);
+            CVMetalTextureCacheCreate(nullptr, nullptr, metalDevice, nullptr, &m_implData->textureCache);
             m_implData->cameraTextureDelegate = [[CameraTextureDelegate alloc]init:m_implData];
             m_implData->avCaptureSession = [[AVCaptureSession alloc] init];
             
 #if (TARGET_OS_IPHONE)
             // Loop over all available camera configurations to find a config that most closely matches the constraints.
-            AVCaptureDevice* bestDevice{NULL};
-            AVCaptureDeviceFormat* bestFormat{NULL};
+            AVCaptureDevice* bestDevice{nullptr};
+            AVCaptureDeviceFormat* bestFormat{nullptr};
             uint32_t bestPixelCount{0};
             uint32_t bestDimDiff{0};
-            NSArray* deviceTypes{NULL};
+            NSArray* deviceTypes{nullptr};
             bool foundExactMatch{false};
             if (@available(iOS 13.0, *))
             {
@@ -156,7 +156,7 @@ namespace Babylon::Plugins
             }
             
             // If no matching device, throw an error with the message "ConstraintError" which matches the behavior in the browser.
-            if (bestDevice == NULL)
+            if (bestDevice == nullptr)
             {
                 taskCompletionSource.complete(arcana::make_unexpected(
                     std::make_exception_ptr(std::runtime_error{"ConstraintError: Unable to match constraints to a supported camera configuration."})));
@@ -325,7 +325,7 @@ namespace Babylon::Plugins
     MTLPixelFormat pixelFormat{MTLPixelFormatBGRA8Unorm};
     
     CVMetalTextureRef texture{nullptr};
-    CVReturn status{CVMetalTextureCacheCreateTextureFromImage(NULL, implData->textureCache, pixelBuffer, NULL, pixelFormat, width, height, 0, &texture)};
+    CVReturn status{CVMetalTextureCacheCreateTextureFromImage(nullptr, implData->textureCache, pixelBuffer, nullptr, pixelFormat, width, height, 0, &texture)};
     if (status == kCVReturnSuccess)
     {
         textureBGRA = CVMetalTextureGetTexture(texture);

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -114,7 +114,7 @@ namespace Babylon::Plugins
                     CMVideoFormatDescriptionRef videoFormatRef = static_cast<CMVideoFormatDescriptionRef>(format.formatDescription);
                     CMVideoDimensions resolution = CMVideoFormatDescriptionGetDimensions(videoFormatRef);
                     
-                    // Reject any resolution that does qualify for the constraint.
+                    // Reject any resolution that doesn't qualify for the constraint.
                     if (static_cast<uint32_t>(resolution.width) > maxWidth || static_cast<uint32_t>(resolution.height) > maxHeight)
                     {
                         continue;
@@ -131,7 +131,7 @@ namespace Babylon::Plugins
                 }
             }
             
-            // If no matching device, throw an error "ConstraintError" which matches the behavior in the browser.
+            // If no matching device, throw an error with the message "ConstraintError" which matches the behavior in the browser.
             if (bestDevice == NULL)
             {
                 taskCompletionSource.complete(arcana::make_unexpected(std::make_exception_ptr(std::runtime_error{"ConstraintError"})));

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -61,10 +61,10 @@ namespace Babylon::Plugins
 
     arcana::task<void, std::exception_ptr> Camera::Impl::Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
     {
-        if (maxWidth == 0) {
+        if (maxWidth == 0 || maxWidth > INT32_MAX) {
             maxWidth = INT32_MAX;
         }
-        if (maxHeight == 0) {
+        if (maxHeight == 0 || maxHeight > INT32_MAX) {
             maxHeight = INT32_MAX;
         }
         

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -111,11 +111,10 @@ namespace Babylon::Plugins
                     }
                 }
             }
-            
+                       
+            // Set video capture input: If there a problem initialising the camera, it will give an error.
             NSError *error;
-
-            // Set video capture input: If there a problem initialising the camera, it will give am error.
-            [bestDevice lockForConfiguration:nil];
+            [bestDevice lockForConfiguration:&error];
             [bestDevice setActiveFormat:bestFormat];
             AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:bestDevice error:&error];
             [bestDevice unlockForConfiguration];

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -118,6 +118,7 @@ namespace Babylon::Plugins
             [bestDevice lockForConfiguration:nil];
             [bestDevice setActiveFormat:bestFormat];
             AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:bestDevice error:&error];
+            [bestDevice unlockForConfiguration];
 
             if (!input) {
                 taskCompletionSource.complete(arcana::make_unexpected(std::make_exception_ptr(std::runtime_error{"Error Getting Camera Input"})));

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -178,6 +178,7 @@ namespace Babylon::Plugins
             UNUSED(maxWidth);
             UNUSED(maxHeight);
             UNUSED(frontCamera);
+            NSError *error{nil};
             AVCaptureDevice* captureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
             AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:captureDevice error:&error];
 #endif

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -264,7 +264,7 @@ namespace Babylon::Plugins
     UIInterfaceOrientation orientation{UIInterfaceOrientationUnknown};
 #if (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_13_0)
     UIScene* scene = [[[sharedApplication connectedScenes] allObjects] firstObject];
-    orienation = [(UIWindowScene*)scene interfaceOrientation];
+    orientation = [(UIWindowScene*)scene interfaceOrientation];
 #else
     if (@available(iOS 13.0, *)) {
         orientation = [[[[sharedApplication windows] firstObject] windowScene] interfaceOrientation];


### PR DESCRIPTION
This PR improves resolution selection and orientation handling for Native Camera sessions on iOS.  As outlined in #1107 currently we are just taking the highest resolution setting on the camera ignoring the constraints set for maxWidth and maxHeight.   Additionally currently we are not making any adjustments to the outputted video texture for device orientation.  This PR fixes this so the output texture is oriented in a way that aligns with the screen.

Landscape before:
![Before landscape](https://user-images.githubusercontent.com/27031140/185494275-f36fe5e7-cda9-46d8-9633-7d813b1d42b6.png)

Landscape after:
![After landscape](https://user-images.githubusercontent.com/27031140/185494261-2eeb7369-d587-4f80-8a69-3b86fe67ec35.png)

Portrait before:
![Portrait Before](https://user-images.githubusercontent.com/27031140/185494496-b47f6460-a884-46bc-b556-cea13b9adc77.png)

Portrait after:
![Portrait after](https://user-images.githubusercontent.com/27031140/185494278-0c9bbded-9a96-46f3-934f-9bfcdeda4198.png)

