### PR TITLE
Fix a crash in the Android NativeCamera plugin

### DIFF
--- a/Plugins/NativeCamera/Source/Android/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Android/CameraDevice.cpp
@@ -511,6 +511,9 @@ namespace Babylon::Plugins
 
         GET_CAMERA_FUNCTION(ACameraDevice_close)(m_impl->aCameraDevice);
 
+        // Ensure any pending graphics commands are executed before deleting resources they may depend on
+        glFinish();
+
         // Capture request for SurfaceTexture
         ANativeWindow_release(m_impl->textureWindow);
         GET_CAMERA_FUNCTION(ACaptureRequest_free)(m_impl->request);


### PR DESCRIPTION
In the Android implementation of the NativeCamera plugin I found an intermittent crash on devices running an adreno GPU. The crash was occurring in the GPU drivers and leading to an app termination (without throwing any exceptions in the app itself).

In logcat I noticed before the app was terminated there were entries that looked like this:
```
2023-02-01 16:46:04.006 26846-26846 Adreno-GSL              com.microsoft.msapps                 W  <gsl_ldd_control:553>: ioctl fd 113 code 0xc0200933 (IOCTL_KGSL_TIMESTAMP_EVENT) failed: errno 22 Invalid argument
2023-02-01 16:46:04.006 26846-26846 Adreno-GSL              com.microsoft.msapps                 W  <ioctl_kgsl_syncobj_create:4451>: (72, 29, 58694) fail 22 Invalid argument
2023-02-01 16:46:04.017 26846-26846 Adreno-GSL              com.microsoft.msapps                 W  <gsl_ldd_control:553>: ioctl fd 113 code 0xc040094a (IOCTL_KGSL_GPU_COMMAND) failed: errno 35 Resource deadlock would occur
2023-02-01 16:46:04.017 26846-26846 Adreno-GSL              com.microsoft.msapps                 W  <log_gpu_snapshot:462>: panel.gpuSnapshotPath is not set.not generating user snapshot
2023-02-01 16:46:04.017 26846-26846 Adreno-GSL              com.microsoft.msapps                 W  <gsl_ldd_control:553>: ioctl fd 113 code 0xc040094a (IOCTL_KGSL_GPU_COMMAND) failed: errno 35 Resource deadlock would occur
2023-02-01 16:46:04.017 26846-26846 Adreno-GSL              com.microsoft.msapps                 W  <log_gpu_snapshot:462>: panel.gpuSnapshotPath is not set.not generating user snapshot
```

Based on those errors and then some trial and error for solutions I found that adding a call to `glFinish();` inside the Close method for the CameraDevice alleviates the crash. My best guess is that there is a timing issue between executing the commands to copy the camera frames and the shutdown process of the camera device. Calling `glFinish()` before destroying the camera graphic components should ensure that there aren't any pending graphic calls still depending on those resources.