### PR TITLE
NativeCamera - Add support for HTMLVideoElement resize event polyfill

### DIFF
--- a/Plugins/NativeCamera/Source/CameraDevice.h
+++ b/Plugins/NativeCamera/Source/CameraDevice.h
@@ -51,7 +51,7 @@ namespace Babylon::Plugins
 
         arcana::task<CameraDimensions, std::exception_ptr> OpenAsync(const CameraTrack& track);
         void Close();
-        void UpdateCameraTexture(bgfx::TextureHandle textureHandle);
+        CameraDimensions UpdateCameraTexture(bgfx::TextureHandle textureHandle);
 
         const std::vector<CameraTrack>& SupportedResolutions() const;
         const std::vector<std::unique_ptr<Capability>>& Capabilities() const;

--- a/Plugins/NativeCamera/Source/MediaStream.cpp
+++ b/Plugins/NativeCamera/Source/MediaStream.cpp
@@ -350,14 +350,25 @@ namespace Babylon::Plugins
         m_cameraDevice = nullptr;
     }
 
-    void MediaStream::UpdateTexture(bgfx::TextureHandle textureHandle)
+    bool MediaStream::UpdateTexture(bgfx::TextureHandle textureHandle)
     {
+        bool dimensionsChanged = false;
+
         if (m_cameraDevice == nullptr)
         {
             // We don't have a cameraDevice selected yet.
-            return;
+            return dimensionsChanged;
         }
 
-        m_cameraDevice->UpdateCameraTexture(textureHandle);
+        auto cameraDimensions{m_cameraDevice->UpdateCameraTexture(textureHandle)};
+
+        if (this->Width != cameraDimensions.width || this->Height != cameraDimensions.height)
+        {
+            dimensionsChanged = true;
+            this->Width = cameraDimensions.width;
+            this->Height = cameraDimensions.height;
+        }
+
+        return dimensionsChanged;
     }
 }

--- a/Plugins/NativeCamera/Source/MediaStream.h
+++ b/Plugins/NativeCamera/Source/MediaStream.h
@@ -31,11 +31,12 @@ namespace Babylon::Plugins
         Napi::Value GetSettings(const Napi::CallbackInfo& info);
         Napi::Value GetConstraints(const Napi::CallbackInfo& info);
         void Stop(const Napi::CallbackInfo& info);
+
+        // Update the camera texture and return true if the dimensions have changed, false otherwise
+        bool UpdateTexture(bgfx::TextureHandle textureHandle);
         
-        void UpdateTexture(bgfx::TextureHandle textureHandle);
-        
-        int Width{0};
-        int Height{0};
+        uint32_t Width{0};
+        uint32_t Height{0};
         
     private:
         arcana::task<void, std::exception_ptr> ApplyInitialConstraintsAsync(Napi::Env env, Napi::Object constraints);

--- a/Plugins/NativeCamera/Source/NativeVideo.h
+++ b/Plugins/NativeCamera/Source/NativeVideo.h
@@ -40,8 +40,6 @@ namespace Babylon::Plugins
 
         std::unordered_map<std::string, std::vector<Napi::FunctionReference>> m_eventHandlerRefs{};
 
-        uint32_t m_width{0};
-        uint32_t m_height{0};
         bool m_isReady{false};
 
         bool m_IsPlaying{};

--- a/Plugins/NativeCamera/Source/UWP/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/UWP/CameraDevice.cpp
@@ -30,7 +30,7 @@ namespace Babylon::Plugins
         throw std::runtime_error{"HW Camera not implemented for this platform."};
     }
 
-    void CameraDevice::UpdateCameraTexture(bgfx::TextureHandle /*textureHandle*/)
+    CameraDevice::CameraDimensions CameraDevice::UpdateCameraTexture(bgfx::TextureHandle /*textureHandle*/)
     {
         throw std::runtime_error{"HW Camera not implemented for this platform."};
     }

--- a/Plugins/NativeCamera/Source/Unix/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Unix/CameraDevice.cpp
@@ -28,7 +28,7 @@ namespace Babylon::Plugins
         throw std::runtime_error{"HW Camera not implemented for this platform."};
     }
 
-    void CameraDevice::UpdateCameraTexture(bgfx::TextureHandle /*textureHandle*/)
+    CameraDevice::CameraDimensions CameraDevice::UpdateCameraTexture(bgfx::TextureHandle /*textureHandle*/)
     {
         throw std::runtime_error{"HW Camera not implemented for this platform."};
     }

--- a/Plugins/NativeCamera/Source/Win32/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Win32/CameraDevice.cpp
@@ -30,7 +30,7 @@ namespace Babylon::Plugins
         throw std::runtime_error{"HW Camera not implemented for this platform."};
     }
 
-    void CameraDevice::UpdateCameraTexture(bgfx::TextureHandle /*textureHandle*/)
+    CameraDevice::CameraDimensions CameraDevice::UpdateCameraTexture(bgfx::TextureHandle /*textureHandle*/)
     {
         throw std::runtime_error{"HW Camera not implemented for this platform."};
     }


### PR DESCRIPTION
This PR updates the implementation of the NativeCamera plugin to support the HTMLVideoElement resize event. See [this doc](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/videoHeight#examples) for an example of how the web API works.

The main scenario where the video dimensions would change for the NativeCamera is when the device orientation changes. This issue is mentioned in more detail in issue #1107 

Exposing the resize event will allow the Babylon.JS VideoTexture to respond to the underlying video size changes and update the internal texture accordingly. This enables rotating the device while maintaining the same VideoTexture object and maintaining the same NativeCamera in conjunction with it. This becomes more important if you use the move advanced camera capabilities (such as zoom and torch).