### PR TITLE
Bump NDK and disable compilation error in Android Camera

### DIFF
--- a/Apps/Playground/Android/app/build.gradle
+++ b/Apps/Playground/Android/app/build.gradle
@@ -42,7 +42,7 @@ android {
         applicationId "com.android.babylonnative.playground"
         minSdkVersion "${platformVersion}"
         targetSdkVersion 28
-        ndkVersion "21.4.7075529"
+        ndkVersion "23.1.7779620"
         if (project.hasProperty("NDK_VERSION")) {
             def NDKVersion = project.property("NDK_VERSION")
             ndkVersion  "${NDK_VERSION}"

--- a/Plugins/NativeCamera/Source/Android/CameraWrappers.h
+++ b/Plugins/NativeCamera/Source/Android/CameraWrappers.h
@@ -12,6 +12,13 @@
 #define __ORIG_ANDROID_API__ __ANDROID_API__
 #undef __ANDROID_API__
 #define __ANDROID_API__ 24
+
+// __INTRODUCED_IN changed in NDK newer than 21.4.7075529 so that it's impossible just to specify method names.
+// auto cameraManager{GET_CAMERA_FUNCTION(ACameraManager_create)()}; will produce an error even if the method is
+// not called explicitely.
+// A fix is to remove that #define. It's only meant to be done here, in the Android Camera context.
+#undef __INTRODUCED_IN
+#define __INTRODUCED_IN(x)
 namespace API24
 {
     #include <camera/NdkCameraManager.h>


### PR DESCRIPTION
Same NDK version as React-Native 0.71

fixes https://github.com/BabylonJS/BabylonReactNative/issues/566