### PR TITLE
Android native camera resolution and orientation

### DIFF
--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -78,7 +78,7 @@ CreateBoxAsync(scene).then(function () {
 
     if (cameraTexture) {
         scene.meshes[0].setEnabled(false);
-        var plane = BABYLON.MeshBuilder.CreatePlane("plane", {size: 7, sideOrientation: BABYLON.Mesh.DOUBLESIDE});
+        var plane = BABYLON.MeshBuilder.CreatePlane("plane", {size: 1, sideOrientation: BABYLON.Mesh.DOUBLESIDE});
         plane.rotation.y = Math.PI;
         plane.rotation.z = Math.PI;
 
@@ -88,9 +88,12 @@ CreateBoxAsync(scene).then(function () {
         mat.diffuseColor = BABYLON.Color3.Black();
 
         var tex = BABYLON.VideoTexture.CreateFromWebCam(scene, function(videoTexture) {
+            const videoSize = videoTexture.getSize();
             mat.emissiveTexture = videoTexture;
             plane.material = mat;
-            console.log("Video texture size: " + videoTexture.getSize());
+            plane.scaling.x = 5;
+            plane.scaling.y = 5 * (videoSize.height / videoSize.width);
+            console.log("Video texture size: " + videoSize);
         }, { maxWidth: 1280, maxHeight: 720, facingMode: 'environment'});
     }
 

--- a/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
+++ b/Dependencies/AndroidExtensions/Include/AndroidExtensions/JavaWrappers.h
@@ -311,6 +311,7 @@ namespace android::graphics
         SurfaceTexture();
         void InitWithTexture(int texture);
         void updateTexImage() const;
+        void setDefaultBufferSize(int width, int height);
     };
 }
 

--- a/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
+++ b/Dependencies/AndroidExtensions/Source/JavaWrappers.cpp
@@ -588,4 +588,12 @@ namespace android::graphics
             m_env->CallVoidMethod(JObject(), m_env->GetMethodID(m_class, "updateTexImage", "()V"));
         }
     }
+
+    void SurfaceTexture::setDefaultBufferSize(int width, int height)
+    {
+        if (JObject()) {
+            m_env->CallVoidMethod(JObject(), m_env->GetMethodID(m_class, "setDefaultBufferSize", "(II)V"), width, height);
+        }
+    }
+
 }

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
@@ -108,10 +108,10 @@ namespace Babylon::Plugins
             // 3: input?
 
             for (uint32_t j = 0; j < streamConfigurations.count; j += 4) {
-                int32_t format = streamConfigurations.data.i32[j + 0];
-                int32_t width = streamConfigurations.data.i32[j + 1];
-                int32_t height = streamConfigurations.data.i32[j + 2];
-                int32_t input = streamConfigurations.data.i32[j + 3];
+                int32_t format{streamConfigurations.data.i32[j + 0]};
+                int32_t width{streamConfigurations.data.i32[j + 1]};
+                int32_t height{streamConfigurations.data.i32[j + 2]};
+                int32_t input{streamConfigurations.data.i32[j + 3]};
 
                 if (input || format != AIMAGE_FORMAT_YUV_420_888 || static_cast<uint32_t>(width) > maxWidth || static_cast<uint32_t>(height) > maxHeight)
                 {
@@ -262,8 +262,8 @@ namespace Babylon::Plugins
             // The sensor rotation dictates the orientation of the camera when the phone is in it's default orientation
             // Subtracting the phone's rotation from the camera's rotation will give us the current orientation
             // of the sensor. Then add 360 and modulus 360 to ensure we're always talking about positive degrees.
-            int sensorRotationDiff = (bestCameraConfiguration.sensorRotation - phoneRotation + 360) % 360;
-            bool sensorIsPortrait = sensorRotationDiff == 90 || sensorRotationDiff == 270;
+            int sensorRotationDiff{(bestCameraConfiguration.sensorRotation - phoneRotation + 360) % 360};
+            bool sensorIsPortrait{sensorRotationDiff == 90 || sensorRotationDiff == 270};
             if (frontCamera && !sensorIsPortrait && !m_overrideCameraTexture)
             {
                 // Compensate for the front facing camera being naturally mirrored. In the portrait orientation

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
@@ -270,10 +270,12 @@ namespace Babylon::Plugins
             // Subtracting the phone's rotation from the camera's rotation will give us the current orientation
             // of the sensor. Then add 360 and modulus 360 to ensure we're always talking about positive degrees.
             int sensorRotationDiff = (bestCameraConfiguration.sensorRotation - phoneRotation + 360) % 360;
-            bool flipAxis = sensorRotationDiff == 90 || sensorRotationDiff == 270;
+            bool sensorIsPortrait = sensorRotationDiff == 90 || sensorRotationDiff == 270;
 
-            m_cameraDimensions.width = !flipAxis ? bestCameraConfiguration.width : bestCameraConfiguration.height;
-            m_cameraDimensions.height = !flipAxis ? bestCameraConfiguration.height : bestCameraConfiguration.width;
+            // To match the web implementation if the sensor is rotated into a portrait orientation then the width and height
+            // of the video should be swapped
+            m_cameraDimensions.width = !sensorIsPortrait ? bestCameraConfiguration.width : bestCameraConfiguration.height;
+            m_cameraDimensions.height = !sensorIsPortrait ? bestCameraConfiguration.height : bestCameraConfiguration.width;
 
             // Check if there is an already available context for this thread
             EGLContext currentContext = eglGetCurrentContext();

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
@@ -271,6 +271,13 @@ namespace Babylon::Plugins
             // of the sensor. Then add 360 and modulus 360 to ensure we're always talking about positive degrees.
             int sensorRotationDiff = (bestCameraConfiguration.sensorRotation - phoneRotation + 360) % 360;
             bool sensorIsPortrait = sensorRotationDiff == 90 || sensorRotationDiff == 270;
+            if (frontCamera && !sensorIsPortrait && !m_overrideCameraTexture)
+            {
+                // Compensate for the front facing camera being naturally mirrored. In the portrait orientation
+                // the mirrored behavior matches the browser, but in landscape it would result in the image rendering
+                // upside down. Rotate the image by 180 to compensate.
+                sensorRotationDiff = (sensorRotationDiff + 180) % 360;
+            }
 
             // To match the web implementation if the sensor is rotated into a portrait orientation then the width and height
             // of the video should be swapped

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
@@ -21,8 +21,8 @@ using namespace android::global;
 namespace Babylon::Plugins
 {
     // Vertex positions for the camera texture
-    constexpr size_t CAMERA_VERTEX_COUNT{4 };
-    constexpr GLfloat CAMERA_VERTEX_POSITIONS[CAMERA_VERTEX_COUNT * 2]{-1.0f, -1.0f, 1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f };
+    constexpr size_t CAMERA_VERTEX_COUNT{ 4 };
+    constexpr GLfloat CAMERA_VERTEX_POSITIONS[CAMERA_VERTEX_COUNT * 2]{ -1.0f, -1.0f, 1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f };
 
     // UV mappings to correct for the different orientations of the screen versus the camera sensor
     constexpr size_t CAMERA_UVS_COUNT{ 4 };
@@ -101,7 +101,7 @@ namespace Babylon::Plugins
             }
 
             // Get all available stream configurations supported by the camera
-            API24::ACameraMetadata_const_entry streamConfigurations;
+            API24::ACameraMetadata_const_entry streamConfigurations = {};
             GET_CAMERA_FUNCTION(ACameraMetadata_getConstEntry)(metadataObj, API24::ACAMERA_SCALER_AVAILABLE_STREAM_CONFIGURATIONS, &streamConfigurations);
             // format of the data:
             // 0: format

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.cpp
@@ -29,7 +29,6 @@ namespace Babylon::Plugins
         }
     )"};
 
-
     static const std::string CAMERA_FRAG_SHADER_HEADER{R"(#version 300 es
         #extension GL_OES_EGL_image_external_essl3 : require
     )"};
@@ -63,7 +62,7 @@ namespace Babylon::Plugins
         return oesTexture;
     }
 
-    Camera::Impl::CameraConfiguration Camera::Impl::GetCameraId(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
+    Camera::Impl::CameraConfiguration Camera::Impl::GetCameraConfiguration(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera)
     {
         // Get the list of available cameras
         API24::ACameraIdList *cameraIds = nullptr;
@@ -250,7 +249,7 @@ namespace Babylon::Plugins
 
             if (API_LEVEL >= 24 && libCamera2NDK && !m_overrideCameraTexture) {
                 m_cameraManager = GET_CAMERA_FUNCTION(ACameraManager_create)();
-                bestCameraConfiguration = GetCameraId(maxWidth, maxHeight, frontCamera);
+                bestCameraConfiguration = GetCameraConfiguration(maxWidth, maxHeight, frontCamera);
 
                 // If no matching device, throw an error with the message "ConstraintError" which matches the behavior in the browser.
                 if (bestCameraConfiguration.cameraID.empty())

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
@@ -29,12 +29,12 @@ namespace Babylon::Plugins
 
     private:
         struct CameraConfiguration
-            {
-                std::string cameraID;
-                uint32_t width;
-                uint32_t height;
-                int32_t sensorRotation;
-            };
+        {
+            std::string cameraID;
+            uint32_t width;
+            uint32_t height;
+            int32_t sensorRotation;
+        };
 
         Graphics::DeviceContext* m_deviceContext;
         Napi::Env m_env;
@@ -61,7 +61,7 @@ namespace Babylon::Plugins
         GLuint m_cameraRGBATextureId{};
         GLuint m_cameraShaderProgramId{};
         GLuint m_frameBufferId{};
-        const GLfloat* m_cameraUVs;
+        const GLfloat* m_cameraUVs{};
 
         EGLContext m_context{EGL_NO_CONTEXT};
         EGLDisplay m_display{};

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
@@ -33,6 +33,7 @@ namespace Babylon::Plugins
                 std::string cameraID;
                 uint32_t width;
                 uint32_t height;
+                int32_t sensorRotation;
             };
 
         Graphics::DeviceContext* m_deviceContext;

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
@@ -28,6 +28,12 @@ namespace Babylon::Plugins
         void Close();
 
     private:
+        struct CameraConfiguration
+            {
+                std::string cameraID;
+                uint32_t width;
+                uint32_t height;
+            };
 
         Graphics::DeviceContext* m_deviceContext;
         Napi::Env m_env;
@@ -37,7 +43,7 @@ namespace Babylon::Plugins
         CameraDimensions m_cameraDimensions{};
 
         GLuint GenerateOESTexture();
-        std::string GetCameraId(bool frontCamera);
+        CameraConfiguration GetCameraId(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
 
         API24::ACameraManager* m_cameraManager{};
         API24::ACameraDevice* m_cameraDevice{};

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
@@ -61,6 +61,7 @@ namespace Babylon::Plugins
         GLuint m_cameraRGBATextureId{};
         GLuint m_cameraShaderProgramId{};
         GLuint m_frameBufferId{};
+        const GLfloat* m_cameraUVs;
 
         EGLContext m_context{EGL_NO_CONTEXT};
         EGLDisplay m_display{};

--- a/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Android/NativeCameraImpl.h
@@ -44,7 +44,7 @@ namespace Babylon::Plugins
         CameraDimensions m_cameraDimensions{};
 
         GLuint GenerateOESTexture();
-        CameraConfiguration GetCameraId(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
+        CameraConfiguration GetCameraConfiguration(uint32_t maxWidth, uint32_t maxHeight, bool frontCamera);
 
         API24::ACameraManager* m_cameraManager{};
         API24::ACameraDevice* m_cameraDevice{};


### PR DESCRIPTION
This change addresses the android NativeCamera plugin implementation so that it picks a camera resolution based on the passed in maxWidth and maxHeight. Additionally this change fixes the rotation and orientation of the returned camera texture. More information about those two issues can be found in issue #1107.