### PR TITLE
NativeCamera - Expose MediaStreamTrack stop() polyfill

### DIFF
--- a/Plugins/NativeCamera/Source/Android/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Android/CameraDevice.cpp
@@ -487,12 +487,25 @@ namespace Babylon::Plugins
         }
 
         arcana::make_task(m_impl->deviceContext->BeforeRenderScheduler(), arcana::cancellation::none(), [this, textureHandle] {
+            if (m_impl == nullptr)
+            {
+                // We've been destructed, cancel out of the async work
+                return;
+            }
+
             bgfx::overrideInternal(textureHandle, m_impl->cameraRGBATextureId);
         });
     }
 
     void CameraDevice::Close()
     {
+        if (m_impl == nullptr || m_impl->textureSession == nullptr)
+        {
+            // This device was either never opened, or has already been closed.
+            // No action is required.
+            return;
+        }
+
         // Stop recording to SurfaceTexture and do some cleanup
         GET_CAMERA_FUNCTION(ACameraCaptureSession_stopRepeating)(m_impl->textureSession);
         GET_CAMERA_FUNCTION(ACameraCaptureSession_close)(m_impl->textureSession);

--- a/Plugins/NativeCamera/Source/Android/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Android/CameraDevice.cpp
@@ -48,6 +48,8 @@ namespace Babylon::Plugins
 
         Napi::Env env;
 
+        arcana::affinity threadAffinity{};
+
         std::vector<CameraTrack> supportedResolutions{};
         std::vector<std::unique_ptr<Capability>> capabilities{};
         std::string cameraID{};
@@ -178,6 +180,7 @@ namespace Babylon::Plugins
     {
         if (!m_impl->deviceContext){
             m_impl->deviceContext = &Graphics::DeviceContext::GetFromJavaScript(m_impl->env);
+            m_impl->threadAffinity = std::this_thread::get_id();
         }
 
         return android::Permissions::CheckCameraPermissionAsync().then(arcana::inline_scheduler, arcana::cancellation::none(), [this, &track]()

--- a/Plugins/NativeCamera/Source/Android/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Android/CameraDevice.cpp
@@ -486,20 +486,14 @@ namespace Babylon::Plugins
             throw std::runtime_error{"Unable to make current shared GL context for camera texture."};
         }
 
-        arcana::make_task(m_impl->deviceContext->BeforeRenderScheduler(), arcana::cancellation::none(), [this, textureHandle] {
-            if (m_impl == nullptr)
-            {
-                // We've been destructed, cancel out of the async work
-                return;
-            }
-
-            bgfx::overrideInternal(textureHandle, m_impl->cameraRGBATextureId);
+        arcana::make_task(m_impl->deviceContext->BeforeRenderScheduler(), arcana::cancellation::none(), [rgbaTextureId = m_impl->cameraRGBATextureId, textureHandle] {
+            bgfx::overrideInternal(textureHandle, rgbaTextureId);
         });
     }
 
     void CameraDevice::Close()
     {
-        if (m_impl == nullptr || m_impl->textureSession == nullptr)
+        if (m_impl->textureSession == nullptr)
         {
             // This device was either never opened, or has already been closed.
             // No action is required.

--- a/Plugins/NativeCamera/Source/Apple/CameraDevice.mm
+++ b/Plugins/NativeCamera/Source/Apple/CameraDevice.mm
@@ -160,7 +160,6 @@ namespace Babylon::Plugins
         CameraDimensions cameraDimensions{};
 
         CameraTextureDelegate* cameraTextureDelegate{};
-        CameraDevice cameraDevice{nullptr};
         AVCaptureSession* avCaptureSession{};
         CVMetalTextureCacheRef textureCache{};
         id<MTLTexture> textureRGBA{};
@@ -503,7 +502,7 @@ namespace Babylon::Plugins
 
     void CameraDevice::Close()
     {
-        if (m_impl == nil || m_impl->cameraTextureDelegate == nil)
+        if (m_impl->cameraTextureDelegate == nil)
         {
             // This device was either never opened, or has already been closed.
             // No action is required.
@@ -530,7 +529,7 @@ namespace Babylon::Plugins
         if (m_impl->avCaptureSession != nil) {
             // Stopping the capture session is a synchronous (and long running call). Complete the request on the dispatcher thread
             // instead of the main thread.
-            arcana::make_task(m_impl->cameraSessionDispatcher, arcana::cancellation::none(), [avCaptureSession = m_impl->avCaptureSession](){
+            arcana::make_task(arcana::threadpool_scheduler, arcana::cancellation::none(), [avCaptureSession = m_impl->avCaptureSession](){
                 [avCaptureSession stopRunning];
             });
         }

--- a/Plugins/NativeCamera/Source/Apple/CameraDevice.mm
+++ b/Plugins/NativeCamera/Source/Apple/CameraDevice.mm
@@ -152,6 +152,8 @@ namespace Babylon::Plugins
         Graphics::DeviceContext* deviceContext;
         Napi::Env env;
         
+        arcana::affinity threadAffinity{};
+        
         std::vector<CameraTrack> supportedResolutions{};
         std::vector<std::unique_ptr<Capability>> capabilities{};
         AVCaptureDevice* avDevice{};
@@ -319,6 +321,9 @@ namespace Babylon::Plugins
 
         // This is the first time the camera has been opened, perform some one time setup.
         if (!m_impl->isInitialized) {
+            // Set the thread affinity to the current thread
+            m_impl->threadAffinity = std::this_thread::get_id();
+
             m_impl->commandQueue = (__bridge id<MTLCommandQueue>)bgfx::getInternalData()->commandQueue;
             m_impl->metalDevice = (__bridge id<MTLDevice>)bgfx::getInternalData()->context;
             m_impl->deviceContext = &Graphics::DeviceContext::GetFromJavaScript(m_impl->env);

--- a/Plugins/NativeCamera/Source/CameraDeviceSharedPImpl.h
+++ b/Plugins/NativeCamera/Source/CameraDeviceSharedPImpl.h
@@ -27,7 +27,11 @@ namespace Babylon::Plugins
 
     CameraDevice::~CameraDevice()
     {
-        Close();
+        // If m_impl is null then the class has been moved and there is no cleanup required
+        if (m_impl != nullptr)
+        {
+            Close();
+        }
     }
 
     CameraDevice::CameraDevice(CameraDevice&&) noexcept = default;

--- a/Plugins/NativeCamera/Source/CameraDeviceSharedPImpl.h
+++ b/Plugins/NativeCamera/Source/CameraDeviceSharedPImpl.h
@@ -30,6 +30,7 @@ namespace Babylon::Plugins
         // If m_impl is null then the class has been moved and there is no cleanup required
         if (m_impl != nullptr)
         {
+            assert(m_impl->threadAffinity.check());
             Close();
         }
     }

--- a/Plugins/NativeCamera/Source/CameraDeviceSharedPImpl.h
+++ b/Plugins/NativeCamera/Source/CameraDeviceSharedPImpl.h
@@ -25,7 +25,11 @@ namespace Babylon::Plugins
     {
     }
 
-    CameraDevice::~CameraDevice() = default;
+    CameraDevice::~CameraDevice()
+    {
+        Close();
+    }
+
     CameraDevice::CameraDevice(CameraDevice&&) noexcept = default;
     CameraDevice& CameraDevice::operator=(CameraDevice&&) noexcept = default;
 

--- a/Plugins/NativeCamera/Source/MediaStream.cpp
+++ b/Plugins/NativeCamera/Source/MediaStream.cpp
@@ -338,6 +338,12 @@ namespace Babylon::Plugins
         return allConstraintsSatisfied;
     }
 
+    void MediaStream::Close()
+    {
+        // Clear out the cameraDevice which will disconnect the camera stream
+        m_cameraDevice = nullptr;
+    }
+
     void MediaStream::UpdateTexture(bgfx::TextureHandle textureHandle)
     {
         if (m_cameraDevice == nullptr)

--- a/Plugins/NativeCamera/Source/MediaStream.cpp
+++ b/Plugins/NativeCamera/Source/MediaStream.cpp
@@ -37,6 +37,7 @@ namespace Babylon::Plugins
                     InstanceMethod("getCapabilities", &MediaStream::GetCapabilities),
                     InstanceMethod("getSettings", &MediaStream::GetSettings),
                     InstanceMethod("getConstraints", &MediaStream::GetConstraints),
+                    InstanceMethod("stop", &MediaStream::Stop),
                 });
             
             _native.Set(JS_CLASS_NAME, ctor);
@@ -338,7 +339,7 @@ namespace Babylon::Plugins
         return allConstraintsSatisfied;
     }
 
-    void MediaStream::Close()
+    void MediaStream::Stop(const Napi::CallbackInfo& /*info*/)
     {
         // Clear out the cameraDevice which will disconnect the camera stream
         m_cameraDevice = nullptr;

--- a/Plugins/NativeCamera/Source/MediaStream.h
+++ b/Plugins/NativeCamera/Source/MediaStream.h
@@ -30,8 +30,8 @@ namespace Babylon::Plugins
         Napi::Value GetCapabilities(const Napi::CallbackInfo& info);
         Napi::Value GetSettings(const Napi::CallbackInfo& info);
         Napi::Value GetConstraints(const Napi::CallbackInfo& info);
+        void Stop(const Napi::CallbackInfo& info);
         
-        void Close();
         void UpdateTexture(bgfx::TextureHandle textureHandle);
         
         int Width{0};

--- a/Plugins/NativeCamera/Source/MediaStream.h
+++ b/Plugins/NativeCamera/Source/MediaStream.h
@@ -31,6 +31,7 @@ namespace Babylon::Plugins
         Napi::Value GetSettings(const Napi::CallbackInfo& info);
         Napi::Value GetConstraints(const Napi::CallbackInfo& info);
         
+        void Close();
         void UpdateTexture(bgfx::TextureHandle textureHandle);
         
         int Width{0};

--- a/Plugins/NativeCamera/Source/NativeVideo.cpp
+++ b/Plugins/NativeCamera/Source/NativeVideo.cpp
@@ -149,6 +149,14 @@ namespace Babylon::Plugins
     void NativeVideo::SetSrcObject(const Napi::CallbackInfo& info, const Napi::Value& value) {
         auto env{info.Env()};
         
+        if (m_streamObject.Value().IsObject() && m_streamObject.Value().InstanceOf(MediaStream::GetConstructor(env)))
+        {
+            // The MediaStream's lifetime is owned by the javascript environment and relying on garbage collection
+            // to close out the stream can be unpredictable. Explicitly close out the stream before assigining a new source.
+            auto oldStream = MediaStream::Unwrap(m_streamObject.Value());
+            oldStream->Close();
+        }
+        
         if (value.IsNull() || value.IsUndefined() || !value.As<Napi::Object>().InstanceOf(MediaStream::GetConstructor(env)))
         {
             m_streamObject = Napi::ObjectReference();

--- a/Plugins/NativeCamera/Source/NativeVideo.cpp
+++ b/Plugins/NativeCamera/Source/NativeVideo.cpp
@@ -148,15 +148,7 @@ namespace Babylon::Plugins
 
     void NativeVideo::SetSrcObject(const Napi::CallbackInfo& info, const Napi::Value& value) {
         auto env{info.Env()};
-        
-        if (m_streamObject.Value().IsObject() && m_streamObject.Value().InstanceOf(MediaStream::GetConstructor(env)))
-        {
-            // The MediaStream's lifetime is owned by the javascript environment and relying on garbage collection
-            // to close out the stream can be unpredictable. Explicitly close out the stream before assigining a new source.
-            auto oldStream = MediaStream::Unwrap(m_streamObject.Value());
-            oldStream->Close();
-        }
-        
+
         if (value.IsNull() || value.IsUndefined() || !value.As<Napi::Object>().InstanceOf(MediaStream::GetConstructor(env)))
         {
             m_streamObject = Napi::ObjectReference();
@@ -166,7 +158,7 @@ namespace Babylon::Plugins
             this->m_IsPlaying = false;
             return;
         }
-        
+
         // We've received a MediaStream object
         m_streamObject = Napi::Persistent(value.As<Napi::Object>());
         auto mediaStream = MediaStream::Unwrap(m_streamObject.Value());

--- a/Plugins/NativeCamera/Source/UWP/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/UWP/CameraDevice.cpp
@@ -12,6 +12,7 @@ namespace Babylon::Plugins
 
     struct CameraDevice::Impl
     {
+        arcana::affinity threadAffinity{};
         std::vector<CameraTrack> supportedResolutions{};
         std::vector<std::unique_ptr<Capability>> capabilities{};
     };

--- a/Plugins/NativeCamera/Source/UWP/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/UWP/CameraDevice.cpp
@@ -1,6 +1,7 @@
 #include "NativeCamera.h"
 #include "../CameraDevice.h"
 #include <napi/napi.h>
+#include <arcana/threading/affinity.h>
 
 namespace Babylon::Plugins
 {

--- a/Plugins/NativeCamera/Source/Unix/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Unix/CameraDevice.cpp
@@ -12,6 +12,7 @@ namespace Babylon::Plugins
 
     struct CameraDevice::Impl
     {
+        arcana::affinity threadAffinity{};
         std::vector<CameraTrack> supportedResolutions{};
         std::vector<std::unique_ptr<Capability>> capabilities{};
     };

--- a/Plugins/NativeCamera/Source/Unix/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Unix/CameraDevice.cpp
@@ -1,6 +1,7 @@
 #include "NativeCamera.h"
 #include "../CameraDevice.h"
 #include <napi/napi.h>
+#include <arcana/threading/affinity.h>
 
 namespace Babylon::Plugins
 {

--- a/Plugins/NativeCamera/Source/Win32/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Win32/CameraDevice.cpp
@@ -12,6 +12,7 @@ namespace Babylon::Plugins
 
     struct CameraDevice::Impl
     {
+        arcana::affinity threadAffinity{};
         std::vector<CameraTrack> supportedResolutions{};
         std::vector<std::unique_ptr<Capability>> capabilities{};
     };

--- a/Plugins/NativeCamera/Source/Win32/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Win32/CameraDevice.cpp
@@ -1,6 +1,7 @@
 #include "NativeCamera.h"
 #include "../CameraDevice.h"
 #include <napi/napi.h>
+#include <arcana/threading/affinity.h>
 
 namespace Babylon::Plugins
 {


### PR DESCRIPTION
While testing the recent changes to the NativeCamera plugin I noticed that the camera stream was not consistently being closed after the VideoTexture (or even whole scene) was disposed. On iOS it was consistently closing, but took a few seconds. On Android it would only close the stream after opening a different babylon scene. After a bit more debugging I figured out the root issue has to do with garbage collection (possibly specifically in React-Native where I was testing).

This PR fulfills the [MediaStreamTrack stop() WebAPI](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/stop) so that the camera stream can be explicitly ended.

I've logged a related issue where Babylon.JS does not call stop() on the MediaStream tracks that it owns ([#13274](https://github.com/BabylonJS/Babylon.js/issues/13274))

Exposing the stop functionality also exposed an existing issue where the lifetime management of the texture is currently owned by the NativeCamera when it should be owned by the VideoTexture (#1169).