### PR TITLE
NativeCamera - Use the main camera on iOS rather than virtual camera

### DIFF
--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -202,29 +202,30 @@ namespace Babylon::Plugins
             uint32_t bestPixelCount{0};
             uint32_t devicePixelFormat{0};
             uint32_t bestDimDiff{0};
-            NSArray* deviceTypes{nullptr};
+            NSArray* deviceTypes{@[
+                // Use the main camera on the device which is best for general use and will typically be 1x optical zoom and the highest resolution.
+                // https://developer.apple.com/documentation/avfoundation/avcapturedevice/devicetype/2361449-builtinwideanglecamera
+                AVCaptureDeviceTypeBuiltInWideAngleCamera
+            ]};
             bool foundExactMatch{false};
-            if (@available(iOS 13.0, *))
-            {
-                // Ordered list of cameras by general usage quality.
-                deviceTypes = @[
-                    AVCaptureDeviceTypeBuiltInTripleCamera,
-                    AVCaptureDeviceTypeBuiltInDualCamera,
-                    AVCaptureDeviceTypeBuiltInDualWideCamera,
-                    AVCaptureDeviceTypeBuiltInWideAngleCamera,
-                    AVCaptureDeviceTypeBuiltInUltraWideCamera,
-                    AVCaptureDeviceTypeBuiltInTelephotoCamera,
-                    AVCaptureDeviceTypeBuiltInTrueDepthCamera
-                ];
-            }
-            else
-            {
-                // Only these camera types are available for all devices
-                deviceTypes = @[
-                    AVCaptureDeviceTypeBuiltInDualCamera,
-                    AVCaptureDeviceTypeBuiltInWideAngleCamera
-                ];
-            }
+
+            // The below code would allow us to choose virtual cameras which dynamically switch between the different physical
+            // camera sensors based on different zoom levels. Until we support letting the consumer modify the camera's zoom
+            // it would result in often being stuck on the most zoomed out camera on the device which is often not desired.
+            
+            // if (@available(iOS 13.0, *))
+            // {
+            //     // Ordered list of cameras by general usage quality.
+            //     deviceTypes = @[
+            //         AVCaptureDeviceTypeBuiltInTripleCamera,
+            //         AVCaptureDeviceTypeBuiltInDualCamera,
+            //         AVCaptureDeviceTypeBuiltInDualWideCamera,
+            //         AVCaptureDeviceTypeBuiltInWideAngleCamera,
+            //         AVCaptureDeviceTypeBuiltInUltraWideCamera,
+            //         AVCaptureDeviceTypeBuiltInTelephotoCamera,
+            //         AVCaptureDeviceTypeBuiltInTrueDepthCamera
+            //     ];
+            // }
 
             AVCaptureDeviceDiscoverySession* discoverySession{[AVCaptureDeviceDiscoverySession
                discoverySessionWithDeviceTypes:deviceTypes
@@ -294,6 +295,7 @@ namespace Babylon::Plugins
             
             [m_implData->avCaptureSession setSessionPreset:AVCaptureSessionPresetInputPriority];
             [bestDevice setActiveFormat:bestFormat];
+            [bestDevice setVideoZoomFactor:1.0];
             AVCaptureDeviceInput *input{[AVCaptureDeviceInput deviceInputWithDevice:bestDevice error:&error]};
             [bestDevice unlockForConfiguration];
             

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -295,7 +295,6 @@ namespace Babylon::Plugins
             
             [m_implData->avCaptureSession setSessionPreset:AVCaptureSessionPresetInputPriority];
             [bestDevice setActiveFormat:bestFormat];
-            [bestDevice setVideoZoomFactor:1.0];
             AVCaptureDeviceInput *input{[AVCaptureDeviceInput deviceInputWithDevice:bestDevice error:&error]};
             [bestDevice unlockForConfiguration];
             


### PR DESCRIPTION
This change makes it so that the NativeCamera plugin on iOS will use the devices main/primary camera for the VideoTexture. Previously it was picking the virtual (dual/triple) camera's first. The dual and triple cameras are a virtual camera that will swap between the different physical sensors on the device based on the zoom factor. Generally speaker they are the better camera to choose IF you are also in control of the zoom factor. That isn't currently the case for the Babylon implementation so it will be better to choose the main camera sensor instead of one of the virtual sensors.