### PR TITLE
Fix CI after Ubuntu updated from 20.04 to 22.04

### DIFF
--- a/.github/jobs/linux.yml
+++ b/.github/jobs/linux.yml
@@ -4,13 +4,13 @@ parameters:
   CC: ''
   CXX: ''
   JSEngine: ''
-  
+
 jobs:
   - job: ${{ parameters.name }}
     timeoutInMinutes: 30
     pool:
       vmImage: ${{ parameters.vmImage }}
-  
+
     variables:
       CC: ${{ parameters.CC }}
       CXX: ${{ parameters.CXX }}
@@ -32,7 +32,7 @@ jobs:
 
     - script: |
         sudo apt-get update
-        sudo apt-get install libjavascriptcoregtk-4.0-dev libgl1-mesa-dev libcurl4-openssl-dev ${{ parameters.CC }} libc++-9-dev libc++abi-9-dev libnode-dev
+        sudo apt-get install libjavascriptcoregtk-4.0-dev libgl1-mesa-dev libcurl4-openssl-dev
       displayName: 'Install packages'
 
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,37 +88,25 @@ jobs:
       napiType: jsi
 
 # Ubuntu/Linux
-  - template: .github/jobs/linux.yml
-    parameters:
-      name: Ubuntu_Clang9_V8
-      vmImage: 'ubuntu-latest'
-      CC: clang-9
-      CXX: clang++-9
-      JSEngine: V8
+
+  # TODO: v8 is incompatible with curl for some reason
+  # See https://github.com/BabylonJS/BabylonNative/issues/1190
 
   - template: .github/jobs/linux.yml
     parameters:
-      name: Ubuntu_GCC9_JSC
+      name: Ubuntu_Clang_JavaScriptCore
       vmImage: 'ubuntu-latest'
-      CC: gcc-9
-      CXX: g++-9
+      CC: clang
+      CXX: clang++
       JSEngine: JavaScriptCore
 
   - template: .github/jobs/linux.yml
     parameters:
-      name: Ubuntu_GCC9_V8
+      name: Ubuntu_GCC_JavaScriptCore
       vmImage: 'ubuntu-latest'
-      CC: gcc-9
-      CXX: g++-9
-      JSEngine: V8
-
-  - template: .github/jobs/linux.yml
-    parameters:
-      name: Ubuntu_GCC10_V8
-      vmImage: 'ubuntu-latest'
-      CC: gcc-10
-      CXX: g++-10
-      JSEngine: V8
+      CC: gcc
+      CXX: g++
+      JSEngine: JavaScriptCore
 
 # Android
   - template: .github/jobs/android.yml


### PR DESCRIPTION
- Update Linux to use latest Clang/GCC compilers
- Use JavaScriptCore instead of V8 to work around #1190