### PR TITLE
Fix iOS Camera Texture memory leak on dispose

### DIFF
--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
@@ -29,7 +29,7 @@ namespace Babylon::Plugins
         Graphics::DeviceContext* m_deviceContext;
         Napi::Env m_env;
 
-        std::shared_ptr<ImplData> m_implData;
+        std::unique_ptr<ImplData> m_implData;
 
         bool m_overrideCameraTexture{};
 

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -603,7 +603,7 @@ namespace Babylon::Plugins
 /**
  Updates the captured texture with the current pixel buffer.
 */
-- (CVMetalTextureRef)getCameraTexture:(CVPixelBufferRef)pixelBuffer plane:(int)planeIndex {    
+- (CVMetalTextureRef)getCameraTexture:(CVPixelBufferRef)pixelBuffer plane:(int)planeIndex {
     CVReturn ret = CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
     if (ret != kCVReturnSuccess) {
         return {};


### PR DESCRIPTION
The current implementation of the cameraTextureDelegate was taking a strong reference to the implData object, which was preventing the destructor from being run on camera close.  This PR adds a small cleanup protocol to cleanly handle deallocation, and removes the circular reference.

Before:
<img width="993" alt="Screen Shot 2022-09-13 at 10 39 43 AM" src="https://user-images.githubusercontent.com/27031140/189985843-388f0509-9285-498d-9213-226477f12702.png">

After:
<img width="993" alt="Screen Shot 2022-09-13 at 11 50 13 AM" src="https://user-images.githubusercontent.com/27031140/189985856-a16786ff-b52f-4058-9d81-2a79cba2e501.png">
