### PR TITLE
Fix a few issues around readTexture and iOS camera

### DIFF
--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -176,10 +176,7 @@ namespace Babylon::Graphics
             // Drain readTextures queue, completing them in an error state.
             while (!m_readTextureRequests.empty())
             {
-                auto error = arcana::make_unexpected(
-                    std::make_exception_ptr(
-                        std::system_error(std::make_error_code(std::errc::operation_canceled))));
-
+                auto error = arcana::make_unexpected(std::make_exception_ptr(std::system_error(std::make_error_code(std::errc::operation_canceled))));
                 m_readTextureRequests.front().second.complete(error);
                 m_readTextureRequests.pop();
             }
@@ -189,7 +186,7 @@ namespace Babylon::Graphics
             FinishRenderingCurrentFrame();
 
             m_cancellationSource->cancel();
-            
+
             bgfx::shutdown();
             m_state.Bgfx.Initialized = false;
 

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -173,12 +173,23 @@ namespace Babylon::Graphics
 
         if (m_state.Bgfx.Initialized)
         {
+            // Drain readTextures queue, completing them in an error state.
+            while (!m_readTextureRequests.empty())
+            {
+                auto error = arcana::make_unexpected(
+                    std::make_exception_ptr(
+                        std::system_error(std::make_error_code(std::errc::operation_canceled))));
+
+                m_readTextureRequests.front().second.complete(error);
+                m_readTextureRequests.pop();
+            }
+
             // HACK: Render one more frame to drain the before/after render work queues.
             StartRenderingCurrentFrame();
             FinishRenderingCurrentFrame();
 
             m_cancellationSource->cancel();
-
+            
             bgfx::shutdown();
             m_state.Bgfx.Initialized = false;
 
@@ -390,8 +401,7 @@ namespace Babylon::Graphics
         uint32_t frameNumber{bgfx::frame()};
 
         // Process read texture requests.
-        assert(m_readTextureRequests.empty() || m_readTextureRequests.front().first >= frameNumber);
-        while (!m_readTextureRequests.empty() && m_readTextureRequests.front().first == frameNumber)
+        while (!m_readTextureRequests.empty() && m_readTextureRequests.front().first <= frameNumber)
         {
             m_readTextureRequests.front().second.complete();
             m_readTextureRequests.pop();

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -193,6 +193,7 @@ namespace Babylon::Plugins
             CVMetalTextureCacheCreate(nullptr, nullptr, m_implData->metalDevice, nullptr, &m_implData->textureCache);
             m_implData->cameraTextureDelegate = [[CameraTextureDelegate alloc]init:m_implData];
             m_implData->avCaptureSession = [[AVCaptureSession alloc] init];
+            m_implData->textureRGBA = nil;
             
 #if (TARGET_OS_IPHONE)
             // Loop over all available camera configurations to find a config that most closely matches the constraints.
@@ -395,9 +396,14 @@ namespace Babylon::Plugins
                 width = [textureY width];
                 height = [textureY height];
             }
+            
+            // Skip processing this frame.
+            if (width == 0 || height == 0) {
+                return;
+            }
 
             // Recreate the output texture when the camera dimensions change.
-            if (m_cameraDimensions.width != width || m_cameraDimensions.height != height)
+            if (m_cameraDimensions.width != width || m_cameraDimensions.height != height || m_implData->textureRGBA == nil)
             {
                 MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA8Unorm width:width height:height mipmapped:NO];
                 textureDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -189,10 +189,11 @@ namespace Babylon::Plugins
         
         __block arcana::task_completion_source<Camera::Impl::CameraDimensions, std::exception_ptr> taskCompletionSource{};
 
-        dispatch_sync(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
             CVMetalTextureCacheCreate(nullptr, nullptr, m_implData->metalDevice, nullptr, &m_implData->textureCache);
             m_implData->cameraTextureDelegate = [[CameraTextureDelegate alloc]init:m_implData];
             m_implData->avCaptureSession = [[AVCaptureSession alloc] init];
+            m_implData->textureRGBA = nil;
 
 #if (TARGET_OS_IPHONE)
             // Loop over all available camera configurations to find a config that most closely matches the constraints.
@@ -396,13 +397,13 @@ namespace Babylon::Plugins
                 height = [textureY height];
             }
             
-            // Skip processing this frame.
+            // Skip processing this frame if width and height are invalid.
             if (width == 0 || height == 0) {
                 return;
             }
 
             // Recreate the output texture when the camera dimensions change.
-            if (m_cameraDimensions.width != width || m_cameraDimensions.height != height)
+            if (m_implData->textureRGBA == nil || m_cameraDimensions.width != width || m_cameraDimensions.height != height)
             {
                 MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA8Unorm width:width height:height mipmapped:NO];
                 textureDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -193,8 +193,7 @@ namespace Babylon::Plugins
             CVMetalTextureCacheCreate(nullptr, nullptr, m_implData->metalDevice, nullptr, &m_implData->textureCache);
             m_implData->cameraTextureDelegate = [[CameraTextureDelegate alloc]init:m_implData];
             m_implData->avCaptureSession = [[AVCaptureSession alloc] init];
-            m_implData->textureRGBA = nil;
-            
+
 #if (TARGET_OS_IPHONE)
             // Loop over all available camera configurations to find a config that most closely matches the constraints.
             AVCaptureDevice* bestDevice{nullptr};
@@ -403,7 +402,7 @@ namespace Babylon::Plugins
             }
 
             // Recreate the output texture when the camera dimensions change.
-            if (m_cameraDimensions.width != width || m_cameraDimensions.height != height || m_implData->textureRGBA == nil)
+            if (m_cameraDimensions.width != width || m_cameraDimensions.height != height)
             {
                 MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA8Unorm width:width height:height mipmapped:NO];
                 textureDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
@@ -463,7 +462,7 @@ namespace Babylon::Plugins
 
     void Camera::Impl::Close()
     {
-        m_implData.reset();
+        m_implData.reset(new ImplData);
     }
 }
 

--- a/Plugins/NativeCapture/Source/NativeCapture.cpp
+++ b/Plugins/NativeCapture/Source/NativeCapture.cpp
@@ -90,7 +90,7 @@ namespace
                     // Reading the texture is an async operation, but everything that needs to be done prior to future write operations on that texture is completed synchronously,
                     // so we kick off the read for the next frame prior to the read for the current frame completes.
 
-                    // TODO Address potential race condition during engine shutdown and ReadTextureAsync.
+                    // TODO: #1131 Address potential race condition during engine shutdown and ReadTextureAsync.
                     arcana::task<void, std::exception_ptr> readCurrentFrameTask{thisRef->m_graphicsContext.ReadTextureAsync(thisRef->m_blitTextureHandle, thisRef->m_textureBuffer)
                         .then(arcana::inline_scheduler, thisRef->m_cancellationToken, [thisRef] {
                             thisRef->m_frameCallback(thisRef->m_textureInfo.Width, thisRef->m_textureInfo.Height, thisRef->m_textureInfo.Format, bgfx::getCaps()->originBottomLeft, thisRef->m_textureBuffer);

--- a/Plugins/NativeCapture/Source/NativeCapture.cpp
+++ b/Plugins/NativeCapture/Source/NativeCapture.cpp
@@ -90,6 +90,7 @@ namespace
                     // Reading the texture is an async operation, but everything that needs to be done prior to future write operations on that texture is completed synchronously,
                     // so we kick off the read for the next frame prior to the read for the current frame completes.
 
+                    // TODO Address potential race condition during engine shutdown and ReadTextureAsync.
                     arcana::task<void, std::exception_ptr> readCurrentFrameTask{thisRef->m_graphicsContext.ReadTextureAsync(thisRef->m_blitTextureHandle, thisRef->m_textureBuffer)
                         .then(arcana::inline_scheduler, thisRef->m_cancellationToken, [thisRef] {
                             thisRef->m_frameCallback(thisRef->m_textureInfo.Width, thisRef->m_textureInfo.Height, thisRef->m_textureInfo.Format, bgfx::getCaps()->originBottomLeft, thisRef->m_textureBuffer);


### PR DESCRIPTION
This PR fixes a few issues related to the native camera implementation on iOS and readPixels
1. The current implementation for readTextureAsync assumes that the frame number will always increment by 1 when DeviceImpl::Frame is called.  This would be true if we only ever call bgfx::frame in DeviceImpl::Frame, but we have at least two other call sites for bgfx::frame, so this is not a true assumption.  In general this implementation was prone to the queue getting blocked, so I'm making it a bit more lenient.  (See #1131 for a related issue).
2. NativeCameraImpl was not creating a new ImplData object when calling reset() which meant that the unique pointer was invalid on subesquent NativeCamera open calls, and leading to an AV.
3. On Apple devices when initializing a video texture in landscape mode on we were never creating the textureRGBA object, because the resolution from the camera already matched the initial camera dimensions, so I am explicitly setting the textureRGBA value to null when calling Open and validating that we have a valid texture at the start of updateCameraTexture.
4. iOS was using dispatch_sync when creating video textures, this can cause deadlocks on iOS if already running on the main thread or if the main thread is blocked on the current thread.  Changed this to dispatch_async instead.