### PR TITLE
Console with static methods

### DIFF
--- a/Polyfills/Console/Source/Console.cpp
+++ b/Polyfills/Console/Source/Console.cpp
@@ -31,6 +31,11 @@ namespace Babylon::Polyfills::Internal
                 ParentT::StaticMethod("error", &Console::Error),
             });
 
+        const auto existingConsole = env.Global().Get(JS_INSTANCE_NAME);
+        if (!existingConsole.IsUndefined())
+        {
+            s_engineConsole = std::make_unique<Napi::ObjectReference>(Napi::Persistent(existingConsole.As<Napi::Object>()));
+        }
         env.Global().Set(JS_CONSTRUCTOR_NAME, func);
         s_callback = callback;
     }

--- a/Polyfills/Console/Source/Console.cpp
+++ b/Polyfills/Console/Source/Console.cpp
@@ -32,7 +32,7 @@ namespace Babylon::Polyfills::Internal
             });
 
         env.Global().Set(JS_CONSTRUCTOR_NAME, func);
-        m_callback = callback;
+        s_callback = callback;
     }
 
     Console::Console(const Napi::CallbackInfo& info)
@@ -70,17 +70,17 @@ namespace Babylon::Polyfills::Internal
             ss << info[index].ToString().Utf8Value().c_str();
         }
         ss << std::endl;
-        m_callback(ss.str().c_str(), logLevel);
+        s_callback(ss.str().c_str(), logLevel);
     }
 
     void Console::InvokeEngineCallback(const std::string functionName, const Napi::CallbackInfo& info)
     {
-        if (m_engineConsole != nullptr)
+        if (s_engineConsole != nullptr)
         {
-            const auto engineConsoleFunc = m_engineConsole->Value().Get(functionName).As<Napi::Function>();
+            const auto engineConsoleFunc = s_engineConsole->Value().Get(functionName).As<Napi::Function>();
             if (!engineConsoleFunc.IsUndefined()) {
                 const auto args = GetCallbackInfoArgs(info);
-                engineConsoleFunc.As<Napi::Function>().Call(m_engineConsole->Value(), args.size(), args.data());
+                engineConsoleFunc.As<Napi::Function>().Call(s_engineConsole->Value(), args.size(), args.data());
             }
         }
     }

--- a/Polyfills/Console/Source/Console.cpp
+++ b/Polyfills/Console/Source/Console.cpp
@@ -16,15 +16,13 @@ namespace
 
 namespace Babylon::Polyfills::Internal
 {
-    static constexpr auto JS_CONSTRUCTOR_NAME = "console";
-
     void Console::CreateInstance(Napi::Env env, Babylon::Polyfills::Console::CallbackT callback)
     {
         Napi::HandleScope scope{env};
 
         Napi::Function func = ParentT::DefineClass(
             env,
-            JS_CONSTRUCTOR_NAME,
+            JS_INSTANCE_NAME,
             {
                 ParentT::StaticMethod("log", &Console::Log),
                 ParentT::StaticMethod("warn", &Console::Warn),
@@ -36,7 +34,7 @@ namespace Babylon::Polyfills::Internal
         {
             s_engineConsole = std::make_unique<Napi::ObjectReference>(Napi::Persistent(existingConsole.As<Napi::Object>()));
         }
-        env.Global().Set(JS_CONSTRUCTOR_NAME, func);
+        env.Global().Set(JS_INSTANCE_NAME, func);
         s_callback = callback;
     }
 

--- a/Polyfills/Console/Source/Console.cpp
+++ b/Polyfills/Console/Source/Console.cpp
@@ -32,7 +32,7 @@ namespace Babylon::Polyfills::Internal
         const auto existingConsole = env.Global().Get(JS_INSTANCE_NAME);
         if (!existingConsole.IsUndefined())
         {
-            s_engineConsole = std::make_unique<Napi::ObjectReference>(Napi::Persistent(existingConsole.As<Napi::Object>()));
+            s_engineConsole = Napi::Persistent(existingConsole.As<Napi::Object>());
         }
         env.Global().Set(JS_INSTANCE_NAME, func);
         s_callback = callback;
@@ -78,12 +78,12 @@ namespace Babylon::Polyfills::Internal
 
     void Console::InvokeEngineCallback(const std::string functionName, const Napi::CallbackInfo& info)
     {
-        if (s_engineConsole != nullptr)
+        if (!s_engineConsole.IsEmpty())
         {
-            const auto engineConsoleFunc = s_engineConsole->Value().Get(functionName).As<Napi::Function>();
+            const auto engineConsoleFunc = s_engineConsole.Get(functionName).As<Napi::Function>();
             if (!engineConsoleFunc.IsUndefined()) {
                 const auto args = GetCallbackInfoArgs(info);
-                engineConsoleFunc.As<Napi::Function>().Call(s_engineConsole->Value(), args.size(), args.data());
+                engineConsoleFunc.As<Napi::Function>().Call(s_engineConsole.Value(), args.size(), args.data());
             }
         }
     }

--- a/Polyfills/Console/Source/Console.cpp
+++ b/Polyfills/Console/Source/Console.cpp
@@ -32,7 +32,8 @@ namespace Babylon::Polyfills::Internal
         const auto existingConsole = env.Global().Get(JS_INSTANCE_NAME);
         if (!existingConsole.IsUndefined())
         {
-            s_engineConsole = std::make_shared<Napi::ObjectReference>(Napi::Persistent(existingConsole.As<Napi::Object>()));
+            s_engineConsole = Napi::Persistent(existingConsole.As<Napi::Object>());
+            s_engineConsole.SuppressDestruct();
         }
         env.Global().Set(JS_INSTANCE_NAME, func);
         s_callback = callback;
@@ -41,11 +42,6 @@ namespace Babylon::Polyfills::Internal
     Console::Console(const Napi::CallbackInfo& info)
         : ParentT{info}
     {
-    }
-    
-    Console::~Console()
-    {
-    
     }
 
     void Console::Log(const Napi::CallbackInfo& info)
@@ -83,12 +79,12 @@ namespace Babylon::Polyfills::Internal
 
     void Console::InvokeEngineCallback(const std::string functionName, const Napi::CallbackInfo& info)
     {
-        if (!s_engineConsole.expired())
+        if (!s_engineConsole.IsEmpty())
         {
-            const auto engineConsoleFunc = s_engineConsole.lock()->Value().Get(functionName).As<Napi::Function>();
+            const auto engineConsoleFunc = s_engineConsole.Value().Get(functionName).As<Napi::Function>();
             if (!engineConsoleFunc.IsUndefined()) {
                 const auto args = GetCallbackInfoArgs(info);
-                engineConsoleFunc.As<Napi::Function>().Call(s_engineConsole.lock()->Value(), args.size(), args.data());
+                engineConsoleFunc.As<Napi::Function>().Call(s_engineConsole.Value(), args.size(), args.data());
             }
         }
     }

--- a/Polyfills/Console/Source/Console.h
+++ b/Polyfills/Console/Source/Console.h
@@ -7,6 +7,8 @@ namespace Babylon::Polyfills::Internal
     class Console final : public Napi::ObjectWrap<Console>
     {
     public:
+        static inline constexpr const char* JS_INSTANCE_NAME{"console"};
+
         using ParentT = Napi::ObjectWrap<Console>;
 
         static void CreateInstance(Napi::Env env, Babylon::Polyfills::Console::CallbackT callback);

--- a/Polyfills/Console/Source/Console.h
+++ b/Polyfills/Console/Source/Console.h
@@ -7,8 +7,6 @@ namespace Babylon::Polyfills::Internal
     class Console final : public Napi::ObjectWrap<Console>
     {
     public:
-        static inline constexpr const char* JS_INSTANCE_NAME{"console"};
-
         using ParentT = Napi::ObjectWrap<Console>;
 
         static void CreateInstance(Napi::Env env, Babylon::Polyfills::Console::CallbackT callback);

--- a/Polyfills/Console/Source/Console.h
+++ b/Polyfills/Console/Source/Console.h
@@ -16,13 +16,13 @@ namespace Babylon::Polyfills::Internal
         explicit Console(const Napi::CallbackInfo& info);
 
     private:
-        void Log(const Napi::CallbackInfo& info);
-        void Warn(const Napi::CallbackInfo& info);
-        void Error(const Napi::CallbackInfo& info);
-        void InvokeCallback(const Napi::CallbackInfo& info, Babylon::Polyfills::Console::LogLevel logLevel) const;
-        void InvokeEngineCallback(const std::string functionName, const Napi::CallbackInfo& info);
+        static void Log(const Napi::CallbackInfo& info);
+        static void Warn(const Napi::CallbackInfo& info);
+        static void Error(const Napi::CallbackInfo& info);
+        static void InvokeCallback(const Napi::CallbackInfo& info, Babylon::Polyfills::Console::LogLevel logLevel);
+        static void InvokeEngineCallback(const std::string functionName, const Napi::CallbackInfo& info);
 
-        std::unique_ptr<Napi::ObjectReference> m_engineConsole{};
-        Babylon::Polyfills::Console::CallbackT m_callback{};
+        static inline std::unique_ptr<Napi::ObjectReference> m_engineConsole{};
+        static inline Babylon::Polyfills::Console::CallbackT m_callback{};
     };
 }

--- a/Polyfills/Console/Source/Console.h
+++ b/Polyfills/Console/Source/Console.h
@@ -14,7 +14,6 @@ namespace Babylon::Polyfills::Internal
         static void CreateInstance(Napi::Env env, Babylon::Polyfills::Console::CallbackT callback);
 
         explicit Console(const Napi::CallbackInfo& info);
-        virtual ~Console();
     private:
         static void Log(const Napi::CallbackInfo& info);
         static void Warn(const Napi::CallbackInfo& info);
@@ -22,7 +21,7 @@ namespace Babylon::Polyfills::Internal
         static void InvokeCallback(const Napi::CallbackInfo& info, Babylon::Polyfills::Console::LogLevel logLevel);
         static void InvokeEngineCallback(const std::string functionName, const Napi::CallbackInfo& info);
 
-        static inline std::weak_ptr<Napi::ObjectReference> s_engineConsole{};
+        static inline Napi::ObjectReference s_engineConsole{};
         static inline Babylon::Polyfills::Console::CallbackT s_callback{};
     };
 }

--- a/Polyfills/Console/Source/Console.h
+++ b/Polyfills/Console/Source/Console.h
@@ -22,7 +22,7 @@ namespace Babylon::Polyfills::Internal
         static void InvokeCallback(const Napi::CallbackInfo& info, Babylon::Polyfills::Console::LogLevel logLevel);
         static void InvokeEngineCallback(const std::string functionName, const Napi::CallbackInfo& info);
 
-        static inline std::unique_ptr<Napi::ObjectReference> s_engineConsole{};
+        static inline Napi::ObjectReference s_engineConsole{};
         static inline Babylon::Polyfills::Console::CallbackT s_callback{};
     };
 }

--- a/Polyfills/Console/Source/Console.h
+++ b/Polyfills/Console/Source/Console.h
@@ -20,7 +20,7 @@ namespace Babylon::Polyfills::Internal
         static void InvokeCallback(const Napi::CallbackInfo& info, Babylon::Polyfills::Console::LogLevel logLevel);
         static void InvokeEngineCallback(const std::string functionName, const Napi::CallbackInfo& info);
 
-        static inline std::unique_ptr<Napi::ObjectReference> m_engineConsole{};
-        static inline Babylon::Polyfills::Console::CallbackT m_callback{};
+        static inline std::unique_ptr<Napi::ObjectReference> s_engineConsole{};
+        static inline Babylon::Polyfills::Console::CallbackT s_callback{};
     };
 }

--- a/Polyfills/Console/Source/Console.h
+++ b/Polyfills/Console/Source/Console.h
@@ -14,7 +14,7 @@ namespace Babylon::Polyfills::Internal
         static void CreateInstance(Napi::Env env, Babylon::Polyfills::Console::CallbackT callback);
 
         explicit Console(const Napi::CallbackInfo& info);
-
+        virtual ~Console();
     private:
         static void Log(const Napi::CallbackInfo& info);
         static void Warn(const Napi::CallbackInfo& info);
@@ -22,7 +22,7 @@ namespace Babylon::Polyfills::Internal
         static void InvokeCallback(const Napi::CallbackInfo& info, Babylon::Polyfills::Console::LogLevel logLevel);
         static void InvokeEngineCallback(const std::string functionName, const Napi::CallbackInfo& info);
 
-        static inline Napi::ObjectReference s_engineConsole{};
+        static inline std::weak_ptr<Napi::ObjectReference> s_engineConsole{};
         static inline Babylon::Polyfills::Console::CallbackT s_callback{};
     };
 }


### PR DESCRIPTION
Recent changes with logger assume console.log/warn/err are static methods.

https://github.com/BabylonJS/Babylon.js/blob/ddb79112d18e74de7a98826c7d4a85f857314783/packages/dev/core/src/Misc/logger.ts#L103

This PR changes console polyfill to use static methods as well.