### PR TITLE
iOS NativeCamera session start/stop synchronization

### DIFF
--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
@@ -34,5 +34,7 @@ namespace Babylon::Plugins
         bool m_overrideCameraTexture{};
 
         CameraDimensions m_cameraDimensions{};
+
+        arcana::background_dispatcher<32> m_cameraDispatcher{};
     };
 }

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.h
@@ -35,6 +35,6 @@ namespace Babylon::Plugins
 
         CameraDimensions m_cameraDimensions{};
 
-        arcana::background_dispatcher<32> m_cameraDispatcher{};
+        arcana::background_dispatcher<32> m_cameraSessionDispatcher{};
     };
 }

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -339,36 +339,36 @@ namespace Babylon::Plugins
         }
 
         // Kick off camera session on a background thread.
-        return arcana::make_task(m_cameraSessionDispatcher, arcana::cancellation::none(), [this, input, devicePixelFormat, cameraDimensions]() mutable {
-            if (m_implData->avCaptureSession == nil) {
-                m_implData->avCaptureSession = [[AVCaptureSession alloc] init];
+        return arcana::make_task(m_cameraSessionDispatcher, arcana::cancellation::none(), [implObj = shared_from_this(), input, devicePixelFormat, cameraDimensions]() mutable {
+            if (implObj->m_implData->avCaptureSession == nil) {
+                implObj->m_implData->avCaptureSession = [[AVCaptureSession alloc] init];
             } else {
-                for (AVCaptureInput* input in [m_implData->avCaptureSession inputs]) {
-                    [m_implData->avCaptureSession removeInput: input];
+                for (AVCaptureInput* input in [implObj->m_implData->avCaptureSession inputs]) {
+                    [implObj->m_implData->avCaptureSession removeInput: input];
                 }
 
-                for (AVCaptureOutput* output in [m_implData->avCaptureSession outputs]) {
-                    [m_implData->avCaptureSession removeOutput: output];
+                for (AVCaptureOutput* output in [implObj->m_implData->avCaptureSession outputs]) {
+                    [implObj->m_implData->avCaptureSession removeOutput: output];
                 }
             }
 
 #if (TARGET_OS_IPHONE)
-            [m_implData->avCaptureSession setSessionPreset:AVCaptureSessionPresetInputPriority];
+            [implObj->m_implData->avCaptureSession setSessionPreset:AVCaptureSessionPresetInputPriority];
 #endif
 
             // Add camera input source to the capture session.
-            [m_implData->avCaptureSession addInput:input];
+            [implObj->m_implData->avCaptureSession addInput:input];
 
             // Create the camera buffer, and set up camera texture delegate to capture frames.
             dispatch_queue_t sampleBufferQueue{dispatch_queue_create("CameraMulticaster", DISPATCH_QUEUE_SERIAL)};
             AVCaptureVideoDataOutput* dataOutput{[[AVCaptureVideoDataOutput alloc] init]};
             [dataOutput setAlwaysDiscardsLateVideoFrames:YES];
             [dataOutput setVideoSettings:@{(id)kCVPixelBufferPixelFormatTypeKey: @(devicePixelFormat)}];
-            [dataOutput setSampleBufferDelegate:m_implData->cameraTextureDelegate queue:sampleBufferQueue];
-            [m_implData->avCaptureSession addOutput:dataOutput];
+            [dataOutput setSampleBufferDelegate:implObj->m_implData->cameraTextureDelegate queue:sampleBufferQueue];
+            [implObj->m_implData->avCaptureSession addOutput:dataOutput];
 
             // Actually start the camera session.
-            [m_implData->avCaptureSession startRunning];
+            [implObj->m_implData->avCaptureSession startRunning];
             return cameraDimensions;
         });
     }
@@ -486,8 +486,8 @@ namespace Babylon::Plugins
         }
 
         if (m_implData->avCaptureSession != nil) {
-            arcana::make_task(m_cameraSessionDispatcher, arcana::cancellation::none(), [this](){
-                [m_implData->avCaptureSession stopRunning];
+            arcana::make_task(m_cameraSessionDispatcher, arcana::cancellation::none(), [implObj = shared_from_this()](){
+                [implObj->m_implData->avCaptureSession stopRunning];
             });
         }
     }

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -614,6 +614,11 @@ namespace Babylon::Plugins
     CVMetalTextureRef textureCbCr = [self getCameraTexture:pixelBuffer plane:1];
 
     @synchronized(self) {
+        // It's possible that the texture cache has been invalidated, in which case we should skip assignment.
+        if (self->textureCache == nil) {
+            return;
+        }
+
         [self cleanupTextures];
         cameraTextureY = textureY;
         cameraTextureCbCr = textureCbCr;

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -414,6 +414,7 @@ namespace Babylon::Plugins
             } else if (m_implData->refreshBgfxHandle) {
                 // On texture re-use across sessions set the bgfx texture handle.
                 bgfx::overrideInternal(textureHandle, reinterpret_cast<uintptr_t>(m_implData->textureRGBA));
+                m_implData->refreshBgfxHandle = false;
             }
 
             if (textureY != nil && textureCbCr != nil && m_implData->textureRGBA != nil)
@@ -466,7 +467,7 @@ namespace Babylon::Plugins
 
     void Camera::Impl::Close()
     {
-        // Stop collecting frames, release up camera texture delegate.
+        // Stop collecting frames, release camera texture delegate.
         [m_implData->cameraTextureDelegate reset];
         m_implData->cameraTextureDelegate = nil;
 
@@ -538,10 +539,6 @@ namespace Babylon::Plugins
 }
 
 - (void) reset {
-#if (TARGET_OS_IPHONE)
-        [[NSNotificationCenter defaultCenter]removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
-#endif
-
     @synchronized (self) {
         [self cleanupTextures];
         self->textureCache = nil;
@@ -666,6 +663,10 @@ namespace Babylon::Plugins
 }
 
 -(void)dealloc {
+#if (TARGET_OS_IPHONE)
+        [[NSNotificationCenter defaultCenter]removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
+#endif
+
     [self reset];
 }
 

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -145,13 +145,13 @@ namespace Babylon::Plugins
 
             dispatch_async(cameraQueue, ^{
                 [avCaptureSession stopRunning];
-
-                if (textureCache)
-                {
-                    CVMetalTextureCacheFlush(textureCache, 0);
-                    CFRelease(textureCache);
-                }
             });
+            
+            if (textureCache)
+            {
+                CVMetalTextureCacheFlush(textureCache, 0);
+                CFRelease(textureCache);
+            }
         }
         
         CameraTextureDelegate* cameraTextureDelegate{};

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -312,7 +312,6 @@ namespace Babylon::Plugins
         UNUSED(maxWidth);
         UNUSED(maxHeight);
         UNUSED(frontCamera);
-        NSError *error{nil};
         AVCaptureDevice* captureDevice{[AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo]};
         AVCaptureDeviceInput *input{[AVCaptureDeviceInput deviceInputWithDevice:captureDevice error:&error]};
         CMVideoFormatDescriptionRef videoFormatRef{static_cast<CMVideoFormatDescriptionRef>(captureDevice.activeFormat.formatDescription)};
@@ -320,7 +319,7 @@ namespace Babylon::Plugins
         uint32_t devicePixelFormat{static_cast<uint32_t>(CMFormatDescriptionGetMediaSubType(videoFormatRef))};
         if (!isPixelFormatSupported(devicePixelFormat))
         {
-            return arcana::task_from_error<CameraDimensions>(std::make_exception_ptr(runtime_error{"ConstraintError: Unable to match constraints to a supported camera configuration."}));
+            return arcana::task_from_error<CameraDimensions>(std::make_exception_ptr(std::runtime_error{"ConstraintError: Unable to match constraints to a supported camera configuration."}));
         }
 #endif
 

--- a/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
+++ b/Plugins/NativeCamera/Source/Apple/NativeCameraImpl.mm
@@ -146,7 +146,7 @@ namespace Babylon::Plugins
             dispatch_async(cameraQueue, ^{
                 [avCaptureSession stopRunning];
             });
-            
+
             if (textureCache)
             {
                 CVMetalTextureCacheFlush(textureCache, 0);

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1409,13 +1409,20 @@ namespace Babylon
                 }
 
                 return textureBuffer;
-            }).then(m_runtimeScheduler, *m_cancellationSource, [bufferRef{Napi::Persistent(buffer)}, bufferOffset, deferred](std::vector<uint8_t> textureBuffer) {
+            }).then(m_runtimeScheduler, *m_cancellationSource, [this, bufferRef{Napi::Persistent(buffer)}, bufferOffset, deferred, tempTexture, sourceTextureHandle](std::vector<uint8_t> textureBuffer) mutable {
                 // Double check the destination buffer length. This is redundant with prior checks, but we'll be extra sure before the memcpy.
                 assert(bufferRef.Value().ByteLength() - bufferOffset >= textureBuffer.size());
 
                 // Copy the pixel data into the JS ArrayBuffer.
                 uint8_t* buffer{static_cast<uint8_t*>(bufferRef.Value().Data())};
                 std::memcpy(buffer + bufferOffset, textureBuffer.data(), textureBuffer.size());
+
+                if (tempTexture && !m_cancellationSource->cancelled())
+                {
+                    bgfx::destroy(sourceTextureHandle);
+                    tempTexture = false;
+                }
+
                 deferred.Resolve(bufferRef.Value());
             }).then(m_runtimeScheduler, arcana::cancellation::none(), [this, env, deferred, tempTexture, sourceTextureHandle](const arcana::expected<void, std::exception_ptr>& result) {
                 if (tempTexture && !m_cancellationSource->cancelled())

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1417,8 +1417,8 @@ namespace Babylon
                 uint8_t* buffer{static_cast<uint8_t*>(bufferRef.Value().Data())};
                 std::memcpy(buffer + bufferOffset, textureBuffer.data(), textureBuffer.size());
                 deferred.Resolve(bufferRef.Value());
-            }).then(m_runtimeScheduler, arcana::cancellation::none(), [env, deferred, tempTexture, sourceTextureHandle](const arcana::expected<void, std::exception_ptr>& result) {
-                if (tempTexture)
+            }).then(m_runtimeScheduler, arcana::cancellation::none(), [this, env, deferred, tempTexture, sourceTextureHandle](const arcana::expected<void, std::exception_ptr>& result) {
+                if (tempTexture && !m_cancellationSource->cancelled())
                 {
                     bgfx::destroy(sourceTextureHandle);
                 }


### PR DESCRIPTION
# Description
This PR fixes a few issues around NativeCamera start/stop synchronization.  

- The primary change is switching from using dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) to using an arcana background scheduler for starting/stopping the AR camera session.  This is necessary as calls to  avCaptureSession stopRunning and avCaptureSession startRunning must be serialized or it will result in a crash at runtime.
- The second major change is changing CameraImpl to not be disposed on reset, but to instead handle managing its resources, and re-use durable resources across sessions.
- Removed unnecessary dispatch to the main thread in Open which could cause the camera to hang
- Texture creation promise will not resolve until the native camera session is actually ready

I recommend viewing this PR with [whitespace ignored](https://github.com/BabylonJS/BabylonNative/pull/1137/files?diff=split&w=1), as the removal of the synchronization caused a lot of spacing changes.

# Validation
Ran in the Babylon Native Playground, as well as in our test application that consumes this code through Babylon React Native and heavily exercises this code path.