### PR TITLE
Task chain for texture copy/destruction

### DIFF
--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -8,10 +8,10 @@
       "name": "BabylonNative",
       "version": "0.0.1",
       "dependencies": {
-        "babylonjs": "^5.35.1",
-        "babylonjs-gui": "^5.35.1",
-        "babylonjs-loaders": "^5.35.1",
-        "babylonjs-materials": "^5.35.1",
+        "babylonjs": "^5.41.0",
+        "babylonjs-gui": "^5.41.0",
+        "babylonjs-loaders": "^5.41.0",
+        "babylonjs-materials": "^5.41.0",
         "chai": "^4.3.4",
         "jsc-android": "^241213.1.0",
         "mocha": "^9.2.2",
@@ -79,39 +79,39 @@
       }
     },
     "node_modules/babylonjs": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-5.35.1.tgz",
-      "integrity": "sha512-oNkKHRSv/qVIMwlfAb07Cg8ptF7bDZKJV4T7dfshI0Em2MTs/j8kWTntNd65kO8J3c/o92k+7cDxN15UYTyFew==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-5.41.0.tgz",
+      "integrity": "sha512-zdo94/Xy0DenP6vR/nTTZQKyzyF0GpnfRrzbFtloSmkhSD4sM4nfO4chaPRLcmxbHJUwGEjmjMIsukUtsw5FFg==",
       "hasInstallScript": true
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.35.1.tgz",
-      "integrity": "sha512-bJe2Dv2K5PsbW5cLaOLpgJSGEEDj5M4etBUdQwZLC+hTpU/kPpQtKdfzCLPf1X7FwMFe0ZLpMZM+F+VnfAZNtw=="
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.41.0.tgz",
+      "integrity": "sha512-+aARV7Q6rxLxKnLX7aqe2klaPHzg6c5JBtsadpSAfMLL9laF3e7YqfTlPR6Zf7XxsAZGJBxU9BULLvC5R3BapA=="
     },
     "node_modules/babylonjs-gui": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-5.35.1.tgz",
-      "integrity": "sha512-6AgJZZtIa5Yolwn0KnvEqSKBkKuIwukuBn8sD+qlol6FkmAL/pr3oKKMh5sl93CIGACFVdwYua5ZpBuQ9DoF5w==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-5.41.0.tgz",
+      "integrity": "sha512-Sh9nzY95hrJEp8zBTWP9stc/rWPBKb2HaKM6XtouiMTJanPB3YfQH431vQebCctt15x/VGpgEhtMIzy06YQsaA==",
       "dependencies": {
-        "babylonjs": "^5.35.1"
+        "babylonjs": "^5.41.0"
       }
     },
     "node_modules/babylonjs-loaders": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-5.35.1.tgz",
-      "integrity": "sha512-MW75klgPoizcv+bKVLY1Y7h3qk8Sji/wFC6ERgf3IjSV3OzQyNQ8avuWV/AatselOjYAhxgGwBL9KFnhyb1+lQ==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-5.41.0.tgz",
+      "integrity": "sha512-nItF7iZoYlFuIvEtIo4ctoRVINt7DhaEKpXSXMIVMYKCD/gvvOlo0ZyiNPqY6mcF6Rm3I58L+B5YH4qPim2vmw==",
       "dependencies": {
-        "babylonjs": "^5.35.1",
-        "babylonjs-gltf2interface": "^5.35.1"
+        "babylonjs": "^5.41.0",
+        "babylonjs-gltf2interface": "^5.41.0"
       }
     },
     "node_modules/babylonjs-materials": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-5.35.1.tgz",
-      "integrity": "sha512-QYxrYL2ah85/YFSgXNUya3V/L23xwK3eESAVowSqZUOv4I9U6Y5gp/+4vRDW1RfqZ+EXS2XJqcOxgnQqjTbyeg==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-5.41.0.tgz",
+      "integrity": "sha512-iXXWZQSOinU9hnhBWcvSbYeA32riz/GekdfTViTF5IY0kMQH4XfTxzDHOZ5MpunwKia1PYU1qZCpN0L0p2TG6g==",
       "dependencies": {
-        "babylonjs": "^5.35.1"
+        "babylonjs": "^5.41.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1034,38 +1034,38 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "babylonjs": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-5.35.1.tgz",
-      "integrity": "sha512-oNkKHRSv/qVIMwlfAb07Cg8ptF7bDZKJV4T7dfshI0Em2MTs/j8kWTntNd65kO8J3c/o92k+7cDxN15UYTyFew=="
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-5.41.0.tgz",
+      "integrity": "sha512-zdo94/Xy0DenP6vR/nTTZQKyzyF0GpnfRrzbFtloSmkhSD4sM4nfO4chaPRLcmxbHJUwGEjmjMIsukUtsw5FFg=="
     },
     "babylonjs-gltf2interface": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.35.1.tgz",
-      "integrity": "sha512-bJe2Dv2K5PsbW5cLaOLpgJSGEEDj5M4etBUdQwZLC+hTpU/kPpQtKdfzCLPf1X7FwMFe0ZLpMZM+F+VnfAZNtw=="
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.41.0.tgz",
+      "integrity": "sha512-+aARV7Q6rxLxKnLX7aqe2klaPHzg6c5JBtsadpSAfMLL9laF3e7YqfTlPR6Zf7XxsAZGJBxU9BULLvC5R3BapA=="
     },
     "babylonjs-gui": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-5.35.1.tgz",
-      "integrity": "sha512-6AgJZZtIa5Yolwn0KnvEqSKBkKuIwukuBn8sD+qlol6FkmAL/pr3oKKMh5sl93CIGACFVdwYua5ZpBuQ9DoF5w==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-5.41.0.tgz",
+      "integrity": "sha512-Sh9nzY95hrJEp8zBTWP9stc/rWPBKb2HaKM6XtouiMTJanPB3YfQH431vQebCctt15x/VGpgEhtMIzy06YQsaA==",
       "requires": {
-        "babylonjs": "^5.35.1"
+        "babylonjs": "^5.41.0"
       }
     },
     "babylonjs-loaders": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-5.35.1.tgz",
-      "integrity": "sha512-MW75klgPoizcv+bKVLY1Y7h3qk8Sji/wFC6ERgf3IjSV3OzQyNQ8avuWV/AatselOjYAhxgGwBL9KFnhyb1+lQ==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-5.41.0.tgz",
+      "integrity": "sha512-nItF7iZoYlFuIvEtIo4ctoRVINt7DhaEKpXSXMIVMYKCD/gvvOlo0ZyiNPqY6mcF6Rm3I58L+B5YH4qPim2vmw==",
       "requires": {
-        "babylonjs": "^5.35.1",
-        "babylonjs-gltf2interface": "^5.35.1"
+        "babylonjs": "^5.41.0",
+        "babylonjs-gltf2interface": "^5.41.0"
       }
     },
     "babylonjs-materials": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-5.35.1.tgz",
-      "integrity": "sha512-QYxrYL2ah85/YFSgXNUya3V/L23xwK3eESAVowSqZUOv4I9U6Y5gp/+4vRDW1RfqZ+EXS2XJqcOxgnQqjTbyeg==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-5.41.0.tgz",
+      "integrity": "sha512-iXXWZQSOinU9hnhBWcvSbYeA32riz/GekdfTViTF5IY0kMQH4XfTxzDHOZ5MpunwKia1PYU1qZCpN0L0p2TG6g==",
       "requires": {
-        "babylonjs": "^5.35.1"
+        "babylonjs": "^5.41.0"
       }
     },
     "balanced-match": {

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -6,10 +6,10 @@
     "getNightly": "node scripts/getNightly.js"
   },
   "dependencies": {
-    "babylonjs": "^5.35.1",
-    "babylonjs-gui": "^5.35.1",
-    "babylonjs-loaders": "^5.35.1",
-    "babylonjs-materials": "^5.35.1",
+    "babylonjs": "^5.41.0",
+    "babylonjs-gui": "^5.41.0",
+    "babylonjs-loaders": "^5.41.0",
+    "babylonjs-materials": "^5.41.0",
     "chai": "^4.3.4",
     "jsc-android": "^241213.1.0",
     "mocha": "^9.2.2",

--- a/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
+++ b/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
@@ -15,6 +15,7 @@ namespace Babylon::Graphics
     };
 
     class Device;
+    class Texture;
 
     class DeviceUpdate
     {
@@ -97,6 +98,8 @@ namespace Babylon::Graphics
         float GetDevicePixelRatio() const;
 
         PlatformInfo GetPlatformInfo() const;
+
+        void TaskChainDeleteTexture(Graphics::Texture* texture);
 
     private:
         Device();

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
@@ -17,6 +17,7 @@ namespace Babylon::Graphics
     class Update;
     class DeviceContext;
     class DeviceImpl;
+    class Texture;
 
     struct TextureInfo final
     {
@@ -114,6 +115,9 @@ namespace Babylon::Graphics
         void AddTexture(bgfx::TextureHandle handle, uint16_t width, uint16_t height, bool hasMips, uint16_t numLayers, bgfx::TextureFormat::Enum format);
         void RemoveTexture(bgfx::TextureHandle handle);
         TextureInfo GetTextureInfo(bgfx::TextureHandle handle);
+
+        void TaskChainDeleteTexture(Graphics::Texture* texture);
+        void TaskChainOpTexture(std::function<void()> op);
 
     private:
         friend UpdateToken;

--- a/Core/Graphics/Source/Device.cpp
+++ b/Core/Graphics/Source/Device.cpp
@@ -128,4 +128,9 @@ namespace Babylon::Graphics
     {
         return m_impl->GetPlatformInfo();
     }
+
+    void Device::TaskChainDeleteTexture(Graphics::Texture* texture)
+    {
+        m_impl->TaskChainDeleteTexture(texture);
+    }
 }

--- a/Core/Graphics/Source/DeviceContext.cpp
+++ b/Core/Graphics/Source/DeviceContext.cpp
@@ -119,4 +119,15 @@ namespace Babylon::Graphics
         std::scoped_lock lock{m_textureHandleToInfoMutex};
         return m_textureHandleToInfo[handle.idx];
     }
+
+    void DeviceContext::TaskChainDeleteTexture(Graphics::Texture* texture)
+    {
+        m_graphicsImpl.TaskChainDeleteTexture(texture);
+    }
+
+    void DeviceContext::TaskChainOpTexture(std::function<void()> op)
+    {
+        m_graphicsImpl.TaskChainOpTexture(op);
+    }
+  
 }

--- a/Core/Graphics/Source/DeviceImpl.h
+++ b/Core/Graphics/Source/DeviceImpl.h
@@ -27,6 +27,7 @@ namespace Babylon::Graphics
     struct WindowConfiguration;
     struct DeviceConfiguration;
     struct BackBufferUpdateInfo;
+    class Texture;
 
     class DeviceImpl
     {
@@ -90,6 +91,9 @@ namespace Babylon::Graphics
         {
             return m_context;
         }
+
+        void TaskChainDeleteTexture(Graphics::Texture* texture);
+        void TaskChainOpTexture(std::function<void()> op);
 
     private:
         friend class UpdateToken;
@@ -156,5 +160,7 @@ namespace Babylon::Graphics
         std::mutex m_updateSafeTimespansMutex{};
 
         DeviceContext m_context;
+        arcana::task<void, std::exception_ptr> m_textureTask{};
+        Graphics::Update m_update;
     };
 }

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1097,6 +1097,10 @@ namespace Babylon
         {
             return arcana::make_task(m_runtimeScheduler, *m_cancellationSource, [this, textureDestination, textureSource, updateToken = m_update.GetUpdateToken(), cancellationSource = m_cancellationSource]()
             {
+                if (!bgfx::isValid(textureDestination->Handle()))
+                {
+                    return;
+                }
                 bgfx::Encoder* encoder = m_update.GetUpdateToken().GetEncoder();
                 GetBoundFrameBuffer(*encoder).Blit(*encoder, textureDestination->Handle(), 0, 0, textureSource->Handle());
             }).then(arcana::inline_scheduler, *m_cancellationSource, [this, cancellationSource{ m_cancellationSource }](const arcana::expected<void, std::exception_ptr>& result) {

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -199,6 +199,7 @@ namespace Babylon
         JsRuntime& m_runtime;
         Graphics::DeviceContext& m_graphicsContext;
         Graphics::Update m_update;
+        arcana::task<void, std::exception_ptr> m_textureTask{};
 
         JsRuntimeScheduler m_runtimeScheduler;
 

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -199,7 +199,6 @@ namespace Babylon
         JsRuntime& m_runtime;
         Graphics::DeviceContext& m_graphicsContext;
         Graphics::Update m_update;
-        arcana::task<void, std::exception_ptr> m_textureTask{};
 
         JsRuntimeScheduler m_runtimeScheduler;
 
@@ -239,5 +238,7 @@ namespace Babylon
 
         // TODO: This should be changed to a non-owning ref once multi-update is available.
         NativeDataStream* m_commandStream{};
+
+        template<typename PointerT> auto NapiPointerDeleterTexture(PointerT pointer);
     };
 }

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -134,6 +134,15 @@ namespace Babylon::Polyfills::Internal
         return false;
     }
 
+    template<typename PointerT>
+    auto NativeCanvas::NapiPointerDeleterTexture(PointerT pointer)
+    {
+        return [pointer,  &graphicsContext = m_graphicsContext]()
+        {
+            graphicsContext.TaskChainDeleteTexture(pointer);
+        };
+    }
+
     Napi::Value NativeCanvas::GetCanvasTexture(const Napi::CallbackInfo& info)
     {
         if (!m_texture)
@@ -142,7 +151,8 @@ namespace Babylon::Polyfills::Internal
         }
 
         m_texture->Attach(bgfx::getTexture(m_frameBuffer->Handle()), false, m_width, m_height, false, 1, bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT);
-        return Napi::Pointer<Graphics::Texture>::Create(info.Env(), m_texture.get());
+        auto texturePtr{ m_texture.get() };
+        return Napi::Pointer<Graphics::Texture>::Create(info.Env(), texturePtr, NapiPointerDeleterTexture(texturePtr));
     }
 
     Napi::Value NativeCanvas::ParseColor(const Napi::CallbackInfo& info)

--- a/Polyfills/Canvas/Source/Canvas.h
+++ b/Polyfills/Canvas/Source/Canvas.h
@@ -93,5 +93,6 @@ namespace Babylon::Polyfills::Internal
         bool m_dirty{};
 
         void FlushGraphicResources() override;
+        template<typename PointerT> auto NapiPointerDeleterTexture(PointerT pointer);
     };
 }

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -157,7 +157,6 @@ namespace Babylon::Polyfills::Internal
         m_fillStyle = value.As<Napi::String>().Utf8Value();
         const auto color = StringToColor(info.Env(), m_fillStyle);
         nvgFillColor(m_nvg, color);
-        SetDirty();
     }
 
     Napi::Value Context::GetStrokeStyle(const Napi::CallbackInfo&)
@@ -170,7 +169,6 @@ namespace Babylon::Polyfills::Internal
         m_strokeStyle = value.As<Napi::String>().Utf8Value();
         auto color = StringToColor(info.Env(), m_strokeStyle);
         nvgStrokeColor(m_nvg, color);
-        SetDirty();
     }
 
     Napi::Value Context::GetLineWidth(const Napi::CallbackInfo& )
@@ -182,7 +180,6 @@ namespace Babylon::Polyfills::Internal
     {
         m_lineWidth = value.As<Napi::Number>().FloatValue();
         nvgStrokeWidth(m_nvg, m_lineWidth);
-        SetDirty();
     }
 
     void Context::Fill(const Napi::CallbackInfo&)


### PR DESCRIPTION
- Taskchain for texture copy/destruction so they are executed in order
- removed some canvas context methods that set it as dirty
- upgrade bjs version

fixes #1193 