### PR TITLE
Properly setup capture session to preserve selected format on iOS

### DIFF
--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -172,10 +172,12 @@ namespace Babylon::Plugins
                 return;
             }
             
+            [m_implData->avCaptureSession setSessionPreset:AVCaptureSessionPresetInputPriority];
             [bestDevice setActiveFormat:bestFormat];
             AVCaptureDeviceInput *input{[AVCaptureDeviceInput deviceInputWithDevice:bestDevice error:&error]};
             [bestDevice unlockForConfiguration];
             
+            // Capture the format dimensions.
             CMVideoFormatDescriptionRef videoFormatRef{static_cast<CMVideoFormatDescriptionRef>(bestFormat.formatDescription)};
             CMVideoDimensions dimensions{CMVideoFormatDescriptionGetDimensions(videoFormatRef)};
 #else


### PR DESCRIPTION
When setting up an AVCaptureSession we must manually set the session preset to AVCaptureSessionPresetInputPriority or else our selected format's resolution gets overwritten.  This PR properly sets that value prior to setting up the capture device so that our preferred resolution actually gets used.