### PR TITLE
Fix potential memory leak on Apple platforms

### DIFF
--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -334,6 +334,7 @@ namespace {
         // Create a texture from the corresponding plane.
         auto status = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault, textureCache, pixelBuffer, nil, pixelFormat, planeWidth, planeHeight, planeIndex, &texture);
         if (status != kCVReturnSuccess) {
+            CVBufferRelease(texture);
             return nil;
         }
 


### PR DESCRIPTION
In XR.mm when the call to `CVMetalTextureCacheCreateTextureFromImage` fails, the texture reference is not being released. In the Xcode AR example the texture reference is explicitly released when `CVMetalTextureCacheCreateTextureFromImage` fails, so we should probably do the same thing to make sure no memory is being leaked.