### PR TITLE
Push camera dimensions back to NativeVideo texture

### DIFF
--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -90,8 +90,8 @@ CreateBoxAsync(scene).then(function () {
         var tex = BABYLON.VideoTexture.CreateFromWebCam(scene, function(videoTexture) {
             mat.emissiveTexture = videoTexture;
             plane.material = mat;
-            console.log(videoTexture.getSize());
-        }, { minWidth: 1281, minHeight: 721, facingMode: 'user'});
+            console.log("Video texture size: " videoTexture.getSize());
+        }, { maxWidth: 1280, maxHeight: 720, facingMode: 'environment'});
     }
 
     if (readPixels) {

--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -90,7 +90,7 @@ CreateBoxAsync(scene).then(function () {
         var tex = BABYLON.VideoTexture.CreateFromWebCam(scene, function(videoTexture) {
             mat.emissiveTexture = videoTexture;
             plane.material = mat;
-            console.log("Video texture size: " videoTexture.getSize());
+            console.log("Video texture size: " + videoTexture.getSize());
         }, { maxWidth: 1280, maxHeight: 720, facingMode: 'environment'});
     }
 

--- a/Plugins/NativeCamera/Include/Babylon/Plugins/NativeCamera.h
+++ b/Plugins/NativeCamera/Include/Babylon/Plugins/NativeCamera.h
@@ -7,11 +7,6 @@ namespace Babylon::Plugins
     class Camera final
     {
     public:
-        struct CameraDimensions {
-            uint32_t width;
-            uint32_t height;
-        };
-
         class Impl;
 
         Camera(const Camera& other) = default;

--- a/Plugins/NativeCamera/Include/Babylon/Plugins/NativeCamera.h
+++ b/Plugins/NativeCamera/Include/Babylon/Plugins/NativeCamera.h
@@ -7,6 +7,11 @@ namespace Babylon::Plugins
     class Camera final
     {
     public:
+        struct CameraDimensions {
+            uint32_t width;
+            uint32_t height;
+        };
+
         class Impl;
 
         Camera(const Camera& other) = default;

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
@@ -160,7 +160,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<Camera::CameraDimensions, std::exception_ptr> Camera::Impl::Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
+    arcana::task<Camera::Impl::CameraDimensions, std::exception_ptr> Camera::Impl::Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
     {
         if (!m_deviceContext){
             m_deviceContext = &Graphics::DeviceContext::GetFromJavaScript(m_env);

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
@@ -160,7 +160,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<Camera::CameraDimensions*, std::exception_ptr> Camera::Impl::Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
+    arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Camera::Impl::Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
     {
         if (!m_deviceContext){
             m_deviceContext = &Graphics::DeviceContext::GetFromJavaScript(m_env);
@@ -275,7 +275,7 @@ namespace Babylon::Plugins
                 throw std::runtime_error{"Unable to restore GL context for camera texture init."};
             }
 
-            return &m_cameraDimensions;
+            return static_cast<const Camera::CameraDimensions*>(&m_cameraDimensions);
         });
     }
 

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
@@ -160,17 +160,17 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<void, std::exception_ptr> Camera::Impl::Open(uint32_t width, uint32_t height, bool frontCamera)
+    arcana::task<Camera::CameraDimensions*, std::exception_ptr> Camera::Impl::Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
     {
         if (!m_deviceContext){
             m_deviceContext = &Graphics::DeviceContext::GetFromJavaScript(m_env);
         }
 
-        return android::Permissions::CheckCameraPermissionAsync().then(arcana::inline_scheduler, arcana::cancellation::none(), [this, width, height, frontCamera]()
+        return android::Permissions::CheckCameraPermissionAsync().then(arcana::inline_scheduler, arcana::cancellation::none(), [this, maxWidth, maxHeight, frontCamera]()
         {
-            m_width = width;
-            m_height = height;
-        
+            m_cameraDimensions.width = maxWidth;
+            m_cameraDimensions.height = maxHeight;
+
             // Check if there is an already available context for this thread
             EGLContext currentContext = eglGetCurrentContext();
             if (currentContext == EGL_NO_CONTEXT)
@@ -210,7 +210,7 @@ namespace Babylon::Plugins
 
             glGenTextures(1, &m_cameraRGBATextureId);
             glBindTexture(GL_TEXTURE_2D, m_cameraRGBATextureId);
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_width, m_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_cameraDimensions.width, m_cameraDimensions.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
             glGenerateMipmap(GL_TEXTURE_2D);
@@ -274,6 +274,8 @@ namespace Babylon::Plugins
             {
                 throw std::runtime_error{"Unable to restore GL context for camera texture init."};
             }
+
+            return &m_cameraDimensions;
         });
     }
 
@@ -304,7 +306,7 @@ namespace Babylon::Plugins
         }
 
         glBindFramebuffer(GL_FRAMEBUFFER, m_frameBufferId);
-        glViewport(0, 0, m_width, m_height);
+        glViewport(0, 0, m_cameraDimensions.width, m_cameraDimensions.height);
         glUseProgram(m_cameraShaderProgramId);
 
         // Configure the camera texture

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
@@ -160,7 +160,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Camera::Impl::Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
+    arcana::task<Camera::CameraDimensions, std::exception_ptr> Camera::Impl::Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
     {
         if (!m_deviceContext){
             m_deviceContext = &Graphics::DeviceContext::GetFromJavaScript(m_env);
@@ -275,7 +275,7 @@ namespace Babylon::Plugins
                 throw std::runtime_error{"Unable to restore GL context for camera texture init."};
             }
 
-            return static_cast<const Camera::CameraDimensions*>(&m_cameraDimensions);
+            return m_cameraDimensions;
         });
     }
 

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
@@ -17,7 +17,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
@@ -15,9 +15,14 @@ namespace Babylon::Plugins
     class Camera::Impl final : public std::enable_shared_from_this<Camera::Impl>
     {
     public:
+        struct CameraDimensions {
+            uint32_t width;
+            uint32_t height;
+        };
+
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<Camera::CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();
@@ -29,7 +34,7 @@ namespace Babylon::Plugins
 
         bool m_overrideCameraTexture;
 
-        Camera::CameraDimensions m_cameraDimensions{};
+        CameraDimensions m_cameraDimensions{};
 
         GLuint GenerateOESTexture();
         std::string GetCameraId(bool frontCamera);

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
@@ -17,7 +17,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<Camera::CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
@@ -17,7 +17,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<void, std::exception_ptr> Open(uint32_t width, uint32_t height, bool frontCamera);
+        arcana::task<Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();
@@ -29,8 +29,7 @@ namespace Babylon::Plugins
 
         bool m_overrideCameraTexture;
 
-        uint32_t m_width{};
-        uint32_t m_height{};
+        Camera::CameraDimensions m_cameraDimensions{};
 
         GLuint GenerateOESTexture();
         std::string GetCameraId(bool frontCamera);

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
@@ -10,17 +10,12 @@ namespace Babylon::Plugins
 {
     class Camera::Impl final : public std::enable_shared_from_this<Camera::Impl>
     {
-    public:
-        struct CameraDimensions {
-            uint32_t width;
-            uint32_t height;
-        };
-        
+    public:       
         struct ImplData;
         
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<CameraDimensions*, std::exception_ptr> Open(uint32_t width, uint32_t height, bool frontCamera);
+        arcana::task<Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
@@ -11,11 +11,16 @@ namespace Babylon::Plugins
     class Camera::Impl final : public std::enable_shared_from_this<Camera::Impl>
     {
     public:
+        struct CameraDimensions {
+            uint32_t width;
+            uint32_t height;
+        };
+
         struct ImplData;
         
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<Camera::CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
@@ -11,11 +11,16 @@ namespace Babylon::Plugins
     class Camera::Impl final : public std::enable_shared_from_this<Camera::Impl>
     {
     public:
+        struct CameraDimensions {
+            uint32_t width;
+            uint32_t height;
+        };
+        
         struct ImplData;
         
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<void, std::exception_ptr> Open(uint32_t width, uint32_t height, bool frontCamera);
+        arcana::task<CameraDimensions*, std::exception_ptr> Open(uint32_t width, uint32_t height, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();
@@ -25,7 +30,6 @@ namespace Babylon::Plugins
         Napi::Env m_env;
 
         std::shared_ptr<ImplData> m_implData;
-
         bool m_overrideCameraTexture{};
     };
 }

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
@@ -10,12 +10,12 @@ namespace Babylon::Plugins
 {
     class Camera::Impl final : public std::enable_shared_from_this<Camera::Impl>
     {
-    public:       
+    public:
         struct ImplData;
         
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();
@@ -25,6 +25,7 @@ namespace Babylon::Plugins
         Napi::Env m_env;
 
         std::shared_ptr<ImplData> m_implData;
+
         bool m_overrideCameraTexture{};
     };
 }

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
@@ -15,7 +15,7 @@ namespace Babylon::Plugins
         
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<Camera::CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -61,7 +61,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<Camera::CameraDimensions, std::exception_ptr> Camera::Impl::Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
+    arcana::task<Camera::Impl::CameraDimensions, std::exception_ptr> Camera::Impl::Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
     {
         if (maxWidth == 0 || maxWidth > std::numeric_limits<int32_t>::max()) {
             maxWidth = std::numeric_limits<int32_t>::max();
@@ -77,7 +77,7 @@ namespace Babylon::Plugins
             m_deviceContext = &Graphics::DeviceContext::GetFromJavaScript(m_env);
         }
         
-        __block arcana::task_completion_source<Camera::CameraDimensions, std::exception_ptr> taskCompletionSource{};
+        __block arcana::task_completion_source<Camera::Impl::CameraDimensions, std::exception_ptr> taskCompletionSource{};
 
         dispatch_sync(dispatch_get_main_queue(), ^{
             CVMetalTextureCacheCreate(nullptr, nullptr, metalDevice, nullptr, &m_implData->textureCache);
@@ -189,7 +189,7 @@ namespace Babylon::Plugins
             CMVideoDimensions dimensions{CMVideoFormatDescriptionGetDimensions(videoFormatRef)};
 #endif
             
-            Camera::CameraDimensions cameraDimensions{static_cast<uint32_t>(dimensions.width), static_cast<uint32_t>(dimensions.height)};
+            Camera::Impl::CameraDimensions cameraDimensions{static_cast<uint32_t>(dimensions.width), static_cast<uint32_t>(dimensions.height)};
             
             // Check for failed initialisation.
             if (!input)

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -47,7 +47,7 @@ namespace Babylon::Plugins
         CameraTextureDelegate* cameraTextureDelegate{};
         AVCaptureSession* avCaptureSession{};
         CVMetalTextureCacheRef textureCache{};
-        Camera::Impl::CameraDimensions dimensions{};
+        Camera::CameraDimensions dimensions{};
         id <MTLTexture> textureBGRA{};
     };
     Camera::Impl::Impl(Napi::Env env, bool overrideCameraTexture)
@@ -62,7 +62,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<Camera::Impl::CameraDimensions*, std::exception_ptr> Camera::Impl::Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
+    arcana::task<Camera::CameraDimensions*, std::exception_ptr> Camera::Impl::Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
     {
         if (maxWidth == 0 || maxWidth > std::numeric_limits<int32_t>::max()) {
             maxWidth = std::numeric_limits<int32_t>::max();
@@ -78,7 +78,7 @@ namespace Babylon::Plugins
             m_deviceContext = &Graphics::DeviceContext::GetFromJavaScript(m_env);
         }
         
-        __block arcana::task_completion_source<Camera::Impl::CameraDimensions*, std::exception_ptr> taskCompletionSource{};
+        __block arcana::task_completion_source<Camera::CameraDimensions*, std::exception_ptr> taskCompletionSource{};
 
         dispatch_sync(dispatch_get_main_queue(), ^{
             CVMetalTextureCacheCreate(nullptr, nullptr, metalDevice, nullptr, &m_implData->textureCache);

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -62,7 +62,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<Camera::CameraDimensions*, std::exception_ptr> Camera::Impl::Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
+    arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Camera::Impl::Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
     {
         if (maxWidth == 0 || maxWidth > std::numeric_limits<int32_t>::max()) {
             maxWidth = std::numeric_limits<int32_t>::max();
@@ -78,7 +78,7 @@ namespace Babylon::Plugins
             m_deviceContext = &Graphics::DeviceContext::GetFromJavaScript(m_env);
         }
         
-        __block arcana::task_completion_source<Camera::CameraDimensions*, std::exception_ptr> taskCompletionSource{};
+        __block arcana::task_completion_source<const Camera::CameraDimensions*, std::exception_ptr> taskCompletionSource{};
 
         dispatch_sync(dispatch_get_main_queue(), ^{
             CVMetalTextureCacheCreate(nullptr, nullptr, metalDevice, nullptr, &m_implData->textureCache);
@@ -216,7 +216,7 @@ namespace Babylon::Plugins
             [m_implData->avCaptureSession commitConfiguration];
             [m_implData->avCaptureSession startRunning];
             
-            taskCompletionSource.complete(&m_implData->dimensions);
+            taskCompletionSource.complete(static_cast<const Camera::CameraDimensions*>(&m_implData->dimensions));
         });
         
         return taskCompletionSource.as_task();

--- a/Plugins/NativeCamera/Source/NativeVideo.cpp
+++ b/Plugins/NativeCamera/Source/NativeVideo.cpp
@@ -157,9 +157,9 @@ namespace Babylon::Plugins
                 else
                 {
                     if (result.has_value()) {
-                        auto cameraInfo = result.value();
-                        this->m_width = cameraInfo->width;
-                        this->m_height = cameraInfo->height;
+                        auto cameraDimensions{result.value()};
+                        this->m_width = cameraDimensions->width;
+                        this->m_height = cameraDimensions->height;
                     }
                     deferred.Resolve(env.Undefined());
                     RaiseEvent("playing");

--- a/Plugins/NativeCamera/Source/NativeVideo.cpp
+++ b/Plugins/NativeCamera/Source/NativeVideo.cpp
@@ -149,7 +149,7 @@ namespace Babylon::Plugins
         if (!m_IsPlaying)
         {
             m_IsPlaying = true;
-            NativeCameraImpl->Open(m_width, m_height, m_frontCamera).then(m_runtimeScheduler, arcana::cancellation::none(), [this, env, deferred](const arcana::expected<Camera::Impl::CameraDimensions*, std::exception_ptr>& result) {
+            NativeCameraImpl->Open(m_width, m_height, m_frontCamera).then(m_runtimeScheduler, arcana::cancellation::none(), [this, env, deferred](const arcana::expected<Camera::CameraDimensions*, std::exception_ptr>& result) {
                 if (result.has_error())
                 {
                     deferred.Reject(Napi::Error::New(env, result.error()).Value());

--- a/Plugins/NativeCamera/Source/NativeVideo.cpp
+++ b/Plugins/NativeCamera/Source/NativeVideo.cpp
@@ -139,7 +139,7 @@ namespace Babylon::Plugins
         if (!m_IsPlaying)
         {
             m_IsPlaying = true;
-            NativeCameraImpl->Open(m_maxWidth, m_maxHeight, m_frontCamera).then(m_runtimeScheduler, arcana::cancellation::none(), [this, env, deferred](const arcana::expected<Camera::CameraDimensions, std::exception_ptr>& result) {
+            NativeCameraImpl->Open(m_maxWidth, m_maxHeight, m_frontCamera).then(m_runtimeScheduler, arcana::cancellation::none(), [this, env, deferred](const arcana::expected<Camera::Impl::CameraDimensions, std::exception_ptr>& result) {
                 if (result.has_error())
                 {
                     deferred.Reject(Napi::Error::New(env, result.error()).Value());

--- a/Plugins/NativeCamera/Source/NativeVideo.cpp
+++ b/Plugins/NativeCamera/Source/NativeVideo.cpp
@@ -149,13 +149,18 @@ namespace Babylon::Plugins
         if (!m_IsPlaying)
         {
             m_IsPlaying = true;
-            NativeCameraImpl->Open(m_width, m_height, m_frontCamera).then(m_runtimeScheduler, arcana::cancellation::none(), [this, env, deferred](const arcana::expected<void, std::exception_ptr>& result) {
+            NativeCameraImpl->Open(m_width, m_height, m_frontCamera).then(m_runtimeScheduler, arcana::cancellation::none(), [this, env, deferred](const arcana::expected<Camera::Impl::CameraDimensions*, std::exception_ptr>& result) {
                 if (result.has_error())
                 {
                     deferred.Reject(Napi::Error::New(env, result.error()).Value());
                 }
                 else
                 {
+                    if (result.has_value()) {
+                        auto cameraInfo = result.value();
+                        this->m_width = cameraInfo->width;
+                        this->m_height = cameraInfo->height;
+                    }
                     deferred.Resolve(env.Undefined());
                     RaiseEvent("playing");
                 }

--- a/Plugins/NativeCamera/Source/NativeVideo.cpp
+++ b/Plugins/NativeCamera/Source/NativeVideo.cpp
@@ -149,7 +149,7 @@ namespace Babylon::Plugins
         if (!m_IsPlaying)
         {
             m_IsPlaying = true;
-            NativeCameraImpl->Open(m_width, m_height, m_frontCamera).then(m_runtimeScheduler, arcana::cancellation::none(), [this, env, deferred](const arcana::expected<Camera::CameraDimensions*, std::exception_ptr>& result) {
+            NativeCameraImpl->Open(m_width, m_height, m_frontCamera).then(m_runtimeScheduler, arcana::cancellation::none(), [this, env, deferred](const arcana::expected<const Camera::CameraDimensions*, std::exception_ptr>& result) {
                 if (result.has_error())
                 {
                     deferred.Reject(Napi::Error::New(env, result.error()).Value());

--- a/Plugins/NativeCamera/Source/NativeVideo.cpp
+++ b/Plugins/NativeCamera/Source/NativeVideo.cpp
@@ -16,8 +16,8 @@ namespace Babylon::Plugins
                 InstanceMethod("play", &NativeVideo::Play),
                 InstanceMethod("pause", &NativeVideo::Pause),
                 InstanceMethod("setAttribute", &NativeVideo::SetAttribute),
-                InstanceAccessor("videoWidth", &NativeVideo::GetVideoWidth, &NativeVideo::SetVideoWidth),
-                InstanceAccessor("videoHeight", &NativeVideo::GetVideoHeight, &NativeVideo::SetVideoHeight),
+                InstanceAccessor("videoWidth", &NativeVideo::GetVideoWidth, nullptr),
+                InstanceAccessor("videoHeight", &NativeVideo::GetVideoHeight, nullptr),
                 InstanceAccessor("frontCamera", nullptr, &NativeVideo::SetFrontCamera),
                 InstanceAccessor("isNative", &NativeVideo::IsNative, nullptr),
                 InstanceAccessor("readyState", &NativeVideo::GetReadyState, nullptr),
@@ -37,25 +37,15 @@ namespace Babylon::Plugins
     NativeVideo::NativeVideo(const Napi::CallbackInfo& info)
         : Napi::ObjectWrap<NativeVideo>{ info }
         , m_runtimeScheduler{JsRuntime::GetFromJavaScript(info.Env())}
-        , m_width{ info[0].As<Napi::Number>().Uint32Value() }
-        , m_height{ info[1].As<Napi::Number>().Uint32Value() }
+        , m_maxWidth{ info[0].As<Napi::Number>().Uint32Value() }
+        , m_maxHeight{ info[1].As<Napi::Number>().Uint32Value() }
         , m_frontCamera{ info[2].As<Napi::Boolean>().Value() }
     {
-    }
-
-    void NativeVideo::SetVideoWidth(const Napi::CallbackInfo&, const Napi::Value& value)
-    {
-        m_width = value.As<Napi::Number>().Uint32Value();
     }
 
     Napi::Value NativeVideo::GetVideoWidth(const Napi::CallbackInfo& /*info*/)
     {
         return Napi::Value::From(Env(), m_width);
-    }
-
-    void NativeVideo::SetVideoHeight(const Napi::CallbackInfo&, const Napi::Value& value)
-    {
-        m_height = value.As<Napi::Number>().Uint32Value();
     }
 
     Napi::Value NativeVideo::GetVideoHeight(const Napi::CallbackInfo& /*info*/)
@@ -79,7 +69,7 @@ namespace Babylon::Plugins
 
     Napi::Value NativeVideo::GetReadyState(const Napi::CallbackInfo& /*info*/)
     {
-        return Napi::Value::From(Env(), 10u);
+        return Napi::Value::From(Env(), m_isReady ? 10u : 0u);
     }
 
     Napi::Value NativeVideo::GetHaveCurrentData(const Napi::CallbackInfo& /*info*/)
@@ -149,18 +139,17 @@ namespace Babylon::Plugins
         if (!m_IsPlaying)
         {
             m_IsPlaying = true;
-            NativeCameraImpl->Open(m_width, m_height, m_frontCamera).then(m_runtimeScheduler, arcana::cancellation::none(), [this, env, deferred](const arcana::expected<const Camera::CameraDimensions*, std::exception_ptr>& result) {
+            NativeCameraImpl->Open(m_maxWidth, m_maxHeight, m_frontCamera).then(m_runtimeScheduler, arcana::cancellation::none(), [this, env, deferred](const arcana::expected<Camera::CameraDimensions, std::exception_ptr>& result) {
                 if (result.has_error())
                 {
                     deferred.Reject(Napi::Error::New(env, result.error()).Value());
                 }
                 else
                 {
-                    if (result.has_value()) {
-                        auto cameraDimensions{result.value()};
-                        this->m_width = cameraDimensions->width;
-                        this->m_height = cameraDimensions->height;
-                    }
+                    auto cameraDimensions{result.value()};
+                    this->m_width = cameraDimensions.width;
+                    this->m_height = cameraDimensions.height;
+                    this->m_isReady = true;
                     deferred.Resolve(env.Undefined());
                     RaiseEvent("playing");
                 }

--- a/Plugins/NativeCamera/Source/NativeVideo.h
+++ b/Plugins/NativeCamera/Source/NativeVideo.h
@@ -27,9 +27,7 @@ namespace Babylon::Plugins
         void RaiseEvent(const char* eventType);
         Napi::Value Play(const Napi::CallbackInfo& info);
         void Pause(const Napi::CallbackInfo& info);
-        void SetVideoWidth(const Napi::CallbackInfo& info, const Napi::Value& value);
         Napi::Value GetVideoWidth(const Napi::CallbackInfo& info);
-        void SetVideoHeight(const Napi::CallbackInfo& info, const Napi::Value& value);
         Napi::Value GetVideoHeight(const Napi::CallbackInfo& info);
         void SetFrontCamera(const Napi::CallbackInfo& info, const Napi::Value& value);
         void SetAttribute(const Napi::CallbackInfo&);
@@ -40,8 +38,12 @@ namespace Babylon::Plugins
         JsRuntimeScheduler m_runtimeScheduler;
 
         std::unordered_map<std::string, std::vector<Napi::FunctionReference>> m_eventHandlerRefs{};
-        uint32_t m_width{};
-        uint32_t m_height{};
+        uint32_t m_maxWidth{};
+        uint32_t m_maxHeight{};
+
+        uint32_t m_width{0};
+        uint32_t m_height{0};
+        bool m_isReady{false};
         bool m_frontCamera{};
 
         bool m_IsPlaying{};

--- a/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.cpp
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<Camera::CameraDimensions, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
+    arcana::task<Camera::Impl::CameraDimensions, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
     {
         throw std::runtime_error{ "HW Camera not implemented for this platform." };
     }

--- a/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.cpp
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
+    arcana::task<Camera::CameraDimensions, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
     {
         throw std::runtime_error{ "HW Camera not implemented for this platform." };
     }

--- a/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.cpp
@@ -1,3 +1,4 @@
+#include "NativeCamera.h"
 #include "NativeCameraImpl.h"
 #include <napi/napi.h>
 
@@ -11,7 +12,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<void, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
+    arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
     {
         throw std::runtime_error{ "HW Camera not implemented for this platform." };
     }

--- a/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.h
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<void, std::exception_ptr> Open(uint32_t width, uint32_t height, bool frontCamera);
+        arcana::task<Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.h
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.h
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<Camera::CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/UWP/NativeCameraImpl.h
@@ -10,9 +10,14 @@ namespace Babylon::Plugins
     class Camera::Impl final : public std::enable_shared_from_this<Camera::Impl>
     {
     public:
+        struct CameraDimensions {
+            uint32_t width;
+            uint32_t height;
+        };
+
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<Camera::CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.cpp
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<Camera::CameraDimensions, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
+    arcana::task<Camera::Impl::CameraDimensions, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
     {
         throw std::runtime_error{ "HW Camera not implemented for this platform." };
     }

--- a/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.cpp
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
+    arcana::task<Camera::CameraDimensions, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
     {
         throw std::runtime_error{ "HW Camera not implemented for this platform." };
     }

--- a/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.cpp
@@ -1,3 +1,4 @@
+#include "NativeCamera.h"
 #include "NativeCameraImpl.h"
 #include <napi/napi.h>
 
@@ -11,7 +12,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<void, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
+    arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
     {
         throw std::runtime_error{ "HW Camera not implemented for this platform." };
     }

--- a/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.h
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<void, std::exception_ptr> Open(uint32_t width, uint32_t height, bool frontCamera);
+        arcana::task<Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.h
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.h
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<Camera::CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Unix/NativeCameraImpl.h
@@ -10,9 +10,14 @@ namespace Babylon::Plugins
     class Camera::Impl final : public std::enable_shared_from_this<Camera::Impl>
     {
     public:
+        struct CameraDimensions {
+            uint32_t width;
+            uint32_t height;
+        };
+
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<Camera::CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.cpp
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<Camera::CameraDimensions, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
+    arcana::task<Camera::Impl::CameraDimensions, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
     {
         throw std::runtime_error{ "HW Camera not implemented for this platform." };
     }

--- a/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.cpp
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
+    arcana::task<Camera::CameraDimensions, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
     {
         throw std::runtime_error{ "HW Camera not implemented for this platform." };
     }

--- a/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.cpp
@@ -1,3 +1,4 @@
+#include "NativeCamera.h"
 #include "NativeCameraImpl.h"
 #include <napi/napi.h>
 
@@ -11,7 +12,7 @@ namespace Babylon::Plugins
     {
     }
 
-    arcana::task<void, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
+    arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Camera::Impl::Open(uint32_t /*width*/, uint32_t /*height*/, bool /*frontCamera*/)
     {
         throw std::runtime_error{ "HW Camera not implemented for this platform." };
     }

--- a/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.h
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<void, std::exception_ptr> Open(uint32_t width, uint32_t height, bool frontCamera);
+        arcana::task<Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.h
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.h
@@ -12,7 +12,7 @@ namespace Babylon::Plugins
     public:
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<const Camera::CameraDimensions*, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<Camera::CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();

--- a/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Win32/NativeCameraImpl.h
@@ -10,9 +10,14 @@ namespace Babylon::Plugins
     class Camera::Impl final : public std::enable_shared_from_this<Camera::Impl>
     {
     public:
+        struct CameraDimensions {
+            uint32_t width;
+            uint32_t height;
+        };
+
         Impl(Napi::Env env, bool overrideCameraTexture);
         ~Impl();
-        arcana::task<Camera::CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        arcana::task<CameraDimensions, std::exception_ptr> Open(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
         void SetTextureOverride(void* texturePtr);
         void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
         void Close();


### PR DESCRIPTION
This PR pushes the actual used camera dimension back to the NativeVideo texture so that readPixels and getSize return the proper dimensions of the object rather than defaulting to whatever is passed in for maxHeight and maxWidth as outlined in #1107.  With this change we will properly report the correct resolution on both iOS and Android.  Android requires additional follow up work to select the correct camera configuration to most closely match the target resolution.