### PR TITLE
Make clang-format compatible with VS

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,29 +1,36 @@
-BasedOnStyle: LLVM
-
+---
 Language: Cpp
+# BasedOnStyle: LLVM
 
-AlignOperands: true
-BreakBeforeBraces: Allman
-BreakConstructorInitializersBeforeComma: true
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignEscapedNewlines: Left
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeWhile: true
+BreakBeforeBraces: Custom
 BreakConstructorInitializers: BeforeComma
+BreakStringLiterals: false
 ColumnLimit: 0
 FixNamespaceComments: false
 IndentCaseLabels: true
 IndentWidth: 4
-SortIncludes: false
-SpaceAfterTemplateKeyword: false
-SpaceBeforeParens: ControlStatements
-SpaceBeforeRangeBasedForLoopColon: true
-SpacesBeforeTrailingComments: 1
+KeepEmptyLinesAtTheStartOfBlocks: false
 NamespaceIndentation: All
-AccessModifierOffset: -4
+ReflowComments: false
+PackConstructorInitializers: Never
 PointerAlignment: Left
-AlwaysBreakTemplateDeclarations: true
-AlignAfterOpenBracket: DontAlign
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-AllowShortLambdasOnASingleLine: All
-AllowShortCaseLabelsOnASingleLine: true
-AllowShortIfStatementsOnASingleLine: WithoutElse
-BreakBeforeTernaryOperators: true
+SortIncludes: Never
+SortUsingDeclarations: false
+SpaceAfterTemplateKeyword: false

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -28,7 +28,8 @@ namespace Babylon::Graphics
         init.type = s_bgfxRenderType;
         init.resolution.reset = BGFX_RESET_VSYNC | BGFX_RESET_MAXANISOTROPY;
         init.resolution.maxFrameLatency = 1;
-        if (s_bgfxFlipAfterRender) init.resolution.reset |= BGFX_RESET_FLIP_AFTER_RENDER;
+        if (s_bgfxFlipAfterRender)
+            init.resolution.reset |= BGFX_RESET_FLIP_AFTER_RENDER;
 
         init.callback = &m_bgfxCallback;
         init.platformData = {};

--- a/Plugins/NativeCamera/Source/Android/CameraWrappers.h
+++ b/Plugins/NativeCamera/Source/Android/CameraWrappers.h
@@ -21,36 +21,37 @@
 #define __INTRODUCED_IN(x)
 namespace API24
 {
-    #include <camera/NdkCameraManager.h>
-    #include <camera/NdkCameraCaptureSession.h>
-    #include <camera/NdkCameraDevice.h>
-    #include <camera/NdkCameraError.h>
-    #include <camera/NdkCameraManager.h>
-    #include <camera/NdkCameraMetadata.h>
-    #include <camera/NdkCameraMetadataTags.h>
-    #include <camera/NdkCameraWindowType.h>
-    #include <camera/NdkCaptureRequest.h>
+#include <camera/NdkCameraManager.h>
+#include <camera/NdkCameraCaptureSession.h>
+#include <camera/NdkCameraDevice.h>
+#include <camera/NdkCameraError.h>
+#include <camera/NdkCameraManager.h>
+#include <camera/NdkCameraMetadata.h>
+#include <camera/NdkCameraMetadataTags.h>
+#include <camera/NdkCameraWindowType.h>
+#include <camera/NdkCaptureRequest.h>
 }
 #undef __ANDROID_API__
 #define __ANDROID_API__ __ORIG_ANDROID_API__
 #undef __ORIG_ANDROID_API__
 
 // Helper macro to make calling camera NDK api's more type safe
-#define GET_CAMERA_FUNCTION(function) reinterpret_cast<decltype(&API24::function)>(Babylon::Plugins::GetCameraDynamicFunction(#function))
+#define CAMERA_FUNCTION(function, ...) reinterpret_cast<decltype(&API24::function)>(Babylon::Plugins::GetCameraDynamicFunction(#function))(__VA_ARGS__)
 
 namespace
 {
-    const int API_LEVEL{ android_get_device_api_level() };
+    const int API_LEVEL{android_get_device_api_level()};
 
     // Load the NDK camera lib dynamically. When running on OS 6.0 and below this will return nullptr,
     // on OS 7.0 and up this should return a pointer to access the library using dlsym. It is technically fine
     // to call dlopen when the API_LEVEL is below 24, but it's wasted effort on those devices.
-    void* libCamera2NDK{ API_LEVEL >= 24 ? dlopen("libcamera2ndk.so", RTLD_NOW): nullptr };
+    void* libCamera2NDK{API_LEVEL >= 24 ? dlopen("libcamera2ndk.so", RTLD_NOW) : nullptr};
 
     std::map<std::string, void*> CameraDynamicFunctions{};
 }
 
-namespace Babylon::Plugins {
+namespace Babylon::Plugins
+{
     inline void* GetCameraDynamicFunction(const char* functionName)
     {
         if (!libCamera2NDK)

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -752,8 +752,7 @@ namespace Babylon
         Napi::Value jsProgram = Napi::Pointer<ProgramData>::Create(info.Env(), program, Napi::NapiPointerDeleter(program));
 
         arcana::make_task(arcana::threadpool_scheduler, *m_cancellationSource,
-            [this, vertexSource, fragmentSource, cancellationSource{m_cancellationSource}]() -> std::unique_ptr<ProgramData>
-            {
+            [this, vertexSource, fragmentSource, cancellationSource{m_cancellationSource}]() -> std::unique_ptr<ProgramData> {
                 return CreateProgramInternal(vertexSource, fragmentSource);
             })
             .then(m_runtimeScheduler, *m_cancellationSource,
@@ -761,8 +760,7 @@ namespace Babylon
                     jsProgramRef{Napi::Persistent(jsProgram)},
                     onSuccessRef{Napi::Persistent(onSuccess)},
                     onErrorRef{Napi::Persistent(onError)},
-                    cancellationSource{m_cancellationSource}](const arcana::expected<std::unique_ptr<ProgramData>, std::exception_ptr>& result)
-                {
+                    cancellationSource{m_cancellationSource}](const arcana::expected<std::unique_ptr<ProgramData>, std::exception_ptr>& result) {
                     if (result.has_error())
                     {
                         onErrorRef.Call({Napi::Error::New(onErrorRef.Env(), result.error()).Value()});

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -46,12 +46,12 @@ namespace Babylon
         ProgramData(const ProgramData&) = delete;
         ProgramData& operator=(const ProgramData&) = delete;
 
-        ProgramData(ProgramData&& other) noexcept:
-            Handle{other.Handle},
-            Uniforms{std::move(other.Uniforms)},
-            UniformNameToIndex{std::move(other.UniformNameToIndex)},
-            UniformInfos{std::move(other.UniformInfos)},
-            VertexAttributeLocations{std::move(other.VertexAttributeLocations)}
+        ProgramData(ProgramData&& other) noexcept
+            : Handle{other.Handle}
+            , Uniforms{std::move(other.Uniforms)}
+            , UniformNameToIndex{std::move(other.UniformNameToIndex)}
+            , UniformInfos{std::move(other.UniformInfos)}
+            , VertexAttributeLocations{std::move(other.VertexAttributeLocations)}
         {
             other.Handle = BGFX_INVALID_HANDLE;
         }

--- a/Plugins/NativeInput/Source/Shared/DeviceInputSystem.cpp
+++ b/Plugins/NativeInput/Source/Shared/DeviceInputSystem.cpp
@@ -8,8 +8,7 @@ namespace Babylon::Plugins
 
         static constexpr auto JS_CONSTRUCTOR_NAME = "DeviceInputSystem";
 
-        Napi::Function func
-        {
+        Napi::Function func{
             DefineClass(
                 env,
                 JS_CONSTRUCTOR_NAME,
@@ -17,8 +16,7 @@ namespace Babylon::Plugins
                     InstanceMethod("pollInput", &DeviceInputSystem::PollInput),
                     InstanceMethod("isDeviceAvailable", &DeviceInputSystem::IsDeviceAvailable),
                     InstanceMethod("dispose", &DeviceInputSystem::Dispose),
-                })
-        };
+                })};
 
         JsRuntime::NativeObject::GetFromJavaScript(env).Set(JS_CONSTRUCTOR_NAME, func);
     }
@@ -29,24 +27,18 @@ namespace Babylon::Plugins
         : Napi::ObjectWrap<DeviceInputSystem>{info}
         , m_nativeInput{*NativeInput::GetFromJavaScript(info.Env()).m_impl}
         , m_deviceConnectedTicket{m_nativeInput.AddDeviceConnectedCallback([this, callback = std::make_shared<Napi::FunctionReference>(Napi::Persistent(info[0].As<Napi::Function>()))](DeviceType deviceType, int32_t deviceSlot) {
-            (*callback)({
-                Napi::Value::From(Env(), static_cast<uint32_t>(deviceType)),
-                Napi::Value::From(Env(), deviceSlot)
-            });
+            (*callback)({Napi::Value::From(Env(), static_cast<uint32_t>(deviceType)),
+                Napi::Value::From(Env(), deviceSlot)});
         })}
         , m_deviceDisconnectedTicket{m_nativeInput.AddDeviceDisconnectedCallback([this, callback = std::make_shared<Napi::FunctionReference>(Napi::Persistent(info[1].As<Napi::Function>()))](DeviceType deviceType, int32_t deviceSlot) {
-            (*callback)({
-                Napi::Value::From(Env(), static_cast<uint32_t>(deviceType)),
-                Napi::Value::From(Env(), deviceSlot)
-            });
+            (*callback)({Napi::Value::From(Env(), static_cast<uint32_t>(deviceType)),
+                Napi::Value::From(Env(), deviceSlot)});
         })}
         , m_InputChangedTicket{m_nativeInput.AddInputChangedCallback([this, callback = std::make_shared<Napi::FunctionReference>(Napi::Persistent(info[2].As<Napi::Function>()))](DeviceType deviceType, int32_t deviceSlot, uint32_t inputIndex, std::optional<int32_t> currentState) {
-            (*callback)({
-                Napi::Value::From(Env(), static_cast<uint32_t>(deviceType)),
+            (*callback)({Napi::Value::From(Env(), static_cast<uint32_t>(deviceType)),
                 Napi::Value::From(Env(), deviceSlot),
                 Napi::Value::From(Env(), inputIndex),
-                currentState ? Napi::Value::From(Env(), *currentState) : Env().Null()
-            });
+                currentState ? Napi::Value::From(Env(), *currentState) : Env().Null()});
         })}
     {
     }

--- a/Plugins/NativeInput/Source/Shared/NativeInput.cpp
+++ b/Plugins/NativeInput/Source/Shared/NativeInput.cpp
@@ -36,7 +36,7 @@ namespace Babylon::Plugins
     }
 
     NativeInput::NativeInput(Napi::Env env)
-        : m_impl{ std::make_unique<Impl>(env) }
+        : m_impl{std::make_unique<Impl>(env)}
     {
         Napi::Value nativeInput = Napi::External<NativeInput>::New(env, this, [](Napi::Env, NativeInput* nativeInput) { delete nativeInput; });
         env.Global().Set(JS_NATIVE_INPUT_NAME, nativeInput);
@@ -110,7 +110,7 @@ namespace Babylon::Plugins
                     POINTER_MOUSEWHEEL_Z_INDEX,
                     POINTER_DELTA_HORIZONTAL_INDEX,
                     POINTER_DELTA_VERTICAL_INDEX,
-                    POINTER_MOVE_INDEX
+                    POINTER_MOVE_INDEX,
                 });
         }
     }
@@ -153,14 +153,16 @@ namespace Babylon::Plugins
     void NativeInput::Impl::PointerDown(uint32_t pointerId, uint32_t buttonIndex, int32_t x, int32_t y, DeviceType deviceType)
     {
         m_runtimeScheduler([pointerId, buttonIndex, x, y, deviceType, this]() {
-            const uint32_t inputIndex{ GetPointerButtonInputIndex(buttonIndex) };
-            std::vector<int32_t>& deviceInputs{ GetOrCreateInputMap(deviceType, pointerId, {
-                inputIndex,
-                POINTER_X_INPUT_INDEX,
-                POINTER_Y_INPUT_INDEX,
-                POINTER_DELTA_HORIZONTAL_INDEX,
-                POINTER_DELTA_VERTICAL_INDEX
-            })};
+            const uint32_t inputIndex{GetPointerButtonInputIndex(buttonIndex)};
+            std::vector<int32_t>& deviceInputs{
+                GetOrCreateInputMap(deviceType, pointerId,
+                    {
+                        inputIndex,
+                        POINTER_X_INPUT_INDEX,
+                        POINTER_Y_INPUT_INDEX,
+                        POINTER_DELTA_HORIZONTAL_INDEX,
+                        POINTER_DELTA_VERTICAL_INDEX,
+                    })};
 
             // Record the x/y, but don't raise associated events (this matches the behavior in the browser).
             SetInputState(deviceType, pointerId, POINTER_DELTA_HORIZONTAL_INDEX, 0, deviceInputs, false);
@@ -176,14 +178,16 @@ namespace Babylon::Plugins
     void NativeInput::Impl::PointerUp(uint32_t pointerId, uint32_t buttonIndex, int32_t x, int32_t y, DeviceType deviceType)
     {
         m_runtimeScheduler([pointerId, buttonIndex, x, y, deviceType, this]() {
-            const uint32_t inputIndex{ GetPointerButtonInputIndex(buttonIndex) };
-            std::vector<int32_t>& deviceInputs{ GetOrCreateInputMap(deviceType, pointerId, {
-                inputIndex,
-                POINTER_X_INPUT_INDEX,
-                POINTER_Y_INPUT_INDEX,
-                POINTER_DELTA_HORIZONTAL_INDEX,
-                POINTER_DELTA_VERTICAL_INDEX
-            })};
+            const uint32_t inputIndex{GetPointerButtonInputIndex(buttonIndex)};
+            std::vector<int32_t>& deviceInputs{
+                GetOrCreateInputMap(deviceType, pointerId,
+                    {
+                        inputIndex,
+                        POINTER_X_INPUT_INDEX,
+                        POINTER_Y_INPUT_INDEX,
+                        POINTER_DELTA_HORIZONTAL_INDEX,
+                        POINTER_DELTA_VERTICAL_INDEX,
+                    })};
 
             // Record the x/y, but don't raise associated events (this matches the behavior in the browser).
             SetInputState(deviceType, pointerId, POINTER_DELTA_HORIZONTAL_INDEX, 0, deviceInputs, false);
@@ -208,13 +212,15 @@ namespace Babylon::Plugins
     void NativeInput::Impl::PointerMove(uint32_t pointerId, int32_t x, int32_t y, DeviceType deviceType)
     {
         m_runtimeScheduler([pointerId, x, y, deviceType, this]() {
-            std::vector<int32_t>& deviceInputs{GetOrCreateInputMap(deviceType, pointerId, {
-                POINTER_X_INPUT_INDEX,
-                POINTER_Y_INPUT_INDEX,
-                POINTER_DELTA_HORIZONTAL_INDEX,
-                POINTER_DELTA_VERTICAL_INDEX,
-                POINTER_MOVE_INDEX
-            })};
+            std::vector<int32_t>& deviceInputs{
+                GetOrCreateInputMap(deviceType, pointerId,
+                    {
+                        POINTER_X_INPUT_INDEX,
+                        POINTER_Y_INPUT_INDEX,
+                        POINTER_DELTA_HORIZONTAL_INDEX,
+                        POINTER_DELTA_VERTICAL_INDEX,
+                        POINTER_MOVE_INDEX,
+                    })};
             int32_t deltaX = 0;
             int32_t deltaY = 0;
 
@@ -240,21 +246,19 @@ namespace Babylon::Plugins
             SetInputState(deviceType, pointerId, POINTER_DELTA_HORIZONTAL_INDEX, 0, deviceInputs, false);
             SetInputState(deviceType, pointerId, POINTER_DELTA_VERTICAL_INDEX, 0, deviceInputs, false);
             m_eventDispatcher.tick(arcana::cancellation::none());
-
         });
     }
 
     void NativeInput::Impl::PointerScroll(uint32_t pointerId, uint32_t scrollAxis, int32_t scrollValue, DeviceType deviceType)
     {
-        m_runtimeScheduler([pointerId, scrollAxis, scrollValue, deviceType, this]()
-            {
-                std::vector<int32_t>& deviceInputs{GetOrCreateInputMap(deviceType, pointerId, {scrollAxis})};
-                SetInputState(deviceType, pointerId, scrollAxis, scrollValue, deviceInputs, true);
+        m_runtimeScheduler([pointerId, scrollAxis, scrollValue, deviceType, this]() {
+            std::vector<int32_t>& deviceInputs{GetOrCreateInputMap(deviceType, pointerId, {scrollAxis})};
+            SetInputState(deviceType, pointerId, scrollAxis, scrollValue, deviceInputs, true);
 
-                m_eventDispatcher.tick(arcana::cancellation::none());
-                SetInputState(deviceType, pointerId, scrollAxis, 0, deviceInputs, true);
-                m_eventDispatcher.tick(arcana::cancellation::none());
-            });
+            m_eventDispatcher.tick(arcana::cancellation::none());
+            SetInputState(deviceType, pointerId, scrollAxis, 0, deviceInputs, true);
+            m_eventDispatcher.tick(arcana::cancellation::none());
+        });
     }
 
     NativeInput::Impl::DeviceStatusChangedCallbackTicket NativeInput::Impl::AddDeviceConnectedCallback(NativeInput::Impl::DeviceStatusChangedCallback&& callback)
@@ -265,7 +269,7 @@ namespace Babylon::Plugins
             callback(key.first, key.second);
         }
 
-        return  m_deviceConnectedCallbacks.insert(std::move(callback));
+        return m_deviceConnectedCallbacks.insert(std::move(callback));
     }
 
     NativeInput::Impl::DeviceStatusChangedCallbackTicket NativeInput::Impl::AddDeviceDisconnectedCallback(NativeInput::Impl::DeviceStatusChangedCallback&& callback)
@@ -273,7 +277,7 @@ namespace Babylon::Plugins
         return m_deviceDisconnectedCallbacks.insert(std::move(callback));
     }
 
-    NativeInput::Impl::InputStateChangedCallbackTicket NativeInput::Impl::AddInputChangedCallback(NativeInput::Impl::InputStateChangedCallback &&callback)
+    NativeInput::Impl::InputStateChangedCallbackTicket NativeInput::Impl::AddInputChangedCallback(NativeInput::Impl::InputStateChangedCallback&& callback)
     {
         return m_inputChangedCallbacks.insert(std::move(callback));
     }
@@ -285,7 +289,7 @@ namespace Babylon::Plugins
         {
             std::ostringstream message;
             message << "Unable to find device of type " << static_cast<uint32_t>(deviceType) << " with slot " << deviceSlot;
-            throw std::runtime_error{ message.str() };
+            throw std::runtime_error{message.str()};
         }
 
         const auto& device = it->second;
@@ -293,7 +297,7 @@ namespace Babylon::Plugins
         {
             std::ostringstream message;
             message << "Unable to find " << inputIndex << " on device of type " << static_cast<uint32_t>(deviceType) << " with slot " << deviceSlot;
-            throw std::runtime_error{ message.str() };
+            throw std::runtime_error{message.str()};
         }
 
         return device.at(inputIndex);
@@ -331,7 +335,7 @@ namespace Babylon::Plugins
         if (m_inputs.erase({deviceType, deviceSlot}))
         {
             m_eventDispatcher.queue([this, deviceType, deviceSlot]() {
-                m_deviceDisconnectedCallbacks.apply_to_all([deviceType, deviceSlot](auto& callback){
+                m_deviceDisconnectedCallbacks.apply_to_all([deviceType, deviceSlot](auto& callback) {
                     callback(deviceType, deviceSlot);
                 });
             });

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -557,7 +557,8 @@ namespace Babylon
                                     // Block and burn frames until XR successfully shuts down.
                                     m_sessionState->Frame = m_sessionState->Session->GetNextFrame(shouldEndSession, shouldRestartSession);
                                     m_sessionState->Frame.reset();
-                                } while (!shouldEndSession);
+                                }
+                                while (!shouldEndSession);
 
                                 m_sessionState.reset();
                                 m_beginTask.reset();

--- a/Plugins/TestUtils/Source/Unix/TestUtilsImpl.cpp
+++ b/Plugins/TestUtils/Source/Unix/TestUtilsImpl.cpp
@@ -34,7 +34,7 @@ namespace Babylon::Plugins::Internal
     {
     }
 
-    void TestUtils::SetTitle(const Napi::CallbackInfo & info)
+    void TestUtils::SetTitle(const Napi::CallbackInfo& info)
     {
         const auto title = info[0].As<Napi::String>().Utf8Value();
         Display* display = XOpenDisplay(NULL);
@@ -45,8 +45,8 @@ namespace Babylon::Plugins::Internal
     Napi::Value TestUtils::GetOutputDirectory(const Napi::CallbackInfo& info)
     {
         char exe[1024];
-        int ret = readlink("/proc/self/exe", exe, sizeof(exe)-1);
-        if(ret == -1)
+        int ret = readlink("/proc/self/exe", exe, sizeof(exe) - 1);
+        if (ret == -1)
         {
             throw Napi::Error::New(info.Env(), "Unable to get executable location");
         }

--- a/Plugins/TestUtils/Source/Win32/TestUtilsImpl.cpp
+++ b/Plugins/TestUtils/Source/Win32/TestUtilsImpl.cpp
@@ -32,7 +32,7 @@ namespace Babylon::Plugins::Internal
         const int32_t height = info[1].As<Napi::Number>().Int32Value();
 
         auto hwnd = m_implData->m_window;
-        RECT rc{ 0, 0, width, height };
+        RECT rc{0, 0, width, height};
         AdjustWindowRectEx(&rc, GetWindowStyle(hwnd), GetMenu(hwnd) != NULL, GetWindowExStyle(hwnd));
         SetWindowPos(hwnd, NULL, 0, 0, rc.right - rc.left, rc.bottom - rc.top, SWP_NOMOVE | SWP_NOZORDER);
     }


### PR DESCRIPTION
The previous [PR](https://github.com/BabylonJS/BabylonNative/pull/1201) assumed clang-format version 11. VS2022 uses version 15. This change will make the formatting compatible with VS.