### PR TITLE
Support external render target textures

### DIFF
--- a/Plugins/ExternalTexture/Source/ExternalTexture_D3D11.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_D3D11.cpp
@@ -163,6 +163,11 @@ namespace Babylon::Plugins
             info.Height = static_cast<uint16_t>(desc.Height);
             info.MipLevels = static_cast<uint16_t>(desc.MipLevels);
 
+            if ((desc.BindFlags & D3D11_BIND_RENDER_TARGET) != 0)
+            {
+                info.Flags |= BGFX_TEXTURE_RT;
+            }
+
             for (int i = 0; i < BX_COUNTOF(s_textureFormat); ++i)
             {
                 const auto& format = s_textureFormat[i];

--- a/Plugins/ExternalTexture/Source/ExternalTexture_D3D12.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_D3D12.cpp
@@ -157,6 +157,11 @@ namespace Babylon::Plugins
             info.Height = static_cast<uint16_t>(desc.Height);
             info.MipLevels = static_cast<uint16_t>(desc.MipLevels);
 
+            if ((desc.BindFlags & D3D12_BIND_RENDER_TARGET) != 0)
+            {
+                info.Flags |= BGFX_TEXTURE_RT;
+            }
+
             for (int i = 0; i < BX_COUNTOF(s_textureFormat); ++i)
             {
                 const auto& format = s_textureFormat[i];

--- a/Plugins/ExternalTexture/Source/ExternalTexture_D3D12.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_D3D12.cpp
@@ -157,7 +157,7 @@ namespace Babylon::Plugins
             info.Height = static_cast<uint16_t>(desc.Height);
             info.MipLevels = static_cast<uint16_t>(desc.MipLevels);
 
-            if ((desc.BindFlags & D3D12_BIND_RENDER_TARGET) != 0)
+            if ((desc.Flags & D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET) != 0)
             {
                 info.Flags |= BGFX_TEXTURE_RT;
             }

--- a/Plugins/ExternalTexture/Source/ExternalTexture_Metal.mm
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Metal.mm
@@ -145,6 +145,11 @@ namespace Babylon::Plugins
             info.Height = static_cast<uint16_t>(ptr.height);
             info.MipLevels = static_cast<uint16_t>(ptr.mipmapLevelCount);
 
+            if ((ptr.usage & MTLTextureUsage::renderTarget) != 0)
+            {
+                info.Flags |= BGFX_TEXTURE_RT;
+            }
+
             const auto pixelFormat = m_ptr.pixelFormat;
             for (size_t i = 0; i < BX_COUNTOF(s_textureFormat); ++i)
             {

--- a/Plugins/ExternalTexture/Source/ExternalTexture_Metal.mm
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Metal.mm
@@ -145,7 +145,7 @@ namespace Babylon::Plugins
             info.Height = static_cast<uint16_t>(ptr.height);
             info.MipLevels = static_cast<uint16_t>(ptr.mipmapLevelCount);
 
-            if ((ptr.usage & MTLTextureUsage::renderTarget) != 0)
+            if ((ptr.usage & MTLTextureUsageRenderTarget) != 0)
             {
                 info.Flags |= BGFX_TEXTURE_RT;
             }
@@ -156,10 +156,10 @@ namespace Babylon::Plugins
                 const auto& format = s_textureFormat[i];
                 if (format.m_fmt == pixelFormat || format.m_fmtSrgb == pixelFormat)
                 {
-                    info.format = static_cast<bgfx::TextureFormat::Enum>(i);
+                    info.Format = static_cast<bgfx::TextureFormat::Enum>(i);
                     if (format.m_fmtSrgb == pixelFormat)
                     {
-                        info.flags |= BGFX_TEXTURE_SRGB;
+                        info.Flags |= BGFX_TEXTURE_SRGB;
                     }
                     break;
                 }

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1450,7 +1450,8 @@ namespace Babylon
 
         if (!texture->IsValid())
         {
-            texture->Attach(bgfx::createTexture2D(width, height, generateMips, 1, format, BGFX_TEXTURE_RT), false, width, height);
+            auto handle = bgfx::createTexture2D(width, height, generateMips, 1, format, BGFX_TEXTURE_RT);
+            texture->Attach(handle, false, width, height, generateMips, 1, format, BGFX_TEXTURE_RT);
         }
         attachments[numAttachments++].init(texture->Handle());
 


### PR DESCRIPTION
This change makes it possible to use external textures with render target textures. It fixes setting the bgfx flag when constructing an external texture as well as make it such that creating a render target from an existing texture works in native engine.