### PR TITLE
[iOS native camera] - Swap height and width camera dimensions & video texture size based on initial orientation

### DIFF
--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -114,18 +114,7 @@ namespace Babylon::Plugins
                     AVCaptureDeviceTypeBuiltInWideAngleCamera
                 ];
             }
-            
-            // In portrait mode swap height and width when selecting the best format.
-            uint32_t targetFormatHeight{maxHeight};
-            uint32_t targetFormatWidth{maxWidth};
-            
-            if (m_implData->cameraTextureDelegate->videoOrientation == AVCaptureVideoOrientationPortrait
-                ||  m_implData->cameraTextureDelegate->videoOrientation == AVCaptureVideoOrientationPortraitUpsideDown)
-            {
-                std::swap(targetFormatHeight, targetFormatWidth);
-            }
 
-            
             AVCaptureDeviceDiscoverySession* discoverySession{[AVCaptureDeviceDiscoverySession
                discoverySessionWithDeviceTypes:deviceTypes
                mediaType:AVMediaTypeVideo position:frontCamera ? AVCaptureDevicePositionFront: AVCaptureDevicePositionBack]};
@@ -137,14 +126,14 @@ namespace Babylon::Plugins
                     CMVideoDimensions dimensions{CMVideoFormatDescriptionGetDimensions(videoFormatRef)};
                     
                     // Reject any resolution that doesn't qualify for the constraint.
-                    if (static_cast<uint32_t>(dimensions.width) > targetFormatWidth || static_cast<uint32_t>(dimensions.height) > targetFormatHeight)
+                    if (static_cast<uint32_t>(dimensions.width) > maxWidth || static_cast<uint32_t>(dimensions.height) > maxHeight)
                     {
                         continue;
                     }
                     
                     // Calculate pixel count and dimension differential and take the best qualifying one.
                     uint32_t pixelCount{static_cast<uint32_t>(dimensions.width * dimensions.height)};
-                    uint32_t dimDiff{(targetFormatWidth - dimensions.width) + (targetFormatHeight - dimensions.height)};
+                    uint32_t dimDiff{(maxWidth - dimensions.width) + (maxHeight - dimensions.height)};
                     if (bestDevice == nullptr || pixelCount > bestPixelCount || (pixelCount == bestPixelCount && dimDiff < bestDimDiff))
                     {
                         bestPixelCount = pixelCount;
@@ -153,7 +142,7 @@ namespace Babylon::Plugins
                         bestDimDiff = dimDiff;
                         
                         // Check if we got an exact match, and exit the loop early in this case.
-                        if (static_cast<uint32_t>(dimensions.width) == targetFormatWidth && static_cast<uint32_t>(dimensions.height) == targetFormatHeight)
+                        if (static_cast<uint32_t>(dimensions.width) == maxWidth && static_cast<uint32_t>(dimensions.height) == maxHeight)
                         {
                             foundExactMatch = true;
                             break;

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -116,14 +116,14 @@ namespace Babylon::Plugins
             }
             
             // In portrait mode swap height and width when selecting the best format.
-            uint32_t targetHeight{maxHeight};
-            uint32_t targetWidth{maxWidth};
+            uint32_t targetFormatHeight{maxHeight};
+            uint32_t targetFormatWidth{maxWidth};
             
             if (m_implData->cameraTextureDelegate->videoOrientation == AVCaptureVideoOrientationPortrait
                 ||  m_implData->cameraTextureDelegate->videoOrientation == AVCaptureVideoOrientationPortraitUpsideDown)
             {
-                targetHeight = maxWidth;
-                targetWidth = maxHeight;
+                targetFormatHeight = maxWidth;
+                targetFormatWidth = maxHeight;
             }
 
             
@@ -138,14 +138,14 @@ namespace Babylon::Plugins
                     CMVideoDimensions dimensions{CMVideoFormatDescriptionGetDimensions(videoFormatRef)};
                     
                     // Reject any resolution that doesn't qualify for the constraint.
-                    if (static_cast<uint32_t>(dimensions.width) > targetWidth || static_cast<uint32_t>(dimensions.height) > targetHeight)
+                    if (static_cast<uint32_t>(dimensions.width) > targetFormatWidth || static_cast<uint32_t>(dimensions.height) > targetFormatHeight)
                     {
                         continue;
                     }
                     
                     // Calculate pixel count and dimension differential and take the best qualifying one.
                     uint32_t pixelCount{static_cast<uint32_t>(dimensions.width * dimensions.height)};
-                    uint32_t dimDiff{(targetWidth - dimensions.width) + (targetHeight - dimensions.height)};
+                    uint32_t dimDiff{(targetFormatWidth - dimensions.width) + (targetFormatHeight - dimensions.height)};
                     if (bestDevice == nullptr || pixelCount > bestPixelCount || (pixelCount == bestPixelCount && dimDiff < bestDimDiff))
                     {
                         bestPixelCount = pixelCount;
@@ -154,7 +154,7 @@ namespace Babylon::Plugins
                         bestDimDiff = dimDiff;
                         
                         // Check if we got an exact match, and exit the loop early in this case.
-                        if (static_cast<uint32_t>(dimensions.width) == targetWidth && static_cast<uint32_t>(dimensions.height) == targetHeight)
+                        if (static_cast<uint32_t>(dimensions.width) == targetFormatWidth && static_cast<uint32_t>(dimensions.height) == targetFormatHeight)
                         {
                             foundExactMatch = true;
                             break;
@@ -204,7 +204,7 @@ namespace Babylon::Plugins
             CMVideoDimensions dimensions{CMVideoFormatDescriptionGetDimensions(videoFormatRef)};
 #endif
 
-            // For portrait orientations swap the height and width of the device dimensions.
+            // For portrait orientations swap the height and width of the video format dimensions.
             Camera::Impl::CameraDimensions cameraDimensions{};
             if (m_implData->cameraTextureDelegate->videoOrientation == AVCaptureVideoOrientationPortrait
                 ||  m_implData->cameraTextureDelegate->videoOrientation == AVCaptureVideoOrientationPortraitUpsideDown)

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -122,8 +122,7 @@ namespace Babylon::Plugins
             if (m_implData->cameraTextureDelegate->videoOrientation == AVCaptureVideoOrientationPortrait
                 ||  m_implData->cameraTextureDelegate->videoOrientation == AVCaptureVideoOrientationPortraitUpsideDown)
             {
-                targetFormatHeight = maxWidth;
-                targetFormatWidth = maxHeight;
+                std::swap(targetFormatHeight, targetFormatWidth);
             }
 
             
@@ -204,18 +203,13 @@ namespace Babylon::Plugins
             CMVideoDimensions dimensions{CMVideoFormatDescriptionGetDimensions(videoFormatRef)};
 #endif
 
+            Camera::Impl::CameraDimensions cameraDimensions{static_cast<uint32_t>(dimensions.width), static_cast<uint32_t>(dimensions.height)};
+            
             // For portrait orientations swap the height and width of the video format dimensions.
-            Camera::Impl::CameraDimensions cameraDimensions{};
             if (m_implData->cameraTextureDelegate->videoOrientation == AVCaptureVideoOrientationPortrait
                 ||  m_implData->cameraTextureDelegate->videoOrientation == AVCaptureVideoOrientationPortraitUpsideDown)
             {
-                cameraDimensions.height = dimensions.width;
-                cameraDimensions.width = dimensions.height;
-            }
-            else
-            {
-                cameraDimensions.width = dimensions.width;
-                cameraDimensions.height = dimensions.height;
+                std::swap(cameraDimensions.width, cameraDimensions.height);
             }
             
             // Check for failed initialisation.


### PR DESCRIPTION
Camera format resolutions are always in landscape. To the web implementation we need to swap height and width of the video format when reporting the size of the video texture when a session is started in portrait mode.