### PR TITLE
Fix `setTimeout` race condition

### DIFF
--- a/Apps/UnitTests/Scripts/tests.js
+++ b/Apps/UnitTests/Scripts/tests.js
@@ -410,17 +410,17 @@ describe("setTimeout", function () {
         const called = [];
         for (let i = 9; i >= 0; i--) {
             setTimeout(() => {
-                called.push(i * 2);
+                called.push(i);
                 if (called.length === 10) {
                     try {
-                        expect(called).to.deep.equal([0, 2, 4, 6, 8, 10, 12, 14, 16, 18]);
+                        expect(called).to.deep.equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
                         done();
                     }
                     catch (e) {
                         done(e);
                     }
                 }
-            }, i * 2);
+            }, i * 10);
         }
     });
 })

--- a/Polyfills/Window/Source/TimeoutDispatcher.cpp
+++ b/Polyfills/Window/Source/TimeoutDispatcher.cpp
@@ -142,7 +142,7 @@ namespace Babylon::Polyfills::Internal
             while (!m_timeMap.empty() && m_timeMap.begin()->second->time == nextTimePoint)
             {
                 const auto* timeout = m_timeMap.begin()->second;
-                auto function = timeout->function;
+                auto function = std::move(timeout->function);
                 m_timeMap.erase(m_timeMap.begin());
                 m_idMap.erase(timeout->id);
                 CallFunction(std::move(function));

--- a/Polyfills/Window/Source/TimeoutDispatcher.cpp
+++ b/Polyfills/Window/Source/TimeoutDispatcher.cpp
@@ -142,9 +142,10 @@ namespace Babylon::Polyfills::Internal
             while (!m_timeMap.empty() && m_timeMap.begin()->second->time == nextTimePoint)
             {
                 const auto* timeout = m_timeMap.begin()->second;
-                CallFunction(timeout->function);
+                auto function = timeout->function;
                 m_timeMap.erase(m_timeMap.begin());
                 m_idMap.erase(timeout->id);
+                CallFunction(std::move(function));
             }
 
             while (!m_shutdown && m_timeMap.empty())


### PR DESCRIPTION
In rare cases it's possible for the timeout function's shared pointer to call delete from the `setTimeout` worker thread instead of the JavaScript runtime thread. This happens when the timeout function is dispatched in `CallFunction` and called on the runtime thread before the worker thread removes it from the time and id maps. In this case, it is destroyed on the worker thread when the timeout is removed from the id map since the runtime thread has already released its shared pointer reference to the function. This causes a Napi assert since the function object has to be destroyed on the same thread it was created on.

This change fixes the issue by holding a shared pointer to the timeout function while the timeout is being removed from the maps in the worker thread, and then moving that held shared pointer to `CallFunction` to ensure the shared pointer ref count falls to zero on the JavaScript runtime thread.