### PR TITLE
Fix iOS NativeCamera texture pixel format

### DIFF
--- a/Plugins/NativeCamera/CMakeLists.txt
+++ b/Plugins/NativeCamera/CMakeLists.txt
@@ -24,6 +24,9 @@ if(ANDROID)
     set(EXTENSIONS AndroidExtensions)
 elseif(APPLE)
     set(EXTENSIONS "-framework CoreMedia -framework AVFoundation")
+    set_target_properties(NativeCamera PROPERTIES
+        XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES
+    )
 endif()
 
 target_link_to_dependencies(NativeCamera

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
@@ -32,5 +32,7 @@ namespace Babylon::Plugins
         std::shared_ptr<ImplData> m_implData;
 
         bool m_overrideCameraTexture{};
+
+        CameraDimensions m_cameraDimensions{};
     };
 }

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -1,3 +1,7 @@
+#if ! __has_feature(objc_arc)
+#error "ARC is off"
+#endif
+
 #import <MetalKit/MetalKit.h>
 #include <bgfx/bgfx.h>
 #include <bgfx/platform.h>

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -231,7 +231,7 @@ namespace Babylon::Plugins
             dispatch_queue_t sampleBufferQueue{dispatch_queue_create("CameraMulticaster", DISPATCH_QUEUE_SERIAL)};
             AVCaptureVideoDataOutput * dataOutput{[[AVCaptureVideoDataOutput alloc] init]};
             [dataOutput setAlwaysDiscardsLateVideoFrames:YES];
-            [dataOutput setVideoSettings:@{(id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA)}];
+            [dataOutput setVideoSettings:@{(id)kCVPixelBufferPixelFormatTypeKey: @(bestPixelFormat)}];
             [dataOutput setSampleBufferDelegate:m_implData->cameraTextureDelegate queue:sampleBufferQueue];
 
             // Actually start the camera session.

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -43,10 +43,10 @@ namespace {
         return false;
     }
 
-    typedef struct {
+    struct Vertex {
         vector_float2 position;
         vector_float2 uv;
-    } Vertex;
+    };
 
     constexpr Vertex vertices[] = {
         // 2D positions, UV

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -582,7 +582,8 @@ namespace Babylon::Plugins
         // Create a texture from the corresponding plane.
         auto status = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault, implData->textureCache, pixelBuffer, nil, pixelFormat, planeWidth, planeHeight, planeIndex, &textureRef);
         if (status != kCVReturnSuccess) {
-            return nil;
+            CVBufferRelease(textureRef);
+            textureRef = nil;
         }
 
         return textureRef;

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -578,26 +578,21 @@ namespace Babylon::Plugins
         return {};
     }
 
-    @try {
-        size_t planeWidth = CVPixelBufferGetWidthOfPlane(pixelBuffer, planeIndex);
-        size_t planeHeight = CVPixelBufferGetHeightOfPlane(pixelBuffer, planeIndex);
+    size_t planeWidth = CVPixelBufferGetWidthOfPlane(pixelBuffer, planeIndex);
+    size_t planeHeight = CVPixelBufferGetHeightOfPlane(pixelBuffer, planeIndex);
 
-        // Plane 0 is the Y plane, which is in R8Unorm format, and the second plane is the CBCR plane which is RG8Unorm format.
-        auto pixelFormat = planeIndex ? MTLPixelFormatRG8Unorm : MTLPixelFormatR8Unorm;
-        CVMetalTextureRef textureRef;
+    // Plane 0 is the Y plane, which is in R8Unorm format, and the second plane is the CBCR plane which is RG8Unorm format.
+    auto pixelFormat = planeIndex ? MTLPixelFormatRG8Unorm : MTLPixelFormatR8Unorm;
+    CVMetalTextureRef textureRef;
 
-        // Create a texture from the corresponding plane.
-        auto status = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault, implData->textureCache, pixelBuffer, nil, pixelFormat, planeWidth, planeHeight, planeIndex, &textureRef);
-        if (status != kCVReturnSuccess) {
-            CVBufferRelease(textureRef);
-            textureRef = nil;
-        }
-
-        return textureRef;
+    // Create a texture from the corresponding plane.
+    auto status = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault, implData->textureCache, pixelBuffer, nil, pixelFormat, planeWidth, planeHeight, planeIndex, &textureRef);
+    if (status != kCVReturnSuccess) {
+        CVBufferRelease(textureRef);
+        textureRef = nil;
     }
-    @finally {
-        CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
-    }
+
+    return textureRef;
 }
 
 -(void)cleanupTextures {

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -136,7 +136,12 @@ namespace Babylon::Plugins
     {
         ~ImplData()
         {
+            if (currentCommandBuffer != nil) {
+                [currentCommandBuffer waitUntilCompleted];
+            }
+
             [avCaptureSession stopRunning];
+
             if (textureCache)
             {
                 CVMetalTextureCacheFlush(textureCache, 0);

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -296,6 +296,13 @@ namespace Babylon::Plugins
             AVCaptureDeviceInput *input{[AVCaptureDeviceInput deviceInputWithDevice:captureDevice error:&error]};
             CMVideoFormatDescriptionRef videoFormatRef{static_cast<CMVideoFormatDescriptionRef>(captureDevice.activeFormat.formatDescription)};
             CMVideoDimensions dimensions{CMVideoFormatDescriptionGetDimensions(videoFormatRef)};
+            uint32_t bestPixelFormat{static_cast<uint32_t>(CMFormatDescriptionGetMediaSubType(videoFormatRef))};
+            if (!isPixelFormatSupported(bestPixelFormat))
+            {
+                taskCompletionSource.complete(arcana::make_unexpected(
+                    std::make_exception_ptr(std::runtime_error{"ConstraintError: Unable to match constraints to a supported camera configuration."})));
+                return;
+            }
 #endif
 
             Camera::Impl::CameraDimensions cameraDimensions{static_cast<uint32_t>(dimensions.width), static_cast<uint32_t>(dimensions.height)};

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -39,8 +39,6 @@ namespace Babylon::Plugins
         ~ImplData()
         {
             [avCaptureSession stopRunning];
-            [avCaptureSession release];
-            [cameraTextureDelegate release];
             if (textureCache)
             {
                 CVMetalTextureCacheFlush(textureCache, 0);
@@ -74,7 +72,7 @@ namespace Babylon::Plugins
             maxHeight = std::numeric_limits<int32_t>::max();
         }
         
-        auto metalDevice = (id<MTLDevice>)bgfx::getInternalData()->context;
+        auto metalDevice = (__bridge id<MTLDevice>)bgfx::getInternalData()->context;
 
         if (!m_deviceContext)
         {

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -46,9 +46,9 @@ namespace {
     typedef struct {
         vector_float2 position;
         vector_float2 uv;
-    } XRVertex;
+    } Vertex;
 
-    static XRVertex vertices[] = {
+    static Vertex vertices[] = {
         // 2D positions, UV
         { { -1, -1 },   { 0, 1 } },
         { { -1, 1 },    { 0, 0 } },
@@ -65,7 +65,7 @@ namespace {
         {
             vector_float2 position;
             vector_float2 uv;
-        } XRVertex;
+        } Vertex;
         typedef struct
         {
             float4 position [[position]];
@@ -73,7 +73,7 @@ namespace {
         } RasterizerData;
         vertex RasterizerData
         vertexShader(uint vertexID [[vertex_id]],
-                        constant XRVertex *vertices [[buffer(0)]])
+                        constant Vertex *vertices [[buffer(0)]])
         {
             RasterizerData out;
             out.position = vector_float4(vertices[vertexID].position.xy, 0.0, 1.0);

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -62,18 +62,23 @@ namespace {
     constexpr char shaderSource[] = R"(
         #include <metal_stdlib>
         #include <simd/simd.h>
+
         using namespace metal;
+
         #include <simd/simd.h>
+
         typedef struct
         {
             vector_float2 position;
             vector_float2 uv;
         } Vertex;
+
         typedef struct
         {
             float4 position [[position]];
             float2 uv;
         } RasterizerData;
+
         vertex RasterizerData
         vertexShader(uint vertexID [[vertex_id]],
                         constant Vertex *vertices [[buffer(0)]])
@@ -83,24 +88,29 @@ namespace {
             out.uv = vertices[vertexID].uv;
             return out;
         }
+
         fragment float4 fragmentShader(RasterizerData in [[stage_in]],
             texture2d<float, access::sample> cameraTextureY [[ texture(1) ]],
             texture2d<float, access::sample> cameraTextureCbCr [[ texture(2) ]])
         {
             constexpr sampler linearSampler(mip_filter::linear, mag_filter::linear, min_filter::linear);
+
             if (!is_null_texture(cameraTextureY) && !is_null_texture(cameraTextureCbCr))
             {
                 const float4 cameraSampleY = cameraTextureY.sample(linearSampler, in.uv);
                 const float4 cameraSampleCbCr = cameraTextureCbCr.sample(linearSampler, in.uv);
+
                 const float4x4 ycbcrToRGBTransform = float4x4(
                     float4(+1.0000f, +1.0000f, +1.0000f, +0.0000f),
                     float4(+0.0000f, -0.3441f, +1.7720f, +0.0000f),
                     float4(+1.4020f, -0.7141f, +0.0000f, +0.0000f),
                     float4(-0.7010f, +0.5291f, -0.8860f, +1.0000f)
                 );
+
                 float4 ycbcr = float4(cameraSampleY.r, cameraSampleCbCr.rg, 1.0);
                 float4 cameraSample = ycbcrToRGBTransform * ycbcr;
                 cameraSample.a = 1.0;
+
                 return cameraSample;
             }
             else

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -107,7 +107,7 @@ namespace {
         }
     )";
 
-    id<MTLLibrary> CompileShader(id<MTLDevice> metalDevice, const char* source) {
+    static id<MTLLibrary> CompileShader(id<MTLDevice> metalDevice, const char* source) {
         NSError* error;
         id<MTLLibrary> lib = [metalDevice newLibraryWithSource:@(source) options:nil error:&error];
         if(nil != error) {

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -355,7 +355,7 @@ namespace Babylon::Plugins
             pipelineStateDescriptor.label = @"Native Camera YCbCr to RGBA Pipeline";
             pipelineStateDescriptor.vertexFunction = vertexFunction;
             pipelineStateDescriptor.fragmentFunction = fragmentFunction;
-            pipelineStateDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+            pipelineStateDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatRGBA8Unorm;
             m_implData->cameraPipelineState = [m_implData->metalDevice newRenderPipelineStateWithDescriptor:pipelineStateDescriptor error:&error];
 
             if (!m_implData->cameraPipelineState) {

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -48,7 +48,7 @@ namespace {
         vector_float2 uv;
     } Vertex;
 
-    static Vertex vertices[] = {
+    constexpr Vertex vertices[] = {
         // 2D positions, UV
         { { -1, -1 },   { 0, 1 } },
         { { -1, 1 },    { 0, 0 } },

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -187,7 +187,7 @@ namespace Babylon::Plugins
             AVCaptureDevice* bestDevice{nullptr};
             AVCaptureDeviceFormat* bestFormat{nullptr};
             uint32_t bestPixelCount{0};
-            uint32_t bestPixelFormat{0};
+            uint32_t devicePixelFormat{0};
             uint32_t bestDimDiff{0};
             NSArray* deviceTypes{nullptr};
             bool foundExactMatch{false};
@@ -242,7 +242,7 @@ namespace Babylon::Plugins
                     if (bestDevice == nullptr || pixelCount > bestPixelCount || (pixelCount == bestPixelCount && dimDiff < bestDimDiff))
                     {
                         bestPixelCount = pixelCount;
-                        bestPixelFormat = pixelFormat;
+                        devicePixelFormat = pixelFormat;
                         bestDevice = device;
                         bestFormat = format;
                         bestDimDiff = dimDiff;
@@ -296,8 +296,8 @@ namespace Babylon::Plugins
             AVCaptureDeviceInput *input{[AVCaptureDeviceInput deviceInputWithDevice:captureDevice error:&error]};
             CMVideoFormatDescriptionRef videoFormatRef{static_cast<CMVideoFormatDescriptionRef>(captureDevice.activeFormat.formatDescription)};
             CMVideoDimensions dimensions{CMVideoFormatDescriptionGetDimensions(videoFormatRef)};
-            uint32_t bestPixelFormat{static_cast<uint32_t>(CMFormatDescriptionGetMediaSubType(videoFormatRef))};
-            if (!isPixelFormatSupported(bestPixelFormat))
+            uint32_t devicePixelFormat{static_cast<uint32_t>(CMFormatDescriptionGetMediaSubType(videoFormatRef))};
+            if (!isPixelFormatSupported(devicePixelFormat))
             {
                 taskCompletionSource.complete(arcana::make_unexpected(
                     std::make_exception_ptr(std::runtime_error{"ConstraintError: Unable to match constraints to a supported camera configuration."})));
@@ -328,7 +328,7 @@ namespace Babylon::Plugins
             dispatch_queue_t sampleBufferQueue{dispatch_queue_create("CameraMulticaster", DISPATCH_QUEUE_SERIAL)};
             AVCaptureVideoDataOutput * dataOutput{[[AVCaptureVideoDataOutput alloc] init]};
             [dataOutput setAlwaysDiscardsLateVideoFrames:YES];
-            [dataOutput setVideoSettings:@{(id)kCVPixelBufferPixelFormatTypeKey: @(bestPixelFormat)}];
+            [dataOutput setVideoSettings:@{(id)kCVPixelBufferPixelFormatTypeKey: @(devicePixelFormat)}];
             [dataOutput setSampleBufferDelegate:m_implData->cameraTextureDelegate queue:sampleBufferQueue];
 
             // Actually start the camera session.


### PR DESCRIPTION
The BJS side creates the texture and specifies the format (as RGBA8, in NativeEngine.createDynamicTexture), and then the native side overrides the texture handle in the Graphics::Texture, but the other properties (including format) are not updated, so the format (BGRA8) is incorrect, and operations like readPixels won't work.

This change fixes the issue by using a shader to convert the camera's YpCbCr format into RGBA, similar to how it's done in [XR.mm](https://github.com/docEdub/BabylonNative/blob/97da91efb19cde88775a83fede8e5296ae234682/Dependencies/xr/Source/ARKit/XR.mm#L554-L636).

## Related issue
https://github.com/babylonjs/babylonnative/issues/1107