### PR TITLE
NativeCamera - Disable unreachable code warning for non-supported platforms

### DIFF
--- a/Plugins/NativeCamera/Source/MediaStream.cpp
+++ b/Plugins/NativeCamera/Source/MediaStream.cpp
@@ -1,5 +1,7 @@
-// Disable the compiler warning for unreachable code due to CameraDevice being stubbed out on some platforms
-#pragma warning(disable: 4702)
+#if !(defined(__APPLE__) || defined(ANDROID))
+    // Disable the compiler warning for unreachable code due to CameraDevice being stubbed out on some platforms
+    #pragma warning(disable: 4702)
+#endif
 
 #include "MediaStream.h"
 #include "CameraDevice.h"

--- a/Plugins/NativeCamera/Source/MediaStream.cpp
+++ b/Plugins/NativeCamera/Source/MediaStream.cpp
@@ -1,5 +1,5 @@
 #if defined(_MSC_VER)
-    // Disable the compiler warning for unreachable code due to CameraDevice being stubbed out on some platforms
+    // Disable the compiler warning for unreachable code due to CameraDevice being stubbed out on the windows platform
     #pragma warning(disable: 4702)
 #endif
 

--- a/Plugins/NativeCamera/Source/MediaStream.cpp
+++ b/Plugins/NativeCamera/Source/MediaStream.cpp
@@ -1,3 +1,6 @@
+// Disable the compiler warning for unreachable code due to CameraDevice being stubbed out on some platforms
+#pragma warning(disable: 4702)
+
 #include "MediaStream.h"
 #include "CameraDevice.h"
 #include "Constraint.h"

--- a/Plugins/NativeCamera/Source/MediaStream.cpp
+++ b/Plugins/NativeCamera/Source/MediaStream.cpp
@@ -1,4 +1,4 @@
-#if !(defined(__APPLE__) || defined(ANDROID))
+#if defined(_MSC_VER)
     // Disable the compiler warning for unreachable code due to CameraDevice being stubbed out on some platforms
     #pragma warning(disable: 4702)
 #endif

--- a/Plugins/NativeCamera/Source/UWP/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/UWP/CameraDevice.cpp
@@ -20,11 +20,13 @@ namespace Babylon::Plugins
 
     std::vector<CameraDevice> CameraDevice::GetCameraDevices(Napi::Env /*env*/)
     {
+        // When implementing this function remove the disabled warning at the top of MediaStream.cpp
         throw std::runtime_error{"HW Camera not implemented for this platform."};
     }
 
     arcana::task<CameraDevice::CameraDimensions, std::exception_ptr> CameraDevice::OpenAsync(const CameraTrack& /*track*/)
     {
+        // When implementing this function remove the disabled warning at the top of MediaStream.cpp
         throw std::runtime_error{"HW Camera not implemented for this platform."};
     }
 

--- a/Plugins/NativeCamera/Source/Win32/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Win32/CameraDevice.cpp
@@ -20,11 +20,13 @@ namespace Babylon::Plugins
 
     std::vector<CameraDevice> CameraDevice::GetCameraDevices(Napi::Env /*env*/)
     {
+        // When implementing this function remove the disabled warning at the top of MediaStream.cpp
         throw std::runtime_error{"HW Camera not implemented for this platform."};
     }
 
     arcana::task<CameraDevice::CameraDimensions, std::exception_ptr> CameraDevice::OpenAsync(const CameraTrack& /*track*/)
     {
+        // When implementing this function remove the disabled warning at the top of MediaStream.cpp
         throw std::runtime_error{"HW Camera not implemented for this platform."};
     }
 


### PR DESCRIPTION
This PR is to resolve a compiler error I was getting when upgrading Babylon Native in Babylon React Native. The Windows compiler is pickier in that scenarios and treats the warning about unreachable code as an error.

The warning is fired because the CameraDevice class for Win32/UWP/Unix is a stub implementation that only throws errors instead of returning values. That leads to the compiler complaining on Windows that any code after a call to CameraDevice is unreachable (which is technically true).