### PR TITLE
NativeCamera - Fix iOS crash and expose enumerateDevices

### DIFF
--- a/Plugins/NativeCamera/Source/Apple/CameraDevice.mm
+++ b/Plugins/NativeCamera/Source/Apple/CameraDevice.mm
@@ -424,12 +424,9 @@ namespace Babylon::Plugins
 
     void CameraDevice::UpdateCameraTexture(bgfx::TextureHandle textureHandle)
     {
+        // Hook into the BeforeRender loop to copy over the texture. Capture the cancellation token so that the shared pointer is kept alive when
+        // arcana checks internally for cancellation.
         arcana::make_task(m_impl->deviceContext->BeforeRenderScheduler(), *m_impl->cancellationSource, [this, textureHandle, cancellationSource{m_impl->cancellationSource}] {
-            if (cancellationSource->cancelled()) {
-                // The stream was closed while we were waiting to render.
-                return;
-            }
-
             id<MTLTexture> textureY{};
             id<MTLTexture> textureCbCr{};
             int64_t width{0};

--- a/Plugins/NativeCamera/Source/Apple/CameraDevice.mm
+++ b/Plugins/NativeCamera/Source/Apple/CameraDevice.mm
@@ -626,7 +626,7 @@ namespace Babylon::Plugins
     [self updateOrientation];
 #else
     // Orientation not supported on non-iOS devices. LandscapeLeft assumes the video is already in the correct orientation.
-    self->UIOrientation = UIInterfaceOrientationLandscapeLeft;
+    self->VideoOrientation = AVCaptureVideoOrientationLandscapeLeft;
 #endif
 
     return self;

--- a/Plugins/NativeCamera/Source/MediaDevices.cpp
+++ b/Plugins/NativeCamera/Source/MediaDevices.cpp
@@ -64,7 +64,7 @@ namespace Babylon::Plugins::Internal
             
             Napi::Array devices{Napi::Array::New(env, cameraDevices.size())};
             
-            for (uint i=0; i<cameraDevices.size(); i++)
+            for (u_long i=0; i<cameraDevices.size(); i++)
             {
                 Napi::Object device{Napi::Object::New(env)};
                 device.Set("deviceId", Napi::String::New(env, std::to_string(i)));
@@ -72,7 +72,7 @@ namespace Babylon::Plugins::Internal
                 device.Set("kind", Napi::String::New(env, "videoinput"));
                 device.Set("label", Napi::String::New(env, ""));
                 
-                devices.Set(i, device);
+                devices.Set(static_cast<uint32_t>(i), device);
             }
             
             deferred.Resolve(devices);

--- a/Plugins/NativeCamera/Source/MediaDevices.cpp
+++ b/Plugins/NativeCamera/Source/MediaDevices.cpp
@@ -64,7 +64,7 @@ namespace Babylon::Plugins::Internal
             
             Napi::Array devices{Napi::Array::New(env, cameraDevices.size())};
             
-            for (u_long i=0; i<cameraDevices.size(); i++)
+            for (unsigned long i=0; i<cameraDevices.size(); i++)
             {
                 Napi::Object device{Napi::Object::New(env)};
                 device.Set("deviceId", Napi::String::New(env, std::to_string(i)));

--- a/Plugins/NativeCamera/Source/MediaDevices.cpp
+++ b/Plugins/NativeCamera/Source/MediaDevices.cpp
@@ -52,6 +52,33 @@ namespace Babylon::Plugins::Internal
 
             return std::move(promise);
         }
+        
+        static Napi::Value EnumerateDevices(const Napi::CallbackInfo& info)
+        {
+            auto env = info.Env();
+
+            auto deferred = Napi::Promise::Deferred::New(env);
+            auto promise = deferred.Promise();
+
+            std::vector<CameraDevice> cameraDevices{CameraDevice::GetCameraDevices(env)};
+            
+            Napi::Array devices{Napi::Array::New(env, cameraDevices.size())};
+            
+            for (uint i=0; i<cameraDevices.size(); i++)
+            {
+                Napi::Object device{Napi::Object::New(env)};
+                device.Set("deviceId", Napi::String::New(env, std::to_string(i)));
+                device.Set("groupId", Napi::String::New(env, ""));
+                device.Set("kind", Napi::String::New(env, "videoinput"));
+                device.Set("label", Napi::String::New(env, ""));
+                
+                devices.Set(i, device);
+            }
+            
+            deferred.Resolve(devices);
+            
+            return std::move(promise);
+        }
     };
 }
 
@@ -79,6 +106,7 @@ namespace Babylon::Plugins::MediaDevices
         // append media devices to navigator
         Napi::Object mediaDevices = Napi::Object::New(env);
         mediaDevices.Set("getUserMedia", Napi::Function::New(env, &Internal::MediaDevices::GetUserMedia, "getUserMedia"));
+        mediaDevices.Set("enumerateDevices", Napi::Function::New(env, &Internal::MediaDevices::EnumerateDevices, "enumerateDevices"));
         navigator.Set("mediaDevices", mediaDevices);
     }
 }


### PR DESCRIPTION
This PR addresses two scenarios I observed where the NativeCamera implementation would crash on iOS.

 The first was if the camera was created and then quickly destroyed. That would lead to an exception being thrown inside of the UpdateCameraTexture function due to the object being destroyed while the async task was still pending for BeforeRenderScheduler(). The fix for that scenario was to add an arcana cancelation source that gets cancelled when the stream is closed and the async task captures it as a shared reference so it persists after the parent object is destroyed.

The second crash happened during engine shutdown occasionally. The issue is that CameraDevice uses ARC to manage the lifetime of the textureRGBA member variable. It then passes that texture handler to bgfx::overrideInternal which maintains a reference to the texture but doesn't increment the reference count on it. That can lead to a crash if the CameraDevice is disposed during or before a render loop and then bgfx tries to access the now destroyed texture handle. The fix for that scenario is when closing the CameraDevice it now keeps the reference to the textureRGBA member variable alive until AfterRenderScheduler.

Additionally this PR also adds a polyfill for the [MediaDevices::enumerateDevices()  web API](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices). That function can then be used to determine if the current device doesn't have any available camera's before attempting to open a stream. It could be updated in the future to also expose more info about the devices (such as a proper deviceID and label).