### PR TITLE
XMLHttpRequest headers

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,26 +14,12 @@ jobs:
       uses: actions/checkout@master
       with:
         submodules: 'recursive'
-    - name: Download babylon.max.js
-      run: curl.exe -o Apps/node_modules/babylonjs/babylon.max.js --create-dirs https://preview.babylonjs.com/babylon.max.js
-    - name: Download babylon.max.js.map
-      run: curl.exe -o Apps/node_modules/babylonjs/babylon.max.js.map --create-dirs https://preview.babylonjs.com/babylon.max.js.map
-    - name: Download babylonjs.materials.js
-      run: curl.exe -o Apps/node_modules/babylonjs-materials/babylonjs.materials.js --create-dirs https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js
-    - name: Download babylonjs.materials.js.map
-      run: curl.exe -o Apps/node_modules/babylonjs-materials/babylonjs.materials.js.map --create-dirs https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js.map
-    - name: Download babylon.loaders.js
-      run: curl.exe -o Apps/node_modules/babylonjs-loaders/babylonjs.loaders.js --create-dirs https://preview.babylonjs.com/loaders/babylonjs.loaders.js
-    - name: Download babylon.loaders.js.map
-      run: curl.exe -o Apps/node_modules/babylonjs-loaders/babylonjs.loaders.js.map --create-dirs https://preview.babylonjs.com/loaders/babylonjs.loaders.js.map
-    - name: Download babylon.gui.js
-      run: curl.exe -o Apps/node_modules/babylonjs-gui/babylon.gui.js --create-dirs https://preview.babylonjs.com/gui/babylon.gui.js
-    - name: Download babylon.gui.js.map
-      run: curl.exe -o Apps/node_modules/babylonjs-gui/babylon.gui.js.map --create-dirs https://preview.babylonjs.com/gui/babylon.gui.js.map
-    - name: Download chai.js
-      run: curl.exe -o Apps/node_modules/chai/chai.js --create-dirs https://unpkg.com/chai/chai.js
-    - name: Download mocha.js
-      run: curl.exe -o Apps/node_modules/mocha/mocha.js --create-dirs https://unpkg.com/mocha/mocha.js
+    - name: NPM Install
+      run: npm install
+      working-directory: ./Apps
+    - name: NPM download nightly
+      run: npm run getNightly
+      working-directory: ./Apps
     - name: View Apps\node_modules content
       run: Get-ChildItem -Path .\Apps\node_modules -Recurse
     - name: Make Solution

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -2,6 +2,9 @@
   "name": "BabylonNative",
   "version": "0.0.1",
   "private": true,
+  "scripts": {
+    "getNightly": "node scripts/getNightly.js"
+  },
   "dependencies": {
     "babylonjs": "^5.17.0",
     "babylonjs-gui": "^5.17.0",

--- a/Apps/scripts/getNightly.js
+++ b/Apps/scripts/getNightly.js
@@ -1,0 +1,21 @@
+var https = require('https');
+var fs = require('fs');
+
+function download(filename, url) {
+  var file = fs.createWriteStream(filename);
+  var request = https.get(url, function(response) {
+    response.pipe(file);
+  });
+}
+
+console.log('Downloading babylon.js nightly');
+download('node_modules/babylonjs/babylon.max.js', 'https://preview.babylonjs.com/babylon.max.js');
+download('node_modules/babylonjs/babylon.max.js.map', 'https://preview.babylonjs.com/babylon.max.js.map');
+download('node_modules/babylonjs-materials/babylonjs.materials.js', 'https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js');
+download('node_modules/babylonjs-materials/babylonjs.materials.js.map', 'https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js.map');
+download('node_modules/babylonjs-loaders/babylonjs.loaders.js', 'https://preview.babylonjs.com/loaders/babylonjs.loaders.js');
+download('node_modules/babylonjs-loaders/babylonjs.loaders.js.map', 'https://preview.babylonjs.com/loaders/babylonjs.loaders.js.map');
+download('node_modules/babylonjs-gui/babylon.gui.js', 'https://preview.babylonjs.com/gui/babylon.gui.js');
+download('node_modules/babylonjs-gui/babylon.gui.js.map', 'https://preview.babylonjs.com/gui/babylon.gui.js.map');
+download('node_modules/chai/chai.js', 'https://unpkg.com/chai/chai.js');
+download('node_modules/mocha/mocha.js', 'https://unpkg.com/mocha/mocha.js');

--- a/Apps/scripts/getNightly.js
+++ b/Apps/scripts/getNightly.js
@@ -17,5 +17,3 @@ download('node_modules/babylonjs-loaders/babylonjs.loaders.js', 'https://preview
 download('node_modules/babylonjs-loaders/babylonjs.loaders.js.map', 'https://preview.babylonjs.com/loaders/babylonjs.loaders.js.map');
 download('node_modules/babylonjs-gui/babylon.gui.js', 'https://preview.babylonjs.com/gui/babylon.gui.js');
 download('node_modules/babylonjs-gui/babylon.gui.js.map', 'https://preview.babylonjs.com/gui/babylon.gui.js.map');
-//download('node_modules/chai/chai.js', 'https://unpkg.com/chai/chai.js');
-//download('node_modules/mocha/mocha.js', 'https://unpkg.com/mocha/mocha.js');

--- a/Apps/scripts/getNightly.js
+++ b/Apps/scripts/getNightly.js
@@ -17,5 +17,5 @@ download('node_modules/babylonjs-loaders/babylonjs.loaders.js', 'https://preview
 download('node_modules/babylonjs-loaders/babylonjs.loaders.js.map', 'https://preview.babylonjs.com/loaders/babylonjs.loaders.js.map');
 download('node_modules/babylonjs-gui/babylon.gui.js', 'https://preview.babylonjs.com/gui/babylon.gui.js');
 download('node_modules/babylonjs-gui/babylon.gui.js.map', 'https://preview.babylonjs.com/gui/babylon.gui.js.map');
-download('node_modules/chai/chai.js', 'https://unpkg.com/chai/chai.js');
-download('node_modules/mocha/mocha.js', 'https://unpkg.com/mocha/mocha.js');
+//download('node_modules/chai/chai.js', 'https://unpkg.com/chai/chai.js');
+//download('node_modules/mocha/mocha.js', 'https://unpkg.com/mocha/mocha.js');

--- a/Dependencies/UrlLib/Include/UrlLib/UrlLib.h
+++ b/Dependencies/UrlLib/Include/UrlLib/UrlLib.h
@@ -39,7 +39,7 @@ namespace UrlLib
 
         void Abort();
 
-        void Open(UrlMethod method, std::string url);
+        void Open(UrlMethod method, const std::string& url);
 
         UrlResponseType ResponseType() const;
 
@@ -53,9 +53,7 @@ namespace UrlLib
 
         std::string_view ResponseString() const;
 
-        std::string ResponseHeader(const std::string& headerName) const;
-
-        std::string ResponseHeaders() const;
+        std::optional<std::string> GetResponseHeader(const std::string& headerName) const;
 
         gsl::span<const std::byte> ResponseBuffer() const;
 

--- a/Dependencies/UrlLib/Include/UrlLib/UrlLib.h
+++ b/Dependencies/UrlLib/Include/UrlLib/UrlLib.h
@@ -53,6 +53,10 @@ namespace UrlLib
 
         std::string_view ResponseString() const;
 
+        std::string ResponseHeader(const std::string& headerName) const;
+
+        std::string ResponseHeaders() const;
+
         gsl::span<const std::byte> ResponseBuffer() const;
 
     private:

--- a/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
@@ -188,7 +188,7 @@ namespace UrlLib
             return m_responseBuffer;
         }
 
-        std::string ResponseHeader(const std::string& headerName) const
+        std::string ResponseHeader(const std::string& /*headerName*/) const
         {
             // todo: implementation
             return {};

--- a/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
@@ -188,6 +188,18 @@ namespace UrlLib
             return m_responseBuffer;
         }
 
+        std::string ResponseHeader(const std::string& headerName) const
+        {
+            // todo: implementation
+            return {}};
+        }
+
+        std::string ResponseHeaders() const
+        {
+            // todo: implementation
+            return {};
+        }
+
     private:
         arcana::cancellation_source m_cancellationSource{};
         UrlResponseType m_responseType{UrlResponseType::String};

--- a/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
@@ -42,7 +42,7 @@ namespace UrlLib
             m_cancellationSource.cancel();
         }
 
-        void Open(UrlMethod method, std::string url)
+        void Open(UrlMethod method, const std::string& url)
         {
             m_method = method;
             Uri uri{Uri::Parse(url.data())};
@@ -188,13 +188,7 @@ namespace UrlLib
             return m_responseBuffer;
         }
 
-        std::string ResponseHeader(const std::string& /*headerName*/) const
-        {
-            // todo: implementation
-            return {};
-        }
-
-        std::string ResponseHeaders() const
+        std::optional<std::string> GetResponseHeader(const std::string& /*headerName*/) const
         {
             // todo: implementation
             return {};

--- a/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Android/UrlRequest.cpp
@@ -191,7 +191,7 @@ namespace UrlLib
         std::string ResponseHeader(const std::string& headerName) const
         {
             // todo: implementation
-            return {}};
+            return {};
         }
 
         std::string ResponseHeaders() const

--- a/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
+++ b/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
@@ -142,6 +142,18 @@ namespace UrlLib
             return {};
         }
 
+        std::string ResponseHeader(const std::string& headerName) const
+        {
+            // todo: implementation
+            return {}};
+        }
+
+        std::string ResponseHeaders() const
+        {
+            // todo: implementation
+            return {};
+        }
+
     private:
         arcana::cancellation_source m_cancellationSource{};
         UrlResponseType m_responseType{UrlResponseType::String};

--- a/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
+++ b/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
@@ -142,7 +142,7 @@ namespace UrlLib
             return {};
         }
 
-        std::string ResponseHeader(const std::string& headerName) const
+        std::string ResponseHeader(const std::string& /*headerName*/) const
         {
             // todo: implementation
             return {};

--- a/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
+++ b/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
@@ -23,7 +23,7 @@ namespace UrlLib
             m_cancellationSource.cancel();
         }
 
-        void Open(UrlMethod method, std::string url)
+        void Open(UrlMethod method, const std::string& url)
         {
             m_method = method;
             NSString* urlString = [NSString stringWithUTF8String:url.data()];
@@ -142,13 +142,7 @@ namespace UrlLib
             return {};
         }
 
-        std::string ResponseHeader(const std::string& /*headerName*/) const
-        {
-            // todo: implementation
-            return {};
-        }
-
-        std::string ResponseHeaders() const
+        std::optional<std::string> GetResponseHeader(const std::string& /*headerName*/) const
         {
             // todo: implementation
             return {};

--- a/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
+++ b/Dependencies/UrlLib/Source/Apple/UrlRequest.mm
@@ -145,7 +145,7 @@ namespace UrlLib
         std::string ResponseHeader(const std::string& headerName) const
         {
             // todo: implementation
-            return {}};
+            return {};
         }
 
         std::string ResponseHeaders() const

--- a/Dependencies/UrlLib/Source/Shared/UrlRequest.h
+++ b/Dependencies/UrlLib/Source/Shared/UrlRequest.h
@@ -22,9 +22,9 @@ namespace UrlLib
         m_impl->Abort();
     }
 
-    void UrlRequest::Open(UrlMethod method, std::string url)
+    void UrlRequest::Open(UrlMethod method, const std::string& url)
     {
-        m_impl->Open(method, std::move(url));
+        m_impl->Open(method, url);
     }
 
     UrlResponseType UrlRequest::ResponseType() const
@@ -57,14 +57,9 @@ namespace UrlLib
         return m_impl->ResponseString();
     }
 
-    std::string UrlRequest::ResponseHeader(const std::string& headerName) const
+    std::optional<std::string> UrlRequest::GetResponseHeader(const std::string& headerName) const
     {
-        return m_impl->ResponseHeader(headerName);
-    }
-
-    std::string UrlRequest::ResponseHeaders() const
-    {
-        return m_impl->ResponseHeaders();
+        return m_impl->GetResponseHeader(headerName);
     }
 
     gsl::span<const std::byte> UrlRequest::ResponseBuffer() const

--- a/Dependencies/UrlLib/Source/Shared/UrlRequest.h
+++ b/Dependencies/UrlLib/Source/Shared/UrlRequest.h
@@ -57,6 +57,16 @@ namespace UrlLib
         return m_impl->ResponseString();
     }
 
+    std::string UrlRequest::ResponseHeader(const std::string& headerName) const
+    {
+        return m_impl->ResponseHeader(headerName);
+    }
+
+    std::string UrlRequest::ResponseHeaders() const
+    {
+        return m_impl->ResponseHeaders();
+    }
+
     gsl::span<const std::byte> UrlRequest::ResponseBuffer() const
     {
         return m_impl->ResponseBuffer();

--- a/Dependencies/UrlLib/Source/Unix/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Unix/UrlRequest.cpp
@@ -21,7 +21,7 @@ namespace UrlLib
             m_cancellationSource.cancel();
         }
 
-        void Open(UrlMethod method, std::string url)
+        void Open(UrlMethod method, const std::string& url)
         {
             m_method = method;
             if (m_curl)
@@ -118,13 +118,7 @@ namespace UrlLib
             return m_responseBuffer;
         }
 
-        std::string ResponseHeader(const std::string& /*headerName*/) const
-        {
-            // todo: implementation
-            return {};
-        }
-
-        std::string ResponseHeaders() const
+        std::optional<std::string> GetResponseHeader(const std::string& /*headerName*/) const
         {
             // todo: implementation
             return {};

--- a/Dependencies/UrlLib/Source/Unix/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Unix/UrlRequest.cpp
@@ -118,6 +118,18 @@ namespace UrlLib
             return m_responseBuffer;
         }
 
+        std::string ResponseHeader(const std::string& headerName) const
+        {
+            // todo: implementation
+            return {}};
+        }
+
+        std::string ResponseHeaders() const
+        {
+            // todo: implementation
+            return {};
+        }
+
     private:
         struct CurlMulti
         {

--- a/Dependencies/UrlLib/Source/Unix/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Unix/UrlRequest.cpp
@@ -118,7 +118,7 @@ namespace UrlLib
             return m_responseBuffer;
         }
 
-        std::string ResponseHeader(const std::string& headerName) const
+        std::string ResponseHeader(const std::string& /*headerName*/) const
         {
             // todo: implementation
             return {};

--- a/Dependencies/UrlLib/Source/Unix/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Unix/UrlRequest.cpp
@@ -121,7 +121,7 @@ namespace UrlLib
         std::string ResponseHeader(const std::string& headerName) const
         {
             // todo: implementation
-            return {}};
+            return {};
         }
 
         std::string ResponseHeaders() const

--- a/Dependencies/UrlLib/Source/Windows/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Windows/UrlRequest.cpp
@@ -7,6 +7,7 @@
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.Web.Http.h>
 #include <winrt/Windows.ApplicationModel.h>
+#include <winrt/Windows.Foundation.Collections.h>
 
 namespace UrlLib
 {
@@ -114,6 +115,11 @@ namespace UrlLib
 
                             m_responseUrl = winrt::to_string(responseMessage.RequestMessage().RequestUri().RawUri());
 
+                            for (auto&& iter : responseMessage.Headers())
+                            {
+                                m_headers.insert(std::make_pair(winrt::to_string(iter.Key()), winrt::to_string(iter.Value())));
+                            }
+
                             switch (m_responseType)
                             {
                                 case UrlResponseType::String:
@@ -162,6 +168,29 @@ namespace UrlLib
         std::string_view ResponseString()
         {
             return m_responseString;
+        }
+
+        std::string ResponseHeader(const std::string& headerName) const
+        {
+            const auto iter = m_headers.find(headerName);
+            if (iter != m_headers.end())
+            {
+                return iter->second;
+            }
+            return {};
+        }
+
+        std::string ResponseHeaders() const
+        {
+            std::string str{};
+            for (auto& iter : m_headers)
+            {
+                str += iter.first;
+                str += ":";
+                str += iter.second;
+                str += "\n";
+            }
+            return str;
         }
 
         gsl::span<const std::byte> ResponseBuffer() const
@@ -213,6 +242,7 @@ namespace UrlLib
         std::string m_responseUrl{};
         std::string m_responseString{};
         Storage::Streams::IBuffer m_responseBuffer{};
+        std::map<std::string, std::string> m_headers; 
     };
 }
 

--- a/Dependencies/UrlLib/Source/Windows/UrlRequest.cpp
+++ b/Dependencies/UrlLib/Source/Windows/UrlRequest.cpp
@@ -60,7 +60,7 @@ namespace UrlLib
             m_cancellationSource.cancel();
         }
 
-        void Open(UrlMethod method, std::string url)
+        void Open(UrlMethod method, const std::string& url)
         {
             m_method = method;
             m_uri = Foundation::Uri{winrt::to_hstring(url)};
@@ -170,7 +170,7 @@ namespace UrlLib
             return m_responseString;
         }
 
-        std::string ResponseHeader(const std::string& headerName) const
+        std::optional<std::string> GetResponseHeader(const std::string& headerName) const
         {
             const auto iter = m_headers.find(headerName);
             if (iter != m_headers.end())
@@ -178,19 +178,6 @@ namespace UrlLib
                 return iter->second;
             }
             return {};
-        }
-
-        std::string ResponseHeaders() const
-        {
-            std::string str{};
-            for (auto& iter : m_headers)
-            {
-                str += iter.first;
-                str += ":";
-                str += iter.second;
-                str += "\n";
-            }
-            return str;
         }
 
         gsl::span<const std::byte> ResponseBuffer() const

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
@@ -100,6 +100,8 @@ namespace Babylon::Polyfills::Internal
                 InstanceAccessor("responseType", &XMLHttpRequest::GetResponseType, &XMLHttpRequest::SetResponseType),
                 InstanceAccessor("responseURL", &XMLHttpRequest::GetResponseURL, nullptr),
                 InstanceAccessor("status", &XMLHttpRequest::GetStatus, nullptr),
+                InstanceMethod("getResponseHeader", &XMLHttpRequest::GetResponseHeader),
+                InstanceMethod("getAllResponseHeaders", &XMLHttpRequest::GetAllResponseHeaders),
                 InstanceMethod("addEventListener", &XMLHttpRequest::AddEventListener),
                 InstanceMethod("removeEventListener", &XMLHttpRequest::RemoveEventListener),
                 InstanceMethod("abort", &XMLHttpRequest::Abort),
@@ -128,8 +130,8 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value XMLHttpRequest::GetResponse(const Napi::CallbackInfo&)
     {
-        gsl::span<const std::byte> responseBuffer{m_request.ResponseBuffer()};
-        auto arrayBuffer{Napi::ArrayBuffer::New(Env(), responseBuffer.size())};
+        const gsl::span<const std::byte> responseBuffer{m_request.ResponseBuffer()};
+        const auto arrayBuffer{Napi::ArrayBuffer::New(Env(), responseBuffer.size())};
         std::memcpy(arrayBuffer.Data(), responseBuffer.data(), arrayBuffer.ByteLength());
         return std::move(arrayBuffer);
     }
@@ -149,6 +151,17 @@ namespace Babylon::Polyfills::Internal
         m_request.ResponseType(ResponseType::StringToEnum(value.As<Napi::String>().Utf8Value()));
     }
 
+    Napi::Value XMLHttpRequest::GetResponseHeader(const Napi::CallbackInfo& info)
+    {
+        const auto headerName{info[0].As<Napi::String>().Utf8Value()};
+        return Napi::Value::From(Env(), m_request.ResponseHeader(headerName));
+    }
+
+    Napi::Value XMLHttpRequest::GetAllResponseHeaders(const Napi::CallbackInfo&)
+    {
+        return Napi::Value::From(Env(), m_request.ResponseHeaders());
+    }
+
     Napi::Value XMLHttpRequest::GetResponseURL(const Napi::CallbackInfo&)
     {
         return Napi::Value::From(Env(), m_request.ResponseUrl().data());
@@ -161,10 +174,10 @@ namespace Babylon::Polyfills::Internal
 
     void XMLHttpRequest::AddEventListener(const Napi::CallbackInfo& info)
     {
-        std::string eventType = info[0].As<Napi::String>().Utf8Value();
-        Napi::Function eventHandler = info[1].As<Napi::Function>();
+        const std::string eventType{info[0].As<Napi::String>().Utf8Value()};
+        const Napi::Function eventHandler{info[1].As<Napi::Function>()};
 
-        const auto& eventHandlerRefs = m_eventHandlerRefs[eventType];
+        const auto& eventHandlerRefs{m_eventHandlerRefs[eventType]};
         for (auto it = eventHandlerRefs.begin(); it != eventHandlerRefs.end(); ++it)
         {
             if (it->Value() == eventHandler)
@@ -178,9 +191,9 @@ namespace Babylon::Polyfills::Internal
 
     void XMLHttpRequest::RemoveEventListener(const Napi::CallbackInfo& info)
     {
-        std::string eventType = info[0].As<Napi::String>().Utf8Value();
-        Napi::Function eventHandler = info[1].As<Napi::Function>();
-        auto itType = m_eventHandlerRefs.find(eventType);
+        const std::string eventType{info[0].As<Napi::String>().Utf8Value()};
+        const Napi::Function eventHandler{info[1].As<Napi::Function>()};
+        const auto itType{m_eventHandlerRefs.find(eventType)};
         if (itType != m_eventHandlerRefs.end())
         {
             auto& eventHandlerRefs = itType->second;
@@ -205,13 +218,13 @@ namespace Babylon::Polyfills::Internal
         try
         {
             // printfs for debugging CI, will be removed
-            auto inputURL{info[1].As<Napi::String>()};
+            const auto inputURL{info[1].As<Napi::String>()};
             // If the input URL contains any true % characters, encode them as %25
-            auto encodedPercentURL{Napi::String::New(info.Env(), EncodePercent(inputURL.Utf8Value()))};
+            const auto encodedPercentURL{Napi::String::New(info.Env(), EncodePercent(inputURL.Utf8Value()))};
             // Decode the input URL to get a completely unencoded URL
-            auto decodedURL{info.Env().Global().Get("decodeURI").As<Napi::Function>().Call({encodedPercentURL})};
+            const auto decodedURL{info.Env().Global().Get("decodeURI").As<Napi::Function>().Call({encodedPercentURL})};
             // Re-encode the URL to make sure that every illegal character is encoded
-            auto finalURL{info.Env().Global().Get("encodeURI").As<Napi::Function>().Call({decodedURL}).As<Napi::String>()};
+            const auto finalURL{info.Env().Global().Get("encodeURI").As<Napi::Function>().Call({decodedURL}).As<Napi::String>()};
             m_request.Open(MethodType::StringToEnum(info[0].As<Napi::String>().Utf8Value()), finalURL.Utf8Value());
             SetReadyState(ReadyState::Opened);
         }
@@ -257,7 +270,7 @@ namespace Babylon::Polyfills::Internal
 
     void XMLHttpRequest::RaiseEvent(const char* eventType)
     {
-        auto it = m_eventHandlerRefs.find(eventType);
+        const auto it{m_eventHandlerRefs.find(eventType)};
         if (it != m_eventHandlerRefs.end())
         {
             const auto& eventHandlerRefs = it->second;

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
@@ -152,8 +152,8 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value XMLHttpRequest::GetResponseHeader(const Napi::CallbackInfo& info)
     {
-        const auto headerName{info[0].As<Napi::String>().Utf8Value()};
-        const auto header{m_request.GetResponseHeader(headerName)};
+        const auto headerName = info[0].As<Napi::String>().Utf8Value();
+        const auto header = m_request.GetResponseHeader(headerName);
         return header ? Napi::Value::From(Env(), header.value()) : info.Env().Null();
     }
 

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.h
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.h
@@ -28,6 +28,8 @@ namespace Babylon::Polyfills::Internal
         Napi::Value GetResponse(const Napi::CallbackInfo& info);
         Napi::Value GetResponseText(const Napi::CallbackInfo& info);
         Napi::Value GetResponseType(const Napi::CallbackInfo& info);
+        Napi::Value GetResponseHeader(const Napi::CallbackInfo& info);
+        Napi::Value GetAllResponseHeaders(const Napi::CallbackInfo& info);
         void SetResponseType(const Napi::CallbackInfo& info, const Napi::Value& value);
         Napi::Value GetResponseURL(const Napi::CallbackInfo& info);
         Napi::Value GetStatus(const Napi::CallbackInfo& info);

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.h
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.h
@@ -29,7 +29,6 @@ namespace Babylon::Polyfills::Internal
         Napi::Value GetResponseText(const Napi::CallbackInfo& info);
         Napi::Value GetResponseType(const Napi::CallbackInfo& info);
         Napi::Value GetResponseHeader(const Napi::CallbackInfo& info);
-        Napi::Value GetAllResponseHeaders(const Napi::CallbackInfo& info);
         void SetResponseType(const Napi::CallbackInfo& info, const Napi::Value& value);
         Napi::Value GetResponseURL(const Napi::CallbackInfo& info);
         Napi::Value GetStatus(const Napi::CallbackInfo& info);


### PR DESCRIPTION
Fixing Nightly with these changes:

- Nightly bjs build download done with a node script instead of CI script (can be run locally)
- Fix syntax for objects created on the stack to be consistent with the rest of the code base
- add `getResponseHeader` and `getAllResponseHeaders` to XMLHttpRequest as it's now used in bjs

Note: impl added for Win32 and missing for Linux, Apple and Android.