### PR TITLE
Update the graphics contract to support passing in a custom device

### DIFF
--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -151,7 +151,7 @@ extern "C"
         if (runtime)
         {
             ANativeWindow* window = ANativeWindow_fromSurface(env, surface);
-            runtime->Dispatch([window, width = static_cast<size_t>(width), height = static_cast<size_t>(height)](auto env) {
+            runtime->Dispatch([window, width = static_cast<size_t>(width), height = static_cast<size_t>(height)](auto) {
                 device->UpdateWindow(window);
                 device->UpdateSize(width, height);
             });

--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -30,10 +30,10 @@ namespace
     std::optional<Babylon::Graphics::DeviceUpdate> deviceUpdate{};
     std::optional<Babylon::AppRuntime> runtime{};
     std::optional<Babylon::Plugins::ChromeDevTools> chromeDevTools{};
-    Babylon::Plugins::NativeInput* nativeInput{};
-    std::optional<Babylon::ScriptLoader> scriptLoader{};
     std::optional<Babylon::Plugins::NativeXr> nativeXr{};
+    Babylon::Plugins::NativeInput* nativeInput{};
     std::optional<Babylon::Polyfills::Canvas> nativeCanvas{};
+    std::optional<Babylon::ScriptLoader> scriptLoader{};
     bool isXrActive{};
 }
 
@@ -53,14 +53,16 @@ extern "C"
             device->FinishRenderingCurrentFrame();
         }
 
+        isXrActive = false;
+
+        scriptLoader.reset();
+
+        nativeInput = {};
         chromeDevTools.reset();
         nativeXr.reset();
         scriptLoader.reset();
-        nativeInput = {};
         runtime.reset();
         device.reset();
-
-        isXrActive = false;
     }
 
     JNIEXPORT void JNICALL

--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -1,13 +1,13 @@
 #include <jni.h>
+#include <android/native_window.h> // requires ndk r5 or newer
+#include <android/native_window_jni.h> // requires ndk r5 or newer
+#include <android/log.h>
+
 #include <stdlib.h>
 #include <string.h>
 #include <signal.h>
 #include <time.h>
-#include <memory>
 #include <optional>
-#include <android/native_window.h> // requires ndk r5 or newer
-#include <android/native_window_jni.h> // requires ndk r5 or newer
-#include <android/log.h>
 
 #include <AndroidExtensions/Globals.h>
 #include <Babylon/AppRuntime.h>
@@ -26,15 +26,15 @@
 
 namespace
 {
-    std::unique_ptr<Babylon::Graphics::Device> g_device{};
-    std::unique_ptr<Babylon::Graphics::DeviceUpdate> g_deviceUpdate{};
-    std::unique_ptr<Babylon::AppRuntime> g_runtime{};
-    std::unique_ptr<Babylon::Plugins::ChromeDevTools> g_chromeDevTools{};
-    Babylon::Plugins::NativeInput* g_nativeInput{};
-    std::unique_ptr<Babylon::ScriptLoader> g_scriptLoader{};
-    std::optional<Babylon::Plugins::NativeXr> g_nativeXr{};
-    std::unique_ptr<Babylon::Polyfills::Canvas> nativeCanvas{};
-    bool g_isXrActive{};
+    std::optional<Babylon::Graphics::Device> device{};
+    std::optional<Babylon::Graphics::DeviceUpdate> deviceUpdate{};
+    std::optional<Babylon::AppRuntime> runtime{};
+    std::optional<Babylon::Plugins::ChromeDevTools> chromeDevTools{};
+    Babylon::Plugins::NativeInput* nativeInput{};
+    std::optional<Babylon::ScriptLoader> scriptLoader{};
+    std::optional<Babylon::Plugins::NativeXr> nativeXr{};
+    std::optional<Babylon::Polyfills::Canvas> nativeCanvas{};
+    bool isXrActive{};
 }
 
 extern "C"
@@ -47,26 +47,26 @@ extern "C"
     JNIEXPORT void JNICALL
     Java_BabylonNative_Wrapper_finishEngine(JNIEnv* env, jclass clazz)
     {
-        if (g_device)
+        if (device)
         {
-            g_deviceUpdate->Finish();
-            g_device->FinishRenderingCurrentFrame();
+            deviceUpdate->Finish();
+            device->FinishRenderingCurrentFrame();
         }
 
-        g_chromeDevTools.reset();
-        g_nativeXr.reset();
-        g_scriptLoader.reset();
-        g_nativeInput = {};
-        g_runtime.reset();
-        g_device.reset();
+        chromeDevTools.reset();
+        nativeXr.reset();
+        scriptLoader.reset();
+        nativeInput = {};
+        runtime.reset();
+        device.reset();
 
-        g_isXrActive = false;
+        isXrActive = false;
     }
 
     JNIEXPORT void JNICALL
     Java_BabylonNative_Wrapper_surfaceCreated(JNIEnv* env, jclass clazz, jobject surface, jobject context)
     {
-        if (!g_runtime)
+        if (!runtime)
         {
             JavaVM* javaVM{};
             if (env->GetJavaVM(&javaVM) != JNI_OK)
@@ -80,20 +80,20 @@ extern "C"
             int32_t width  = ANativeWindow_getWidth(window);
             int32_t height = ANativeWindow_getHeight(window);
 
-            Babylon::Graphics::WindowConfiguration graphicsConfig{};
+            Babylon::Graphics::Configuration graphicsConfig{};
             graphicsConfig.Window = window;
             graphicsConfig.Width = static_cast<size_t>(width);
             graphicsConfig.Height = static_cast<size_t>(height);
-            g_device = Babylon::Graphics::Device::Create(graphicsConfig);
-            g_deviceUpdate = std::make_unique<Babylon::Graphics::DeviceUpdate>(g_device->GetUpdate("update"));
-            g_device->StartRenderingCurrentFrame();
-            g_deviceUpdate->Start();
+            device.emplace(graphicsConfig);
+            deviceUpdate.emplace(device->GetUpdate("update"));
+            device->StartRenderingCurrentFrame();
+            deviceUpdate->Start();
 
-            g_runtime = std::make_unique<Babylon::AppRuntime>();
+            runtime.emplace();
 
-            g_runtime->Dispatch([](Napi::Env env)
+            runtime->Dispatch([](Napi::Env env)
             {
-                g_device->AddToJavaScript(env);
+                device->AddToJavaScript(env);
 
                 Babylon::Polyfills::Console::Initialize(env, [](const char* message, Babylon::Polyfills::Console::LogLevel level)
                 {
@@ -114,48 +114,44 @@ extern "C"
                 Babylon::Plugins::NativeEngine::Initialize(env);
                 Babylon::Plugins::NativeOptimizations::Initialize(env);
 
-                g_nativeXr.emplace(Babylon::Plugins::NativeXr::Initialize(env));
-                g_nativeXr->SetSessionStateChangedCallback([](bool isXrActive){ g_isXrActive = isXrActive; });
+                nativeXr.emplace(Babylon::Plugins::NativeXr::Initialize(env));
+                nativeXr->SetSessionStateChangedCallback([](bool isXrActive){ isXrActive = isXrActive; });
                 
-                g_nativeInput = &Babylon::Plugins::NativeInput::CreateForJavaScript(env);
+                nativeInput = &Babylon::Plugins::NativeInput::CreateForJavaScript(env);
 
                 Babylon::Plugins::NativeCamera::Initialize(env);
                 Babylon::Polyfills::Window::Initialize(env);
 
                 Babylon::Polyfills::XMLHttpRequest::Initialize(env);
-                nativeCanvas = std::make_unique <Babylon::Polyfills::Canvas>(Babylon::Polyfills::Canvas::Initialize(env));
+                nativeCanvas.emplace(Babylon::Polyfills::Canvas::Initialize(env));
 
-                g_chromeDevTools = std::make_unique<Babylon::Plugins::ChromeDevTools>(Babylon::Plugins::ChromeDevTools::Initialize(env));
-                if (g_chromeDevTools->SupportsInspector())
+                chromeDevTools.emplace(Babylon::Plugins::ChromeDevTools::Initialize(env));
+                if (chromeDevTools->SupportsInspector())
                 {
-                    g_chromeDevTools->StartInspector(5643, "BabylonNative Playground");
+                    chromeDevTools->StartInspector(5643, "BabylonNative Playground");
                 }
             });
 
-            g_scriptLoader = std::make_unique<Babylon::ScriptLoader>(*g_runtime);
-            g_scriptLoader->Eval("document = {}", "");
-            g_scriptLoader->LoadScript("app:///Scripts/ammo.js");
-            g_scriptLoader->LoadScript("app:///Scripts/recast.js");
-            g_scriptLoader->LoadScript("app:///Scripts/babylon.max.js");
-            g_scriptLoader->LoadScript("app:///Scripts/babylonjs.loaders.js");
-            g_scriptLoader->LoadScript("app:///Scripts/babylonjs.materials.js");
-            g_scriptLoader->LoadScript("app:///Scripts/babylon.gui.js");
+            scriptLoader.emplace(*runtime);
+            scriptLoader->Eval("document = {}", "");
+            scriptLoader->LoadScript("app:///Scripts/ammo.js");
+            scriptLoader->LoadScript("app:///Scripts/recast.js");
+            scriptLoader->LoadScript("app:///Scripts/babylon.max.js");
+            scriptLoader->LoadScript("app:///Scripts/babylonjs.loaders.js");
+            scriptLoader->LoadScript("app:///Scripts/babylonjs.materials.js");
+            scriptLoader->LoadScript("app:///Scripts/babylon.gui.js");
         }
     }
 
     JNIEXPORT void JNICALL
     Java_BabylonNative_Wrapper_surfaceChanged(JNIEnv* env, jclass clazz, jint width, jint height, jobject surface)
     {
-        if (g_runtime)
+        if (runtime)
         {
-            ANativeWindow *window = ANativeWindow_fromSurface(env, surface);
-            g_runtime->Dispatch([window, width = static_cast<size_t>(width), height = static_cast<size_t>(height)](auto env) {
-                Babylon::Graphics::WindowConfiguration graphicsConfig{};
-                graphicsConfig.Window = window;
-                graphicsConfig.Width = width;
-                graphicsConfig.Height = height;
-                g_device->UpdateWindow(graphicsConfig);
-                g_device->UpdateSize(width, height);
+            ANativeWindow* window = ANativeWindow_fromSurface(env, surface);
+            runtime->Dispatch([window, width = static_cast<size_t>(width), height = static_cast<size_t>(height)](auto env) {
+                device->UpdateWindow(window);
+                device->UpdateSize(width, height);
             });
         }
     }
@@ -170,18 +166,18 @@ extern "C"
     Java_BabylonNative_Wrapper_activityOnPause(JNIEnv* env, jclass clazz)
     {
         android::global::Pause();
-        if (g_runtime)
+        if (runtime)
         {
-            g_runtime->Suspend();
+            runtime->Suspend();
         }
     }
 
     JNIEXPORT void JNICALL
     Java_BabylonNative_Wrapper_activityOnResume(JNIEnv* env, jclass clazz)
     {
-        if (g_runtime)
+        if (runtime)
         {
-            g_runtime->Resume();
+            runtime->Resume();
         }
         android::global::Resume();
     }
@@ -209,37 +205,37 @@ extern "C"
     JNIEXPORT void JNICALL
     Java_BabylonNative_Wrapper_loadScript(JNIEnv* env, jclass clazz, jstring path)
     {
-        if (g_scriptLoader)
+        if (scriptLoader)
         {
-            g_scriptLoader->LoadScript(env->GetStringUTFChars(path, nullptr));
+            scriptLoader->LoadScript(env->GetStringUTFChars(path, nullptr));
         }
     }
 
     JNIEXPORT void JNICALL
     Java_BabylonNative_Wrapper_eval(JNIEnv* env, jclass clazz, jstring source, jstring sourceURL)
     {
-        if (g_runtime)
+        if (runtime)
         {
             std::string url = env->GetStringUTFChars(sourceURL, nullptr);
             std::string src = env->GetStringUTFChars(source, nullptr);
-            g_scriptLoader->Eval(std::move(src), std::move(url));
+            scriptLoader->Eval(std::move(src), std::move(url));
         }
     }
 
     JNIEXPORT void JNICALL
     Java_BabylonNative_Wrapper_setTouchInfo(JNIEnv* env, jclass clazz, jint pointerId, jfloat x, jfloat y, jboolean buttonAction, jint buttonValue)
     {
-        if (g_nativeInput != nullptr)
+        if (nativeInput != nullptr)
         {
             if (buttonAction)
             {
                 if (buttonValue == 1)
-                    g_nativeInput->TouchDown(pointerId, x, y);
+                    nativeInput->TouchDown(pointerId, x, y);
                 else
-                    g_nativeInput->TouchUp(pointerId, x, y);
+                    nativeInput->TouchUp(pointerId, x, y);
             }
             else {
-                g_nativeInput->TouchMove(pointerId, x, y);
+                nativeInput->TouchMove(pointerId, x, y);
             }
         }
     }
@@ -247,32 +243,32 @@ extern "C"
     JNIEXPORT void JNICALL
     Java_BabylonNative_Wrapper_renderFrame(JNIEnv* env, jclass clazz)
     {
-        if (g_device)
+        if (device)
         {
-            g_deviceUpdate->Finish();
-            g_device->FinishRenderingCurrentFrame();
-            g_device->StartRenderingCurrentFrame();
-            g_deviceUpdate->Start();
+            deviceUpdate->Finish();
+            device->FinishRenderingCurrentFrame();
+            device->StartRenderingCurrentFrame();
+            deviceUpdate->Start();
         }
     }
 
     JNIEXPORT void JNICALL
     Java_BabylonNative_Wrapper_xrSurfaceChanged(JNIEnv* env, jclass clazz, jobject surface)
     {
-        if (g_nativeXr)
+        if (nativeXr)
         {
             ANativeWindow* window{};
             if (surface)
             {
                 window = ANativeWindow_fromSurface(env, surface);
             }
-            g_nativeXr->UpdateWindow(window);
+            nativeXr->UpdateWindow(window);
         }
     }
 
     JNIEXPORT jboolean JNICALL
     Java_BabylonNative_Wrapper_isXRActive(JNIEnv* env, jclass clazz)
     {
-        return g_isXrActive;
+        return isXrActive;
     }
 }

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -364,17 +364,17 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
     size_t height = static_cast<size_t>(bounds.Height * m_displayScale);
     auto window = from_cx<winrt::Windows::Foundation::IInspectable>(CoreWindow::GetForCurrentThread());
 
-    Babylon::Graphics::WindowConfiguration graphicsConfig{};
+    Babylon::Graphics::Configuration graphicsConfig{};
     graphicsConfig.Window = window;
     graphicsConfig.Width = width;
     graphicsConfig.Height = height;
     graphicsConfig.MSAASamples = 4;
-    m_device = Babylon::Graphics::Device::Create(graphicsConfig);
-    m_update = std::make_unique<Babylon::Graphics::DeviceUpdate>(m_device->GetUpdate("update"));
+    m_device.emplace(graphicsConfig);
+    m_update.emplace(m_device->GetUpdate("update"));
     m_device->StartRenderingCurrentFrame();
     m_update->Start();
 
-    m_runtime = std::make_unique<Babylon::AppRuntime>();
+    m_runtime.emplace();
 
     m_runtime->Dispatch([this](Napi::Env env) {
         m_device->AddToJavaScript(env);
@@ -391,13 +391,13 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
 
         Babylon::Plugins::NativeOptimizations::Initialize(env);
 
-        m_nativeCanvas = std::make_unique <Babylon::Polyfills::Canvas>(Babylon::Polyfills::Canvas::Initialize(env));
+        m_nativeCanvas.emplace(Babylon::Polyfills::Canvas::Initialize(env));
 
         Babylon::Plugins::NativeXr::Initialize(env);
 
         m_nativeInput = &Babylon::Plugins::NativeInput::CreateForJavaScript(env);
 
-        m_chromeDevTools = std::make_unique<Babylon::Plugins::ChromeDevTools>(Babylon::Plugins::ChromeDevTools::Initialize(env));
+        m_chromeDevTools.emplace(Babylon::Plugins::ChromeDevTools::Initialize(env));
         if (m_chromeDevTools->SupportsInspector())
         {
             m_chromeDevTools->StartInspector(5643, "BabylonNative Playground");

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -172,8 +172,8 @@ void App::Uninitialize()
     }
 
     m_nativeInput = {};
-    m_nativeCanvas.reset();
     m_chromeDevTools.reset();
+    m_nativeCanvas.reset();
     m_runtime.reset();
     m_update.reset();
     m_device.reset();
@@ -385,6 +385,8 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
             OutputDebugStringA(message);
         });
 
+        m_nativeCanvas.emplace(Babylon::Polyfills::Canvas::Initialize(env));
+
         Babylon::Polyfills::Window::Initialize(env);
 
         Babylon::Polyfills::XMLHttpRequest::Initialize(env);
@@ -392,8 +394,6 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
         Babylon::Plugins::NativeEngine::Initialize(env);
 
         Babylon::Plugins::NativeOptimizations::Initialize(env);
-
-        m_nativeCanvas.emplace(Babylon::Polyfills::Canvas::Initialize(env));
 
         Babylon::Plugins::NativeXr::Initialize(env);
 

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -171,9 +171,11 @@ void App::Uninitialize()
         m_device->FinishRenderingCurrentFrame();
     }
 
-    m_chromeDevTools.reset();
     m_nativeInput = {};
+    m_nativeCanvas.reset();
+    m_chromeDevTools.reset();
     m_runtime.reset();
+    m_update.reset();
     m_device.reset();
 }
 

--- a/Apps/Playground/UWP/App.h
+++ b/Apps/Playground/UWP/App.h
@@ -6,6 +6,8 @@
 #include <Babylon/Plugins/ChromeDevTools.h>
 #include <Babylon/Polyfills/Canvas.h>
 
+#include <optional>
+
 // Main entry point for our app. Connects the app with the Windows shell and handles application lifecycle events.
 ref class App sealed : public Windows::ApplicationModel::Core::IFrameworkView
 {
@@ -42,12 +44,12 @@ private:
 
     void RestartRuntime(Windows::Foundation::Rect bounds);
 
-    std::unique_ptr<Babylon::Graphics::Device> m_device{};
-    std::unique_ptr<Babylon::Graphics::DeviceUpdate> m_update{};
-    std::unique_ptr<Babylon::AppRuntime> m_runtime{};
+    std::optional<Babylon::Graphics::Device> m_device{};
+    std::optional<Babylon::Graphics::DeviceUpdate> m_update{};
+    std::optional<Babylon::AppRuntime> m_runtime{};
     Babylon::Plugins::NativeInput* m_nativeInput{};
-    std::unique_ptr<Babylon::Plugins::ChromeDevTools> m_chromeDevTools{};
-    std::unique_ptr<Babylon::Polyfills::Canvas> m_nativeCanvas{};
+    std::optional<Babylon::Plugins::ChromeDevTools> m_chromeDevTools{};
+    std::optional<Babylon::Polyfills::Canvas> m_nativeCanvas{};
     Windows::Foundation::Collections::IVectorView<Windows::Storage::IStorageItem^>^ m_files;
     bool m_windowClosed;
     bool m_windowVisible;

--- a/Apps/Playground/UWP/App.h
+++ b/Apps/Playground/UWP/App.h
@@ -47,9 +47,10 @@ private:
     std::optional<Babylon::Graphics::Device> m_device{};
     std::optional<Babylon::Graphics::DeviceUpdate> m_update{};
     std::optional<Babylon::AppRuntime> m_runtime{};
-    std::optional<Babylon::Plugins::ChromeDevTools> m_chromeDevTools{};
     std::optional<Babylon::Polyfills::Canvas> m_nativeCanvas{};
+    std::optional<Babylon::Plugins::ChromeDevTools> m_chromeDevTools{};
     Babylon::Plugins::NativeInput* m_nativeInput{};
+
     Windows::Foundation::Collections::IVectorView<Windows::Storage::IStorageItem^>^ m_files;
     bool m_windowClosed;
     bool m_windowVisible;

--- a/Apps/Playground/UWP/App.h
+++ b/Apps/Playground/UWP/App.h
@@ -47,9 +47,9 @@ private:
     std::optional<Babylon::Graphics::Device> m_device{};
     std::optional<Babylon::Graphics::DeviceUpdate> m_update{};
     std::optional<Babylon::AppRuntime> m_runtime{};
-    Babylon::Plugins::NativeInput* m_nativeInput{};
     std::optional<Babylon::Plugins::ChromeDevTools> m_chromeDevTools{};
     std::optional<Babylon::Polyfills::Canvas> m_nativeCanvas{};
+    Babylon::Plugins::NativeInput* m_nativeInput{};
     Windows::Foundation::Collections::IVectorView<Windows::Storage::IStorageItem^>^ m_files;
     bool m_windowClosed;
     bool m_windowVisible;

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -90,10 +90,10 @@ namespace
             device->FinishRenderingCurrentFrame();
         }
 
+        nativeCanvas.reset();
         chromeDevTools.reset();
         nativeInput = {};
         runtime.reset();
-        nativeCanvas.reset();
         update.reset();
         device.reset();
     }
@@ -135,6 +135,7 @@ namespace
             Babylon::Polyfills::Window::Initialize(env);
 
             Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+
             nativeCanvas.emplace(Babylon::Polyfills::Canvas::Initialize(env));
 
             Babylon::Plugins::NativeEngine::Initialize(env);
@@ -143,10 +144,8 @@ namespace
 
             Babylon::Plugins::NativeCapture::Initialize(env);
 
-            // Initialize Camera 
             Babylon::Plugins::NativeCamera::Initialize(env);
 
-            // Initialize NativeXr plugin.
             Babylon::Plugins::NativeXr::Initialize(env);
 
             nativeInput = &Babylon::Plugins::NativeInput::CreateForJavaScript(env);

--- a/Apps/Playground/X11/App.cpp
+++ b/Apps/Playground/X11/App.cpp
@@ -25,8 +25,8 @@ static const char* s_applicationClass = "Playground";
 std::optional<Babylon::Graphics::Device> device{};
 std::optional<Babylon::Graphics::DeviceUpdate> update{};
 std::optional<Babylon::AppRuntime> runtime{};
-Babylon::Plugins::NativeInput* nativeInput{};
 std::optional<Babylon::Polyfills::Canvas> nativeCanvas{};
+Babylon::Plugins::NativeInput* nativeInput{};
 
 namespace
 {
@@ -55,8 +55,11 @@ namespace
             update->Finish();
             device->FinishRenderingCurrentFrame();
         }
-        runtime.reset();
+
         nativeInput = {};
+        nativeCanvas.reset();
+        runtime.reset();
+        update.reset();
         device.reset();
     }
 

--- a/Apps/Playground/X11/App.cpp
+++ b/Apps/Playground/X11/App.cpp
@@ -6,6 +6,7 @@
 #include <unistd.h> // syscall
 #undef None
 #include <filesystem>
+#include <optional>
 
 #include <Babylon/AppRuntime.h>
 #include <Babylon/Graphics/Device.h>
@@ -21,11 +22,11 @@
 static const char* s_applicationName  = "BabylonNative Playground";
 static const char* s_applicationClass = "Playground";
 
-std::unique_ptr<Babylon::Graphics::Device> device{};
-std::unique_ptr<Babylon::Graphics::DeviceUpdate> update{};
-std::unique_ptr<Babylon::AppRuntime> runtime{};
+std::optional<Babylon::Graphics::Device> device{};
+std::optional<Babylon::Graphics::DeviceUpdate> update{};
+std::optional<Babylon::AppRuntime> runtime{};
 Babylon::Plugins::NativeInput* nativeInput{};
-std::unique_ptr<Babylon::Polyfills::Canvas> nativeCanvas{};
+std::optional<Babylon::Polyfills::Canvas> nativeCanvas{};
 
 namespace
 {
@@ -66,21 +67,19 @@ namespace
 
         Uninitialize();
 
-        // Separately call reset and make_unique to ensure prior state is destroyed before new one is created.
-        Babylon::Graphics::WindowConfiguration graphicsConfig{};
+        Babylon::Graphics::Configuration graphicsConfig{};
         graphicsConfig.Window = window;
         graphicsConfig.Width = static_cast<size_t>(width);
         graphicsConfig.Height = static_cast<size_t>(height);
         graphicsConfig.MSAASamples = 4;
 
-        device = Babylon::Graphics::Device::Create(graphicsConfig);
-        update = std::make_unique<Babylon::Graphics::DeviceUpdate>(device->GetUpdate("update"));
+        device.emplace(graphicsConfig);
+        update.emplace(device->GetUpdate("update"));
         device->StartRenderingCurrentFrame();
         update->Start();
 
-        runtime = std::make_unique<Babylon::AppRuntime>();
+        runtime.emplace();
 
-        // Initialize console plugin.
         runtime->Dispatch([](Napi::Env env) {
             Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
                 printf("%s", message);
@@ -89,7 +88,7 @@ namespace
 
             Babylon::Polyfills::Window::Initialize(env);
             Babylon::Polyfills::XMLHttpRequest::Initialize(env);
-            nativeCanvas = std::make_unique <Babylon::Polyfills::Canvas>(Babylon::Polyfills::Canvas::Initialize(env));
+            nativeCanvas.emplace(Babylon::Polyfills::Canvas::Initialize(env));
 
             // Initialize NativeEngine plugin.
             device->AddToJavaScript(env);
@@ -127,7 +126,7 @@ namespace
 
     void UpdateWindowSize(float width, float height)
     {
-        if (device != nullptr)
+        if (device)
         {
             device->UpdateSize(width, height);
         }

--- a/Apps/Playground/macOS/ViewController.mm
+++ b/Apps/Playground/macOS/ViewController.mm
@@ -14,12 +14,13 @@
 #import <MetalKit/MetalKit.h>
 
 #import <math.h>
+#import <optional>
 
-std::unique_ptr<Babylon::Graphics::Device> device{};
-std::unique_ptr<Babylon::Graphics::DeviceUpdate> update{};
-std::unique_ptr<Babylon::AppRuntime> runtime{};
+std::optional<Babylon::Graphics::Device> device{};
+std::optional<Babylon::Graphics::DeviceUpdate> update{};
+std::optional<Babylon::AppRuntime> runtime{};
+std::optional<Babylon::Polyfills::Canvas> nativeCanvas{};
 Babylon::Plugins::NativeInput* nativeInput{};
-std::unique_ptr<Babylon::Polyfills::Canvas> nativeCanvas{};
 
 @interface EngineView : MTKView <MTKViewDelegate>
 
@@ -30,17 +31,23 @@ std::unique_ptr<Babylon::Polyfills::Canvas> nativeCanvas{};
 - (void)mtkView:(MTKView *)__unused view drawableSizeWillChange:(CGSize) size
 {
     if (device) {
+        update->Finish();
+        device->FinishRenderingCurrentFrame();
+
         device->UpdateSize(static_cast<size_t>(size.width), static_cast<size_t>(size.height));
+
+        device->StartRenderingCurrentFrame();
+        update->Start();
     }
 }
 
 - (void)drawInMTKView:(MTKView *)__unused view
 {
     if (device) {
-        device->StartRenderingCurrentFrame();
-        update->Start();
         update->Finish();
         device->FinishRenderingCurrentFrame();
+        device->StartRenderingCurrentFrame();
+        update->Start();
     }
 }
 
@@ -55,12 +62,14 @@ std::unique_ptr<Babylon::Polyfills::Canvas> nativeCanvas{};
 - (void)uninitialize {
     if (device)
     {
+        update->Finish();
         device->FinishRenderingCurrentFrame();
     }
 
-    // Note: JS Context owns this memory for this so it's not actually a leak
     nativeInput = {};
+    nativeCanvas.reset();
     runtime.reset();
+    update.reset();
     device.reset();
 }
 
@@ -85,15 +94,19 @@ std::unique_ptr<Babylon::Polyfills::Canvas> nativeCanvas{};
     CGFloat screenScale = mainScreen.backingScaleFactor;
     size_t width = [self view].frame.size.width * screenScale;
     size_t height = [self view].frame.size.height * screenScale;
-    Babylon::Graphics::WindowConfiguration graphicsConfig{};
+
+    Babylon::Graphics::Configuration graphicsConfig{};
     graphicsConfig.Window = engineView;
     graphicsConfig.Width = width;
     graphicsConfig.Height = height;
     graphicsConfig.MSAASamples = 4;
-    device = Babylon::Graphics::Device::Create(graphicsConfig);
-    update = std::make_unique<Babylon::Graphics::DeviceUpdate>(device->GetUpdate("update"));
 
-    runtime = std::make_unique<Babylon::AppRuntime>();
+    device.emplace(graphicsConfig);
+    update.emplace(device->GetUpdate("update"));
+    device->StartRenderingCurrentFrame();
+    update->Start();
+
+    runtime.emplace();
 
     runtime->Dispatch([](Napi::Env env)
     {
@@ -103,7 +116,8 @@ std::unique_ptr<Babylon::Polyfills::Canvas> nativeCanvas{};
 
         Babylon::Polyfills::XMLHttpRequest::Initialize(env);
 
-        nativeCanvas = std::make_unique <Babylon::Polyfills::Canvas>(Babylon::Polyfills::Canvas::Initialize(env));
+        nativeCanvas.emplace(Babylon::Polyfills::Canvas::Initialize(env));
+
         Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
             NSLog(@"%s", message);
         });

--- a/Apps/Playground/macOS/ViewController.mm
+++ b/Apps/Playground/macOS/ViewController.mm
@@ -112,15 +112,15 @@ Babylon::Plugins::NativeInput* nativeInput{};
     {
         device->AddToJavaScript(env);
 
+        Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
+            NSLog(@"%s", message);
+        });
+
         Babylon::Polyfills::Window::Initialize(env);
 
         Babylon::Polyfills::XMLHttpRequest::Initialize(env);
 
         nativeCanvas.emplace(Babylon::Polyfills::Canvas::Initialize(env));
-
-        Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
-            NSLog(@"%s", message);
-        });
 
         Babylon::Plugins::NativeCamera::Initialize(env);
 

--- a/Apps/UnitTests/Apple/App.mm
+++ b/Apps/UnitTests/Apple/App.mm
@@ -1,6 +1,5 @@
 #include "../Shared/Tests.h"
 
 int main() {
-    Babylon::Graphics::DeviceConfiguration graphicsConfig{};
-    return Run(Babylon::Graphics::Device::Create(graphicsConfig));
+    return Run({{}});
 }

--- a/Apps/UnitTests/Shared/Tests.h
+++ b/Apps/UnitTests/Shared/Tests.h
@@ -26,13 +26,13 @@ void SetExitCode(const Napi::CallbackInfo& info)
     exitCode.set_value(info[0].As<Napi::Number>().Int32Value());
 }
 
-int Run(std::unique_ptr<Babylon::Graphics::Device> device)
+int Run(Babylon::Graphics::Device device)
 {
-    std::unique_ptr<Babylon::Polyfills::Canvas> nativeCanvas{};
+    std::optional<Babylon::Polyfills::Canvas> nativeCanvas;
     std::unique_ptr<Babylon::AppRuntime> runtime = std::make_unique<Babylon::AppRuntime>();
     runtime->Dispatch([&device, &nativeCanvas](Napi::Env env)
     {
-        device->AddToJavaScript(env);
+        device.AddToJavaScript(env);
 
         Babylon::Polyfills::XMLHttpRequest::Initialize(env);
         Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto)
@@ -41,7 +41,7 @@ int Run(std::unique_ptr<Babylon::Graphics::Device> device)
             fflush(stdout);
         });
         Babylon::Polyfills::Window::Initialize(env);
-        nativeCanvas = std::make_unique<Babylon::Polyfills::Canvas>(Babylon::Polyfills::Canvas::Initialize(env));
+        nativeCanvas.emplace(Babylon::Polyfills::Canvas::Initialize(env));
         Babylon::Plugins::NativeEngine::Initialize(env);
         
         env.Global().Set(JS_FUNCTION_NAME, Napi::Function::New(env, SetExitCode, JS_FUNCTION_NAME));
@@ -54,8 +54,8 @@ int Run(std::unique_ptr<Babylon::Graphics::Device> device)
     loader.LoadScript("app:///Scripts/chai.js");
     loader.LoadScript("app:///Scripts/mocha.js");
     loader.LoadScript("app:///Scripts/tests.js");
-    device->StartRenderingCurrentFrame();
-    device->FinishRenderingCurrentFrame();
+    device.StartRenderingCurrentFrame();
+    device.FinishRenderingCurrentFrame();
     auto code{exitCode.get_future().get()};
     return code;
 }

--- a/Apps/UnitTests/Shared/Tests.h
+++ b/Apps/UnitTests/Shared/Tests.h
@@ -60,6 +60,6 @@ int Run(Babylon::Graphics::Device device)
     device.StartRenderingCurrentFrame();
     device.FinishRenderingCurrentFrame();
 
-    auto code{exitCode.get_future()..get()};
+    auto code{exitCode.get_future().get()};
     return code;
 }

--- a/Apps/UnitTests/Win32/App.cpp
+++ b/Apps/UnitTests/Win32/App.cpp
@@ -13,9 +13,9 @@ int main() {
     ::RegisterClassEx(&wc);
     HWND hwnd = ::CreateWindow(wc.lpszClassName, "BabylonNative", WS_OVERLAPPEDWINDOW, -1, -1, -1, -1, NULL, NULL, wc.hInstance, NULL);
 
-    Babylon::Graphics::WindowConfiguration windowConfig{};
-    windowConfig.Window = hwnd;
-    windowConfig.Width = 600;
-    windowConfig.Height = 400;
-    return Run(Babylon::Graphics::Device::Create(windowConfig));
+    Babylon::Graphics::Configuration config{};
+    config.Window = hwnd;
+    config.Width = 600;
+    config.Height = 400;
+    return Run({config});
 }

--- a/Apps/UnitTests/X11/App.cpp
+++ b/Apps/UnitTests/X11/App.cpp
@@ -42,9 +42,9 @@ int main()
     XMapWindow(display, window);
     XStoreName(display, window, applicationName);
 
-    Babylon::Graphics::WindowConfiguration graphicsConfig{};
+    Babylon::Graphics::Configuration graphicsConfig{};
     graphicsConfig.Window = window;
     graphicsConfig.Width = static_cast<size_t>(width);
     graphicsConfig.Height = static_cast<size_t>(height);
-    return Run(Babylon::Graphics::Device::Create(graphicsConfig));
+    return Run({graphicsConfig});
 }

--- a/Apps/ValidationTests/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/ValidationTests/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -110,7 +110,7 @@ extern "C"
                 Babylon::Plugins::TestUtils::Initialize(env, window);
             });
 
-            scriptLoader = std::make_unique<Babylon::ScriptLoader>(*runtime);
+            scriptLoader.emplace(*runtime);
             scriptLoader->Eval("document = {}", "");
             scriptLoader->LoadScript("app:///Scripts/ammo.js");
             scriptLoader->LoadScript("app:///Scripts/recast.js");

--- a/Apps/ValidationTests/UWP/App.cpp
+++ b/Apps/ValidationTests/UWP/App.cpp
@@ -208,17 +208,17 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
     size_t height = static_cast<size_t>(bounds.Height * m_displayScale);
     auto window = from_cx<winrt::Windows::Foundation::IInspectable>(CoreWindow::GetForCurrentThread());
 
-    Babylon::Graphics::WindowConfiguration graphicsConfig{};
+    Babylon::Graphics::Configuration graphicsConfig{};
     graphicsConfig.Window = window;
     graphicsConfig.Width = width;
     graphicsConfig.Height = height;
     graphicsConfig.MSAASamples = 4;
-    m_device = Babylon::Graphics::Device::Create(graphicsConfig);
-    m_update = std::make_unique<Babylon::Graphics::DeviceUpdate>(m_device->GetUpdate("update"));
+    m_device.emplace(graphicsConfig);
+    m_update.emplace(m_device->GetUpdate("update"));
     m_device->StartRenderingCurrentFrame();
     m_update->Start();
 
-    m_runtime = std::make_unique<Babylon::AppRuntime>();
+    m_runtime.emplace();
 
     m_runtime->Dispatch([this, window](Napi::Env env) {
         m_device->AddToJavaScript(env);
@@ -235,7 +235,7 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
 
         Babylon::Plugins::NativeOptimizations::Initialize(env);
 
-        m_nativeCanvas = std::make_unique <Babylon::Polyfills::Canvas>(Babylon::Polyfills::Canvas::Initialize(env));
+        m_nativeCanvas.emplace(Babylon::Polyfills::Canvas::Initialize(env));
 
         Babylon::Plugins::NativeXr::Initialize(env);
 

--- a/Apps/ValidationTests/UWP/App.cpp
+++ b/Apps/ValidationTests/UWP/App.cpp
@@ -122,7 +122,9 @@ void App::Uninitialize()
         m_device->FinishRenderingCurrentFrame();
     }
 
+    m_nativeCanvas.reset();
     m_runtime.reset();
+    m_update.reset();
     m_device.reset();
 }
 

--- a/Apps/ValidationTests/UWP/App.h
+++ b/Apps/ValidationTests/UWP/App.h
@@ -40,6 +40,7 @@ private:
     std::optional<Babylon::Graphics::DeviceUpdate> m_update{};
     std::optional<Babylon::AppRuntime> m_runtime{};
     std::optional<Babylon::Polyfills::Canvas> m_nativeCanvas{};
+
     Windows::Foundation::Collections::IVectorView<Windows::Storage::IStorageItem^>^ m_files;
     bool m_windowClosed;
     bool m_windowVisible;

--- a/Apps/ValidationTests/UWP/App.h
+++ b/Apps/ValidationTests/UWP/App.h
@@ -36,10 +36,10 @@ private:
 
     void RestartRuntime(Windows::Foundation::Rect bounds);
 
-    std::unique_ptr<Babylon::Graphics::Device> m_device{};
-    std::unique_ptr<Babylon::Graphics::DeviceUpdate> m_update{};
-    std::unique_ptr<Babylon::AppRuntime> m_runtime{};
-    std::unique_ptr<Babylon::Polyfills::Canvas> m_nativeCanvas{};
+    std::optional<Babylon::Graphics::Device> m_device{};
+    std::optional<Babylon::Graphics::DeviceUpdate> m_update{};
+    std::optional<Babylon::AppRuntime> m_runtime{};
+    std::optional<Babylon::Polyfills::Canvas> m_nativeCanvas{};
     Windows::Foundation::Collections::IVectorView<Windows::Storage::IStorageItem^>^ m_files;
     bool m_windowClosed;
     bool m_windowVisible;

--- a/Apps/ValidationTests/Win32/App.cpp
+++ b/Apps/ValidationTests/Win32/App.cpp
@@ -55,8 +55,8 @@ namespace
             device->FinishRenderingCurrentFrame();
         }
 
-        runtime.reset();
         nativeCanvas.reset();
+        runtime.reset();
         update.reset();
         device.reset();
     }
@@ -93,7 +93,9 @@ namespace
             });
 
             Babylon::Polyfills::Window::Initialize(env);
+
             Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+
             nativeCanvas.emplace(Babylon::Polyfills::Canvas::Initialize(env));
 
             Babylon::Plugins::NativeEngine::Initialize(env);

--- a/Apps/ValidationTests/Win32/App.cpp
+++ b/Apps/ValidationTests/Win32/App.cpp
@@ -10,6 +10,7 @@
 #include <Shlwapi.h>
 #include <filesystem>
 #include <algorithm>
+#include <optional>
 
 #include <Babylon/AppRuntime.h>
 #include <Babylon/Graphics/Device.h>
@@ -30,10 +31,10 @@
 HINSTANCE hInst;                                // current instance
 WCHAR szTitle[MAX_LOADSTRING];                  // The title bar text
 WCHAR szWindowClass[MAX_LOADSTRING];            // the main window class name
-std::unique_ptr<Babylon::Graphics::Device> device{};
-std::unique_ptr<Babylon::Graphics::DeviceUpdate> update{};
-std::unique_ptr<Babylon::AppRuntime> runtime{};
-std::unique_ptr<Babylon::Polyfills::Canvas> nativeCanvas{};
+std::optional<Babylon::Graphics::Device> device{};
+std::optional<Babylon::Graphics::DeviceUpdate> update{};
+std::optional<Babylon::AppRuntime> runtime{};
+std::optional<Babylon::Polyfills::Canvas> nativeCanvas{};
 
 // 600, 400 mandatory size for CI tests
 static const int TEST_WIDTH = 600;
@@ -62,19 +63,23 @@ namespace
 
     void Initialize(HWND hWnd)
     {
-        Babylon::Graphics::WindowConfiguration graphicsConfig{};
+        Babylon::Graphics::Configuration graphicsConfig{};
         graphicsConfig.Window = hWnd;
         graphicsConfig.Width = static_cast<size_t>(TEST_WIDTH);
         graphicsConfig.Height = static_cast<size_t>(TEST_HEIGHT);
         graphicsConfig.MSAASamples = 4;
 
-        device = Babylon::Graphics::Device::Create(graphicsConfig);
-        update = std::make_unique<Babylon::Graphics::DeviceUpdate>(device->GetUpdate("update"));
+        device.emplace(graphicsConfig);
+        update.emplace(device->GetUpdate("update"));
         device->SetDiagnosticOutput([](const char* outputString) { printf("%s", outputString); fflush(stdout); });
         device->StartRenderingCurrentFrame();
         update->Start();
 
-        runtime = std::make_unique<Babylon::AppRuntime>();
+        runtime.emplace([](const std::exception& ex) {
+            printf("Uncaught Error: %s", ex.what());
+            fflush(stdout);
+            abort();
+        });
 
         // Initialize console plugin.
         runtime->Dispatch([hWnd](Napi::Env env) {
@@ -89,7 +94,7 @@ namespace
 
             Babylon::Polyfills::Window::Initialize(env);
             Babylon::Polyfills::XMLHttpRequest::Initialize(env);
-            nativeCanvas = std::make_unique <Babylon::Polyfills::Canvas>(Babylon::Polyfills::Canvas::Initialize(env));
+            nativeCanvas.emplace(Babylon::Polyfills::Canvas::Initialize(env));
 
             Babylon::Plugins::NativeEngine::Initialize(env);
 

--- a/Core/Graphics/Include/Platform/Android/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/Android/Babylon/Graphics/Platform.h
@@ -1,20 +1,8 @@
 #pragma once
 
 #include <android/native_window.h>
-#include <stdint.h>
 
 namespace Babylon::Graphics
 {
-    using WindowType = ANativeWindow*;
-
-    struct WindowConfiguration
-    {
-        WindowType Window{};
-        size_t Width{};
-        size_t Height{};
-        // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
-        uint8_t MSAASamples{};
-        // When enabled, back buffer will be premultiplied with alpha value
-        bool AlphaPremultiplied{};
-    };
+    using WindowT = ANativeWindow*;
 }

--- a/Core/Graphics/Include/Platform/Unix/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/Unix/Babylon/Graphics/Platform.h
@@ -1,20 +1,8 @@
 #pragma once
 
 #include <X11/Xlib.h>
-#include <stdint.h>
 
 namespace Babylon::Graphics
 {
-    using WindowType = Window;
-
-    struct WindowConfiguration
-    {
-        WindowType Window{};
-        size_t Width{};
-        size_t Height{};
-        // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
-        uint8_t MSAASamples{};
-        // When enabled, back buffer will be premultiplied with alpha value
-        bool AlphaPremultiplied{};
-    };
+    using WindowT = Window;
 }

--- a/Core/Graphics/Include/Platform/Win32/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/Win32/Babylon/Graphics/Platform.h
@@ -1,20 +1,8 @@
 #pragma once
 
 #include <Windows.h>
-#include <stdint.h>
 
 namespace Babylon::Graphics
 {
-    using WindowType = HWND;
-
-    struct WindowConfiguration
-    {
-        WindowType Window{};
-        size_t Width{};
-        size_t Height{};
-        // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
-        uint8_t MSAASamples{};
-        // When enabled, back buffer will be premultiplied with alpha value
-        bool AlphaPremultiplied{};
-    };
+    using WindowT = HWND;
 }

--- a/Core/Graphics/Include/Platform/WinRT/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/WinRT/Babylon/Graphics/Platform.h
@@ -10,16 +10,5 @@ namespace Babylon::Graphics
     // - Windows::Core::UI::ICoreWindow
     // - Windows::UI::Xaml::Controls::ISwapChainPanel
     // - Microsoft::UI::Xaml::Controls::ISwapChainPanel
-    using WindowType = winrt::Windows::Foundation::IInspectable;
-
-    struct WindowConfiguration
-    {
-        WindowType Window{};
-        size_t Width{};
-        size_t Height{};
-        // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
-        uint8_t MSAASamples{};
-        // When enabled, back buffer will be premultiplied with alpha value
-        bool AlphaPremultiplied{};
-    };
+    using WindowT = winrt::Windows::Foundation::IInspectable;
 }

--- a/Core/Graphics/Include/Platform/iOS/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/iOS/Babylon/Graphics/Platform.h
@@ -4,16 +4,5 @@
 
 namespace Babylon::Graphics
 {
-    using WindowType = MTKView*;
-
-    struct WindowConfiguration
-    {
-        WindowType Window{};
-        size_t Width{};
-        size_t Height{};
-        // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
-        uint8_t MSAASamples{};
-        // When enabled, back buffer will be premultiplied with alpha value (Not implemented for Metal yet)
-        bool AlphaPremultiplied{};
-    };
+    using WindowT = MTKView*;
 }

--- a/Core/Graphics/Include/Platform/macOS/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/macOS/Babylon/Graphics/Platform.h
@@ -4,16 +4,5 @@
 
 namespace Babylon::Graphics
 {
-    using WindowType = MTKView*;
-
-    struct WindowConfiguration
-    {
-        WindowType Window{};
-        size_t Width{};
-        size_t Height{};
-        // MSAA sample values can be 2, 4, 8 or 16. Any other value will disable MSAA
-        uint8_t MSAASamples{};
-        // When enabled, back buffer will be premultiplied with alpha value (not implemented for Metal yet)
-        bool AlphaPremultiplied{};
-    };
+    using WindowT = MTKView*;
 }

--- a/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
+++ b/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
@@ -14,17 +14,32 @@ namespace Babylon::Graphics
         DeviceT Device;
     };
 
+    struct Configuration
+    {
+        // Custom device to use instead of creating one internally.
+        DeviceT Device{};
+
+        // The platform specific window.
+        WindowT Window{};
+
+        // The resolution width.
+        size_t Width{};
+
+        // The resolution height.
+        size_t Height{};
+
+        // MSAA sample values can be 2, 4, 8 or 16. Other values will disable MSAA.
+        uint8_t MSAASamples{};
+
+        // When enabled, back buffer will be premultiplied with alpha value.
+        bool AlphaPremultiplied{};
+    };
+
     class Device;
 
     class DeviceUpdate
     {
     public:
-        DeviceUpdate(const DeviceUpdate&) = default;
-        DeviceUpdate& operator=(const DeviceUpdate&) = default;
-
-        DeviceUpdate(DeviceUpdate&&) noexcept = default;
-        DeviceUpdate& operator=(DeviceUpdate&&) noexcept = default;
-
         void Start()
         {
             m_start();
@@ -57,9 +72,12 @@ namespace Babylon::Graphics
         std::function<void(std::function<void()>)> m_requestFinish{};
     };
 
+    class DeviceImpl;
+
     class Device
     {
     public:
+        Device(const Configuration& config);
         ~Device();
 
         // Move semantics
@@ -70,15 +88,13 @@ namespace Babylon::Graphics
         // Features and functionalities will be added and
         // method and structure might change.
 
-        static std::unique_ptr<Device> Create(const WindowConfiguration& config);
-        static std::unique_ptr<Device> Create(const DeviceConfiguration& config);
-
-        void UpdateWindow(const WindowConfiguration& config);
+        void UpdateWindow(WindowT window);
         void UpdateSize(size_t width, size_t height);
         void UpdateMSAA(uint8_t value);
         void UpdateAlphaPremultiplied(bool enabled);
 
         void AddToJavaScript(Napi::Env);
+
         Napi::Value CreateContext(Napi::Env);
 
         void EnableRendering();
@@ -99,11 +115,6 @@ namespace Babylon::Graphics
         PlatformInfo GetPlatformInfo() const;
 
     private:
-        Device();
-
-        void UpdateContext(const DeviceConfiguration& config);
-
-        class Impl;
-        std::unique_ptr<Impl> m_impl{};
+        std::unique_ptr<DeviceImpl> m_impl{};
     };
 }

--- a/Core/Graphics/Source/Device.cpp
+++ b/Core/Graphics/Source/Device.cpp
@@ -3,12 +3,8 @@
 
 namespace Babylon::Graphics
 {
-    class Device::Impl : public DeviceImpl
-    {
-    };
-
-    Device::Device()
-        : m_impl{std::make_unique<Impl>()}
+    Device::Device(const Configuration& config)
+        : m_impl{new DeviceImpl{config}}
     {
     }
 
@@ -18,46 +14,24 @@ namespace Babylon::Graphics
     Device::Device(Device&&) noexcept = default;
     Device& Device::operator=(Device&&) noexcept = default;
 
-    void Device::UpdateWindow(const WindowConfiguration& config)
+    void Device::UpdateWindow(WindowT window)
     {
-        m_impl->UpdateWindow(config);
-    }
-
-    void Device::UpdateContext(const DeviceConfiguration& config)
-    {
-        m_impl->UpdateContext(config);
-    }
-
-    std::unique_ptr<Device> Device::Create(const WindowConfiguration& config)
-    {
-        std::unique_ptr<Device> device{new Device()};
-        device->UpdateWindow(config);
-        device->UpdateSize(config.Width, config.Height);
-        device->UpdateMSAA(config.MSAASamples);
-        device->UpdateAlphaPremultiplied(config.AlphaPremultiplied);
-        return device;
-    }
-
-    std::unique_ptr<Device> Device::Create(const DeviceConfiguration& config)
-    {
-        std::unique_ptr<Device> device{new Device()};
-        device->UpdateContext(config);
-        return device;
+        m_impl->UpdateWindow(window);
     }
 
     void Device::UpdateSize(size_t width, size_t height)
     {
-        m_impl->Resize(width, height);
+        m_impl->UpdateSize(width, height);
     }
 
     void Device::UpdateMSAA(uint8_t value)
     {
-        m_impl->SetMSAA(value);
+        m_impl->UpdateMSAA(value);
     }
 
     void Device::UpdateAlphaPremultiplied(bool enabled)
     {
-        m_impl->SetAlphaPremultiplied(enabled);
+        m_impl->UpdateAlphaPremultiplied(enabled);
     }
 
     void Device::AddToJavaScript(Napi::Env env)

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -17,7 +17,7 @@ namespace
 
 namespace Babylon::Graphics
 {
-    DeviceImpl::DeviceImpl()
+    DeviceImpl::DeviceImpl(const Configuration& config)
         : m_bgfxCallback{[this](const auto& data) { CaptureCallback(data); }}
         , m_context{*this}
     {
@@ -29,10 +29,17 @@ namespace Babylon::Graphics
         init.resolution.reset = BGFX_RESET_VSYNC | BGFX_RESET_MAXANISOTROPY;
         init.resolution.maxFrameLatency = 1;
         if (s_bgfxFlipAfterRender)
+        {
             init.resolution.reset |= BGFX_RESET_FLIP_AFTER_RENDER;
+        }
 
         init.callback = &m_bgfxCallback;
-        init.platformData = {};
+
+        init.platformData.context = config.Device;
+        UpdateWindow(config.Window);
+        UpdateSize(config.Width, config.Height);
+        UpdateMSAA(config.MSAASamples);
+        UpdateAlphaPremultiplied(config.AlphaPremultiplied);
     }
 
     DeviceImpl::~DeviceImpl()
@@ -40,23 +47,15 @@ namespace Babylon::Graphics
         DisableRendering();
     }
 
-    void DeviceImpl::UpdateWindow(const WindowConfiguration& config)
+    void DeviceImpl::UpdateWindow(WindowT window)
     {
         std::scoped_lock lock{m_state.Mutex};
         m_state.Bgfx.Dirty = true;
-        ConfigureBgfxPlatformData(config, m_state.Bgfx.InitState.platformData);
-        m_state.Resolution.DevicePixelRatio = GetDevicePixelRatio(config);
+        ConfigureBgfxPlatformData(m_state.Bgfx.InitState.platformData, window);
+        m_state.Resolution.DevicePixelRatio = GetDevicePixelRatio(window);
     }
 
-    void DeviceImpl::UpdateContext(const DeviceConfiguration& config)
-    {
-        std::scoped_lock lock{m_state.Mutex};
-        m_state.Bgfx.Dirty = true;
-        ConfigureBgfxPlatformData(config, m_state.Bgfx.InitState.platformData);
-        m_state.Resolution.DevicePixelRatio = config.DevicePixelRatio;
-    }
-
-    void DeviceImpl::Resize(size_t width, size_t height)
+    void DeviceImpl::UpdateSize(size_t width, size_t height)
     {
         std::scoped_lock lock{m_state.Mutex};
         m_state.Resolution.Width = width;
@@ -64,7 +63,7 @@ namespace Babylon::Graphics
         UpdateBgfxResolution();
     }
 
-    void DeviceImpl::SetMSAA(uint8_t value)
+    void DeviceImpl::UpdateMSAA(uint8_t value)
     {
         std::scoped_lock lock{m_state.Mutex};
         m_state.Bgfx.Dirty = true;
@@ -94,7 +93,7 @@ namespace Babylon::Graphics
         }
     }
 
-    void DeviceImpl::SetAlphaPremultiplied(bool enabled)
+    void DeviceImpl::UpdateAlphaPremultiplied(bool enabled)
     {
         std::scoped_lock lock{m_state.Mutex};
         m_state.Bgfx.Dirty = true;
@@ -103,14 +102,11 @@ namespace Babylon::Graphics
         init.resolution.reset |= enabled ? BGFX_RESET_TRANSPARENT_BACKBUFFER : 0;
     }
 
-    size_t DeviceImpl::GetWidth() const
+    void DeviceImpl::UpdateDevicePixelRatio(float value)
     {
-        return m_state.Resolution.Width;
-    }
-
-    size_t DeviceImpl::GetHeight() const
-    {
-        return m_state.Resolution.Height;
+        std::scoped_lock lock{m_state.Mutex};
+        m_state.Bgfx.Dirty = true;
+        m_state.Resolution.DevicePixelRatio = value;
     }
 
     void DeviceImpl::AddToJavaScript(Napi::Env env)
@@ -130,16 +126,6 @@ namespace Babylon::Graphics
     Napi::Value DeviceImpl::CreateContext(Napi::Env env)
     {
         return DeviceContext::Create(env, *this);
-    }
-
-    continuation_scheduler<>& DeviceImpl::BeforeRenderScheduler()
-    {
-        return m_beforeRenderDispatcher.scheduler();
-    }
-
-    continuation_scheduler<>& DeviceImpl::AfterRenderScheduler()
-    {
-        return m_afterRenderDispatcher.scheduler();
     }
 
     void DeviceImpl::EnableRendering()
@@ -193,6 +179,25 @@ namespace Babylon::Graphics
 
             m_renderThreadAffinity = {};
         }
+    }
+
+    SafeTimespanGuarantor& DeviceImpl::GetSafeTimespanGuarantor(const char* updateName)
+    {
+        std::scoped_lock lock{m_updateSafeTimespansMutex};
+        std::string updateNameStr{updateName};
+        auto found = m_updateSafeTimespans.find(updateNameStr);
+        if (found == m_updateSafeTimespans.end())
+        {
+            m_updateSafeTimespans.emplace(std::piecewise_construct, std::forward_as_tuple(updateNameStr), std::forward_as_tuple(m_cancellationSource));
+            found = m_updateSafeTimespans.find(updateNameStr);
+        }
+        return found->second;
+    }
+
+    void DeviceImpl::SetDiagnosticOutput(std::function<void(const char* output)> diagnosticOutput)
+    {
+        assert(m_renderThreadAffinity.check());
+        m_bgfxCallback.SetDiagnosticOutput(std::move(diagnosticOutput));
     }
 
     void DeviceImpl::StartRenderingCurrentFrame()
@@ -253,37 +258,6 @@ namespace Babylon::Graphics
         m_rendering = false;
     }
 
-    SafeTimespanGuarantor& DeviceImpl::GetSafeTimespanGuarantor(const char* updateName)
-    {
-        std::scoped_lock lock{m_updateSafeTimespansMutex};
-        std::string updateNameStr{updateName};
-        auto found = m_updateSafeTimespans.find(updateNameStr);
-        if (found == m_updateSafeTimespans.end())
-        {
-            m_updateSafeTimespans.emplace(std::piecewise_construct, std::forward_as_tuple(updateNameStr), std::forward_as_tuple(m_cancellationSource));
-            found = m_updateSafeTimespans.find(updateNameStr);
-        }
-        return found->second;
-    }
-
-    void DeviceImpl::SetDiagnosticOutput(std::function<void(const char* output)> diagnosticOutput)
-    {
-        assert(m_renderThreadAffinity.check());
-        m_bgfxCallback.SetDiagnosticOutput(std::move(diagnosticOutput));
-    }
-
-    void DeviceImpl::RequestScreenShot(std::function<void(std::vector<uint8_t>)> callback)
-    {
-        m_screenShotCallbacks.push(std::move(callback));
-    }
-
-    arcana::task<void, std::exception_ptr> DeviceImpl::ReadTextureAsync(bgfx::TextureHandle handle, gsl::span<uint8_t> data, uint8_t mipLevel)
-    {
-        arcana::task_completion_source<void, std::exception_ptr> completionSource{};
-        m_readTextureRequests.emplace(bgfx::readTexture(handle, data.data(), mipLevel), completionSource);
-        return completionSource.as_task();
-    }
-
     float DeviceImpl::GetHardwareScalingLevel() const
     {
         std::scoped_lock lock{m_state.Mutex};
@@ -296,12 +270,46 @@ namespace Babylon::Graphics
         {
             throw std::runtime_error{"HardwareScalingValue cannot be less than or equal to 0."};
         }
+
         {
             std::scoped_lock lock{m_state.Mutex};
             m_state.Resolution.HardwareScalingLevel = level;
         }
 
         UpdateBgfxResolution();
+    }
+
+    float DeviceImpl::GetDevicePixelRatio() const
+    {
+        std::scoped_lock lock{m_state.Mutex};
+        return m_state.Resolution.DevicePixelRatio;
+    }
+
+    PlatformInfo DeviceImpl::GetPlatformInfo() const
+    {
+        return {static_cast<DeviceT>(bgfx::getInternalData()->context)};
+    }
+
+    continuation_scheduler<>& DeviceImpl::BeforeRenderScheduler()
+    {
+        return m_beforeRenderDispatcher.scheduler();
+    }
+
+    continuation_scheduler<>& DeviceImpl::AfterRenderScheduler()
+    {
+        return m_afterRenderDispatcher.scheduler();
+    }
+
+    void DeviceImpl::RequestScreenShot(std::function<void(std::vector<uint8_t>)> callback)
+    {
+        m_screenShotCallbacks.push(std::move(callback));
+    }
+
+    arcana::task<void, std::exception_ptr> DeviceImpl::ReadTextureAsync(bgfx::TextureHandle handle, gsl::span<uint8_t> data, uint8_t mipLevel)
+    {
+        arcana::task_completion_source<void, std::exception_ptr> completionSource{};
+        m_readTextureRequests.emplace(bgfx::readTexture(handle, data.data(), mipLevel), completionSource);
+        return completionSource.as_task();
     }
 
     DeviceImpl::CaptureCallbackTicketT DeviceImpl::AddCaptureCallback(std::function<void(const BgfxCallback::CaptureData&)> callback)
@@ -453,16 +461,5 @@ namespace Babylon::Graphics
         {
             callback(data);
         }
-    }
-
-    float DeviceImpl::GetDevicePixelRatio() const
-    {
-        std::scoped_lock lock{m_state.Mutex};
-        return m_state.Resolution.DevicePixelRatio;
-    }
-
-    PlatformInfo DeviceImpl::GetPlatformInfo() const
-    {
-        return {static_cast<DeviceT>(bgfx::getInternalData()->context)};
     }
 }

--- a/Core/Graphics/Source/DeviceImpl_Android.cpp
+++ b/Core/Graphics/Source/DeviceImpl_Android.cpp
@@ -8,12 +8,12 @@ namespace Babylon::Graphics
 {
     const bool DeviceImpl::s_bgfxFlipAfterRender = false;
 
-    void DeviceImpl::ConfigureBgfxPlatformData(const WindowConfiguration& config, bgfx::PlatformData& pd)
+    void DeviceImpl::ConfigureBgfxPlatformData(bgfx::PlatformData& pd, WindowT window)
     {
-        pd.nwh = config.Window;
+        pd.nwh = window;
     }
 
-    float DeviceImpl::GetDevicePixelRatio(const WindowConfiguration&)
+    float DeviceImpl::GetDevicePixelRatio(WindowT)
     {
         // In Android, the baseline DPI is 160dpi.
         // See https://developer.android.com/training/multiscreen/screendensities#dips-pels

--- a/Core/Graphics/Source/DeviceImpl_D3D11.cpp
+++ b/Core/Graphics/Source/DeviceImpl_D3D11.cpp
@@ -4,9 +4,4 @@
 namespace Babylon::Graphics
 {
     const bgfx::RendererType::Enum DeviceImpl::s_bgfxRenderType = bgfx::RendererType::Direct3D11;
-
-    void DeviceImpl::ConfigureBgfxPlatformData(const DeviceConfiguration& config, bgfx::PlatformData& pd)
-    {
-        pd.context = config.Device;
-    }
 }

--- a/Core/Graphics/Source/DeviceImpl_D3D12.cpp
+++ b/Core/Graphics/Source/DeviceImpl_D3D12.cpp
@@ -4,9 +4,4 @@
 namespace Babylon::Graphics
 {
     const bgfx::RendererType::Enum DeviceImpl::s_bgfxRenderType = bgfx::RendererType::Direct3D12;
-
-    void DeviceImpl::ConfigureBgfxPlatformData(const DeviceConfiguration& config, bgfx::PlatformData& pd)
-    {
-        pd.context = config.Device;
-    }
 }

--- a/Core/Graphics/Source/DeviceImpl_Metal.cpp
+++ b/Core/Graphics/Source/DeviceImpl_Metal.cpp
@@ -4,9 +4,4 @@
 namespace Babylon::Graphics
 {
     const bgfx::RendererType::Enum DeviceImpl::s_bgfxRenderType = bgfx::RendererType::Metal;
-
-    void DeviceImpl::ConfigureBgfxPlatformData(const DeviceConfiguration& config, bgfx::PlatformData& pd)
-    {
-        pd.context = config.Device;
-    }
 }

--- a/Core/Graphics/Source/DeviceImpl_OpenGL.cpp
+++ b/Core/Graphics/Source/DeviceImpl_OpenGL.cpp
@@ -4,9 +4,4 @@
 namespace Babylon::Graphics
 {
     const bgfx::RendererType::Enum DeviceImpl::s_bgfxRenderType = bgfx::RendererType::OpenGLES;
-
-    void DeviceImpl::ConfigureBgfxPlatformData(const DeviceConfiguration& config, bgfx::PlatformData& pd)
-    {
-        pd.context = config.Device;
-    }
 }

--- a/Core/Graphics/Source/DeviceImpl_Unix.cpp
+++ b/Core/Graphics/Source/DeviceImpl_Unix.cpp
@@ -5,12 +5,12 @@ namespace Babylon::Graphics
 {
     const bool DeviceImpl::s_bgfxFlipAfterRender = false;
 
-    void DeviceImpl::ConfigureBgfxPlatformData(const WindowConfiguration& config, bgfx::PlatformData& pd)
+    void DeviceImpl::ConfigureBgfxPlatformData(bgfx::PlatformData& pd, WindowT window)
     {
-        pd.nwh = reinterpret_cast<void*>(config.Window);
+        pd.nwh = reinterpret_cast<void*>(window);
     }
 
-    float DeviceImpl::GetDevicePixelRatio(const WindowConfiguration&)
+    float DeviceImpl::GetDevicePixelRatio(WindowT)
     {
         // TODO: We should persist a Display object instead of opening a new display.
         // See https://github.com/BabylonJS/BabylonNative/issues/625

--- a/Core/Graphics/Source/DeviceImpl_Win32.cpp
+++ b/Core/Graphics/Source/DeviceImpl_Win32.cpp
@@ -6,16 +6,16 @@ namespace Babylon::Graphics
 {
     const bool DeviceImpl::s_bgfxFlipAfterRender = false;
 
-    void DeviceImpl::ConfigureBgfxPlatformData(const WindowConfiguration& config, bgfx::PlatformData& pd)
+    void DeviceImpl::ConfigureBgfxPlatformData(bgfx::PlatformData& pd, WindowT window)
     {
-        pd.nwh = config.Window;
+        pd.nwh = window;
     }
 
-    float DeviceImpl::GetDevicePixelRatio(const WindowConfiguration& config)
+    float DeviceImpl::GetDevicePixelRatio(WindowT window)
     {
-        UINT dpi{GetDpiForWindow(config.Window)};
+        UINT dpi = GetDpiForWindow(window);
 
-        // In windows, 100% DPI scaling is 96dpi.
+        // 100% DPI scaling is 96dpi.
         // See https://docs.microsoft.com/en-us/windows/win32/learnwin32/dpi-and-device-independent-pixels
         return static_cast<float>(dpi) / 96.0f;
     }

--- a/Core/Graphics/Source/DeviceImpl_WinRT.cpp
+++ b/Core/Graphics/Source/DeviceImpl_WinRT.cpp
@@ -24,7 +24,7 @@ namespace Babylon::Graphics
 
     float DeviceImpl::GetDevicePixelRatio(WindowT window)
     {
-        if (auto uiElement = config.Window.try_as<ABI::Microsoft::UI::Xaml::IUIElement>())
+        if (auto uiElement = window.try_as<ABI::Microsoft::UI::Xaml::IUIElement>())
         {
             // Use the ABI layer manually generated from the Windows App SDK winmd files to avoid C++/WinRT versioning issues.
             DOUBLE rasterizationScale{1};

--- a/Core/Graphics/Source/DeviceImpl_WinRT.cpp
+++ b/Core/Graphics/Source/DeviceImpl_WinRT.cpp
@@ -9,20 +9,20 @@ namespace Babylon::Graphics
 {
     const bool DeviceImpl::s_bgfxFlipAfterRender = false;
 
-    void DeviceImpl::ConfigureBgfxPlatformData(const WindowConfiguration& config, bgfx::PlatformData& pd)
+    void DeviceImpl::ConfigureBgfxPlatformData(bgfx::PlatformData& pd, WindowT window)
     {
         // Assume window is a xaml swap chain panel if not a core window.
-        if (!config.Window.try_as<ABI::Windows::UI::Core::ICoreWindow>())
+        if (!window.try_as<ABI::Windows::UI::Core::ICoreWindow>())
         {
             // Set ndt greater than 1 for xaml swap chain panels.
             // See https://github.com/bkaradzic/bgfx/blob/23edb9c4d90744bf90a89ff9e7308b8ff6517fee/src/dxgi.cpp#L531-L552
             pd.ndt = reinterpret_cast<void*>(2);
         }
 
-        pd.nwh = winrt::get_abi(config.Window);
+        pd.nwh = winrt::get_abi(window);
     }
 
-    float DeviceImpl::GetDevicePixelRatio(const WindowConfiguration& config)
+    float DeviceImpl::GetDevicePixelRatio(WindowT window)
     {
         if (auto uiElement = config.Window.try_as<ABI::Microsoft::UI::Xaml::IUIElement>())
         {

--- a/Core/Graphics/Source/DeviceImpl_iOS.mm
+++ b/Core/Graphics/Source/DeviceImpl_iOS.mm
@@ -5,13 +5,13 @@ namespace Babylon::Graphics
 {
     const bool DeviceImpl::s_bgfxFlipAfterRender = true;
 
-    void DeviceImpl::ConfigureBgfxPlatformData(const WindowConfiguration& config, bgfx::PlatformData& pd)
+    void DeviceImpl::ConfigureBgfxPlatformData(bgfx::PlatformData& pd, WindowT window)
     {
-        pd.nwh = config.Window;
+        pd.nwh = window;
     }
 
-    float DeviceImpl::GetDevicePixelRatio(const WindowConfiguration& config)
+    float DeviceImpl::GetDevicePixelRatio(WindowT window)
     {
-        return config.Window.contentScaleFactor;
+        return window.contentScaleFactor;
     }
 }

--- a/Core/Graphics/Source/DeviceImpl_macOS.mm
+++ b/Core/Graphics/Source/DeviceImpl_macOS.mm
@@ -5,13 +5,13 @@ namespace Babylon::Graphics
 {
     const bool DeviceImpl::s_bgfxFlipAfterRender = true;
 
-    void DeviceImpl::ConfigureBgfxPlatformData(const WindowConfiguration& config, bgfx::PlatformData& pd)
+    void DeviceImpl::ConfigureBgfxPlatformData(bgfx::PlatformData& pd, WindowT window)
     {
-        pd.nwh = config.Window;
+        pd.nwh = window;
     }
 
-    float DeviceImpl::GetDevicePixelRatio(const WindowConfiguration& config)
+    float DeviceImpl::GetDevicePixelRatio(WindowT window)
     {
-        return config.Window.window.screen.backingScaleFactor;
+        return window.window.screen.backingScaleFactor;
     }
 }

--- a/Core/ScriptLoader/Source/ScriptLoader.cpp
+++ b/Core/ScriptLoader/Source/ScriptLoader.cpp
@@ -60,7 +60,7 @@ namespace Babylon
     };
 
     ScriptLoader::ScriptLoader(DispatchFunctionT dispatchFunction)
-        : m_impl{std::make_unique<ScriptLoader::Impl>(std::move(dispatchFunction))}
+        : m_impl{std::make_unique<Impl>(std::move(dispatchFunction))}
     {
     }
 

--- a/Plugins/TestUtils/Include/Babylon/Plugins/TestUtils.h
+++ b/Plugins/TestUtils/Include/Babylon/Plugins/TestUtils.h
@@ -6,5 +6,5 @@
 namespace Babylon::Plugins::TestUtils
 {
     extern int errorCode;
-    void Initialize(Napi::Env env, Graphics::WindowType window);
+    void Initialize(Napi::Env env, Graphics::WindowT window);
 }

--- a/Plugins/TestUtils/Source/Android/TestUtilsImpl.cpp
+++ b/Plugins/TestUtils/Source/Android/TestUtilsImpl.cpp
@@ -23,7 +23,7 @@ namespace Babylon::Plugins::Internal
 
 namespace Babylon::Plugins::TestUtils
 {
-    void Initialize(Napi::Env env, Graphics::WindowType window)
+    void Initialize(Napi::Env env, Graphics::WindowT window)
     {
         auto implData{std::make_shared<Internal::TestUtils::ImplData>(window)};
         Internal::TestUtils::CreateInstance(env, implData);

--- a/Plugins/TestUtils/Source/Apple/TestUtilsImpl.mm
+++ b/Plugins/TestUtils/Source/Apple/TestUtilsImpl.mm
@@ -49,7 +49,7 @@ namespace Babylon::Plugins::Internal
 
 namespace Babylon::Plugins::TestUtils
 {
-    void Initialize(Napi::Env env, Graphics::WindowType window)
+    void Initialize(Napi::Env env, Graphics::WindowT window)
     {
         auto implData{std::make_shared<Internal::TestUtils::ImplData>(window)};
         Internal::TestUtils::CreateInstance(env, implData);

--- a/Plugins/TestUtils/Source/TestUtilsImplData.h
+++ b/Plugins/TestUtils/Source/TestUtilsImplData.h
@@ -7,12 +7,12 @@ namespace Babylon::Plugins::Internal
     class TestUtils::ImplData final : public std::enable_shared_from_this<TestUtils::ImplData>
     {
     public:
-        ImplData(Graphics::WindowType window)
+        ImplData(Graphics::WindowT window)
             : m_window{window}
         {
         }
 
-        Graphics::WindowType m_window{};
+        Graphics::WindowT m_window{};
     };
 
 } // namespace

--- a/Plugins/TestUtils/Source/Unix/TestUtilsImpl.cpp
+++ b/Plugins/TestUtils/Source/Unix/TestUtilsImpl.cpp
@@ -59,7 +59,7 @@ namespace Babylon::Plugins::Internal
 
 namespace Babylon::Plugins::TestUtils
 {
-    void Initialize(Napi::Env env, Graphics::WindowType window)
+    void Initialize(Napi::Env env, Graphics::WindowT window)
     {
         auto implData{std::make_shared<Internal::TestUtils::ImplData>(window)};
         Internal::TestUtils::CreateInstance(env, implData);

--- a/Plugins/TestUtils/Source/Win32/TestUtilsImpl.cpp
+++ b/Plugins/TestUtils/Source/Win32/TestUtilsImpl.cpp
@@ -52,7 +52,7 @@ namespace Babylon::Plugins::Internal
 
 namespace Babylon::Plugins::TestUtils
 {
-    void Initialize(Napi::Env env, Graphics::WindowType window)
+    void Initialize(Napi::Env env, Graphics::WindowT window)
     {
         auto implData{std::make_shared<Internal::TestUtils::ImplData>(window)};
         Internal::TestUtils::CreateInstance(env, implData);

--- a/Plugins/TestUtils/Source/WinRT/TestUtilsImpl.cpp
+++ b/Plugins/TestUtils/Source/WinRT/TestUtilsImpl.cpp
@@ -27,7 +27,7 @@ namespace Babylon::Plugins::Internal
 
 namespace Babylon::Plugins::TestUtils
 {
-    void Initialize(Napi::Env env, Graphics::WindowType window)
+    void Initialize(Napi::Env env, Graphics::WindowT window)
     {
         auto implData{std::make_shared<Internal::TestUtils::ImplData>(window)};
         Internal::TestUtils::CreateInstance(env, implData);


### PR DESCRIPTION
This change updates the graphics contract such that the graphics configuration is merged into one.

I found out recently that bgfx still creates a graphics device when a window is passed in. I think everyone thought that bgfx was somehow getting the graphics device from the window, but it seems this isn't possible, at least with XamlSwapChains. If someone wanted to use their own graphics device with a window (e.g., create a multi-threaded D3D device), the current contract doesn't allow this. This is the main reason for this change.

Another reason is that the MSAA and premultiplied-alpha flags apply for both when there is a window and when there is not (at least for D3D11). The only time that these flags don't apply is when there is a given back buffer, but we don't currently support this.