### PR TITLE
Build and code cleanup

### DIFF
--- a/Apps/Playground/Android/app/CMakeLists.txt
+++ b/Apps/Playground/Android/app/CMakeLists.txt
@@ -41,29 +41,28 @@ set(BABYLON_NATIVE_PLAYGROUND_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 add_subdirectory(${BABYLON_NATIVE_PLAYGROUND_DIR}/../../ ${BABYLON_NATIVE_PLAYGROUND_DIR}/../../build/Android_${CMAKE_ANDROID_ARCH_ABI}/)
 
 add_library(BabylonNativeJNI SHARED
-            src/main/cpp/BabylonNativeJNI.cpp)
+    src/main/cpp/BabylonNativeJNI.cpp)
 
 target_include_directories(BabylonNativeJNI
-        PRIVATE
-        ${BABYLON_NATIVE_PLAYGROUND_DIR}/Shared)
+    PRIVATE ${BABYLON_NATIVE_PLAYGROUND_DIR}/Shared)
 
 target_link_libraries(BabylonNativeJNI
-        GLESv3
-        android
-        EGL
-        log
-        -lz
-        AndroidExtensions
-        AppRuntime
-        Canvas
-        Console
-        ChromeDevTools
-        GraphicsDevice
-        NativeCamera
-        NativeEngine
-        NativeInput
-        NativeOptimizations
-        NativeXr
-        ScriptLoader
-        XMLHttpRequest
-        Window)
+    GLESv3
+    android
+    EGL
+    log
+    -lz
+    AndroidExtensions
+    AppRuntime
+    Canvas
+    Console
+    ChromeDevTools
+    GraphicsDevice
+    NativeCamera
+    NativeEngine
+    NativeInput
+    NativeOptimizations
+    NativeXr
+    ScriptLoader
+    XMLHttpRequest
+    Window)

--- a/Apps/Playground/Android/app/CMakeLists.txt
+++ b/Apps/Playground/Android/app/CMakeLists.txt
@@ -53,17 +53,17 @@ target_link_libraries(BabylonNativeJNI
         EGL
         log
         -lz
+        AndroidExtensions
         AppRuntime
+        Canvas
+        Console
+        ChromeDevTools
+        GraphicsDevice
+        NativeCamera
         NativeEngine
         NativeInput
-        NativeXr
         NativeOptimizations
-        Console
-        Canvas
-        Window
+        NativeXr
         ScriptLoader
         XMLHttpRequest
-        NativeCamera
-        AndroidExtensions
-        ChromeDevTools
-        )
+        Window)

--- a/Apps/Playground/CMakeLists.txt
+++ b/Apps/Playground/CMakeLists.txt
@@ -108,16 +108,17 @@ target_include_directories(Playground PRIVATE "Source" ".")
 
 target_link_to_dependencies(Playground
     PRIVATE AppRuntime
-    PRIVATE NativeCapture
+    PRIVATE Canvas
     PRIVATE ChromeDevTools
+    PRIVATE Console
+    PRIVATE GraphicsDevice
+    PRIVATE NativeCapture
     PRIVATE NativeEngine
     PRIVATE NativeInput
     PRIVATE NativeOptimizations
-    PRIVATE Console
-    PRIVATE Window
     PRIVATE ScriptLoader
+    PRIVATE Window
     PRIVATE XMLHttpRequest
-    PRIVATE Canvas
     ${ADDITIONAL_LIBRARIES}
     ${BABYLON_NATIVE_PLAYGROUND_EXTENSION_LIBRARIES})
 

--- a/Apps/UnitTests/CMakeLists.txt
+++ b/Apps/UnitTests/CMakeLists.txt
@@ -17,11 +17,9 @@ set(NPM_SCRIPTS
 set(HEADERS
     "Shared/Tests.h")
 
-set(ADDITIONAL_LIBRARIES "")
-
 if(APPLE)
     find_library(JSCORE_LIBRARY JavaScriptCore)
-    set(ADDITIONAL_LIBRARIES ${JSCORE_LIBRARY})
+    set(ADDITIONAL_LIBRARIES PRIVATE ${JSCORE_LIBRARY})
     set(TEST_APP "Apple/App.mm")
 elseif(UNIX AND NOT ANDROID)
     set(TEST_APP "X11/App.cpp")
@@ -32,14 +30,15 @@ endif()
 add_executable(UnitTests ${LOCAL_SCRIPTS} ${NPM_SCRIPTS} ${TEST_APP} ${HEADERS})
 
 target_link_to_dependencies(UnitTests
-    UrlLib
-    AppRuntime
-    XMLHttpRequest
-    NativeEngine
-    ScriptLoader
-    Console
-    Window
-    Canvas
+    PRIVATE AppRuntime
+    PRIVATE Canvas
+    PRIVATE Console
+    PRIVATE GraphicsDevice
+    PRIVATE NativeEngine
+    PRIVATE ScriptLoader
+    PRIVATE UrlLib
+    PRIVATE Window
+    PRIVATE XMLHttpRequest
     ${ADDITIONAL_LIBRARIES})
 
 add_test(NAME UnitTests COMMAND UnitTests)

--- a/Apps/ValidationTests/Android/app/CMakeLists.txt
+++ b/Apps/ValidationTests/Android/app/CMakeLists.txt
@@ -21,8 +21,7 @@ cmake_minimum_required(VERSION 3.13.2)
 project(BabylonNative)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 set(BABYLON_NATIVE_PLATFORM "Android")
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+set(CMAKE_CXX_STANDARD 17)
 
 if (${ANDROID_JSENGINE_LIBNAME} STREQUAL "jsc")
     set(NAPI_JAVASCRIPT_ENGINE "JavaScriptCore" CACHE STRING "JavaScript engine for N-API.")
@@ -42,29 +41,22 @@ set(BABYLON_NATIVE_VALIDATIONTESTS_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 add_subdirectory(${BABYLON_NATIVE_VALIDATIONTESTS_DIR}/../../ ${BABYLON_NATIVE_VALIDATIONTESTS_DIR}/../../build/Android_${CMAKE_ANDROID_ARCH_ABI}/)
 
 add_library(BabylonNativeJNI SHARED
-            src/main/cpp/BabylonNativeJNI.cpp)
-
-add_definitions(-DANDROID_STL=c++_shared)
+    src/main/cpp/BabylonNativeJNI.cpp)
 
 target_link_libraries(BabylonNativeJNI
-        GLESv3
-        android
-        EGL
-        log
-        -lz
-        AndroidExtensions
-        AppRuntime
-        NativeEngine
-        NativeOptimizations
-        NativeXr
-        Console
-        Window
-        ScriptLoader
-        bgfx
-        XMLHttpRequest
-        TestUtils)
-
-configure_file(
-    "${ANDROID_NDK}/sources/cxx-stl/llvm-libc++/libs/${ANDROID_ABI}/libc++_shared.so"
-    "${CMAKE_CURRENT_LIST_DIR}/src/main/jniLibs/${CMAKE_ANDROID_ARCH_ABI}/libc++_shared.so"
-    COPYONLY)
+    GLESv3
+    android
+    EGL
+    log
+    -lz
+    AndroidExtensions
+    AppRuntime
+    Console
+    GraphicsDevice
+    NativeEngine
+    NativeOptimizations
+    NativeXr
+    ScriptLoader
+    TestUtils
+    XMLHttpRequest
+    Window)

--- a/Apps/ValidationTests/CMakeLists.txt
+++ b/Apps/ValidationTests/CMakeLists.txt
@@ -110,19 +110,17 @@ if(WINDOWS_STORE)
 endif()
 
 target_link_to_dependencies(ValidationTests
-    PRIVATE bgfx
-    PRIVATE bimg
-    PRIVATE bx
     PRIVATE AppRuntime
+    PRIVATE Canvas
+    PRIVATE Console
+    PRIVATE GraphicsDevice
     PRIVATE NativeEngine
     PRIVATE NativeOptimizations
-    PRIVATE Console
-    PRIVATE Window
     PRIVATE ScriptLoader
-    PRIVATE Canvas
     PRIVATE TestUtils
-    ${ADDITIONAL_LIBRARIES}
-    PRIVATE XMLHttpRequest)
+    PRIVATE Window
+    PRIVATE XMLHttpRequest
+    ${ADDITIONAL_LIBRARIES})
 
 if(APPLE)
     target_link_libraries(ValidationTests PRIVATE "-framework MetalKit")

--- a/Core/AppRuntime/CMakeLists.txt
+++ b/Core/AppRuntime/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 
 target_link_to_dependencies(AppRuntime
     PRIVATE arcana
-    PUBLIC JsRuntime)
+    PRIVATE JsRuntime)
 
 target_compile_definitions(AppRuntime
     PRIVATE NOMINMAX)

--- a/Core/AppRuntime/Include/Babylon/AppRuntime.h
+++ b/Core/AppRuntime/Include/Babylon/AppRuntime.h
@@ -10,6 +10,7 @@
 namespace Babylon
 {
     class WorkQueue;
+
     class AppRuntime final
     {
     public:

--- a/Core/AppRuntime/Include/Babylon/AppRuntime.h
+++ b/Core/AppRuntime/Include/Babylon/AppRuntime.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "Dispatchable.h"
-
-#include <Babylon/JsRuntime.h>
+#include <napi/napi.h>
 
 #include <memory>
 #include <functional>

--- a/Core/AppRuntime/Source/AppRuntime.cpp
+++ b/Core/AppRuntime/Source/AppRuntime.cpp
@@ -1,5 +1,6 @@
 #include "AppRuntime.h"
 #include "WorkQueue.h"
+#include <Babylon/JsRuntime.h>
 
 namespace Babylon
 {

--- a/Core/AppRuntime/Source/AppRuntime_Chakra.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_Chakra.cpp
@@ -1,4 +1,5 @@
 #include "AppRuntime.h"
+#include <napi/env.h>
 
 #include <jsrt.h>
 
@@ -21,28 +22,29 @@ namespace Babylon
     void AppRuntime::RunEnvironmentTier(const char*)
     {
         using DispatchFunction = std::function<void(std::function<void()>)>;
-        DispatchFunction dispatchFunction{
+        DispatchFunction dispatchFunction =
             [this](std::function<void()> action) {
                 Dispatch([action = std::move(action)](Napi::Env) {
                     action();
                 });
-            }};
+            };
 
         JsRuntimeHandle jsRuntime;
         ThrowIfFailed(JsCreateRuntime(JsRuntimeAttributeNone, nullptr, &jsRuntime));
         JsContextRef context;
         ThrowIfFailed(JsCreateContext(jsRuntime, &context));
         ThrowIfFailed(JsSetCurrentContext(context));
-        ThrowIfFailed(JsSetPromiseContinuationCallback([](JsValueRef task, void* callbackState) {
-            ThrowIfFailed(JsAddRef(task, nullptr));
-            auto* dispatch = reinterpret_cast<DispatchFunction*>(callbackState);
-            dispatch->operator()([task]() {
-                JsValueRef undefined;
-                ThrowIfFailed(JsGetUndefinedValue(&undefined));
-                ThrowIfFailed(JsCallFunction(task, &undefined, 1, nullptr));
-                ThrowIfFailed(JsRelease(task, nullptr));
-            });
-        },
+        ThrowIfFailed(JsSetPromiseContinuationCallback(
+            [](JsValueRef task, void* callbackState) {
+                ThrowIfFailed(JsAddRef(task, nullptr));
+                auto* dispatch = reinterpret_cast<DispatchFunction*>(callbackState);
+                dispatch->operator()([task]() {
+                    JsValueRef undefined;
+                    ThrowIfFailed(JsGetUndefinedValue(&undefined));
+                    ThrowIfFailed(JsCallFunction(task, &undefined, 1, nullptr));
+                    ThrowIfFailed(JsRelease(task, nullptr));
+                });
+            },
             &dispatchFunction));
         ThrowIfFailed(JsProjectWinRTNamespace(L"Windows"));
 

--- a/Core/AppRuntime/Source/AppRuntime_Chakra.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_Chakra.cpp
@@ -1,4 +1,5 @@
 #include "AppRuntime.h"
+
 #include <napi/env.h>
 
 #include <jsrt.h>

--- a/Core/AppRuntime/Source/AppRuntime_JSI.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_JSI.cpp
@@ -1,6 +1,7 @@
 #include "AppRuntime.h"
 #include "WorkQueue.h"
 
+#include <Babylon/JsRuntime.h>
 #include <napi/env.h>
 #include <V8JsiRuntime.h>
 #include <ScriptStore.h>

--- a/Core/AppRuntime/Source/AppRuntime_JSI.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_JSI.cpp
@@ -2,7 +2,7 @@
 #include "WorkQueue.h"
 
 #include <Babylon/JsRuntime.h>
-#include <napi/env.h>
+
 #include <V8JsiRuntime.h>
 #include <ScriptStore.h>
 

--- a/Core/AppRuntime/Source/AppRuntime_JavaScriptCore.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_JavaScriptCore.cpp
@@ -1,5 +1,6 @@
 #include "AppRuntime.h"
 
+#include <napi/env.h>
 #include <JavaScriptCore/JavaScript.h>
 
 namespace Babylon

--- a/Core/AppRuntime/Source/AppRuntime_V8.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_V8.cpp
@@ -1,5 +1,7 @@
 #include "AppRuntime.h"
 
+#include <Babylon/JsRuntime.h>
+
 #if defined(_MSC_VER)
 #pragma warning(disable : 4100 4267 4127)
 #endif

--- a/Core/Graphics/CMakeLists.txt
+++ b/Core/Graphics/CMakeLists.txt
@@ -42,7 +42,6 @@ endif()
 
 target_link_to_dependencies(Graphics
     PRIVATE napi_extensions
-    PRIVATE JsRuntime
     PRIVATE JsRuntimeInternal
     PRIVATE bgfx
     PRIVATE bimg

--- a/Core/JsRuntime/CMakeLists.txt
+++ b/Core/JsRuntime/CMakeLists.txt
@@ -1,12 +1,11 @@
 set(SOURCES
     "Include/Babylon/JsRuntime.h"
-    "Include/Babylon/JsRuntimeScheduler.h"
+    "InternalInclude/Babylon/JsRuntimeScheduler.h"
     "Source/JsRuntime.cpp")
 
 add_library(JsRuntime ${SOURCES})
 warnings_as_errors(JsRuntime)
 
-target_include_directories(JsRuntime PRIVATE "Include/Babylon")
 target_include_directories(JsRuntime PUBLIC "Include")
 
 target_link_to_dependencies(JsRuntime
@@ -17,7 +16,7 @@ set_property(TARGET JsRuntime PROPERTY FOLDER Core)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})
 
 add_library(JsRuntimeInternal INTERFACE)
-target_include_directories(JsRuntimeInternal INTERFACE "Source")
+target_include_directories(JsRuntimeInternal INTERFACE "InternalInclude")
 target_link_to_dependencies(JsRuntimeInternal
     INTERFACE JsRuntime
     INTERFACE arcana)

--- a/Core/JsRuntime/Include/Babylon/JsRuntime.h
+++ b/Core/JsRuntime/Include/Babylon/JsRuntime.h
@@ -47,6 +47,5 @@ namespace Babylon
         JsRuntime(Napi::Env, DispatchFunctionT);
 
         DispatchFunctionT m_dispatchFunction{};
-        std::mutex m_mutex{};
     };
 }

--- a/Core/JsRuntime/InternalInclude/Babylon/JsRuntimeScheduler.h
+++ b/Core/JsRuntime/InternalInclude/Babylon/JsRuntimeScheduler.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "JsRuntime.h"
+#include <Babylon/JsRuntime.h>
 
 namespace Babylon
 {

--- a/Core/JsRuntime/Source/JsRuntime.cpp
+++ b/Core/JsRuntime/Source/JsRuntime.cpp
@@ -1,4 +1,4 @@
-#include "JsRuntime.h"
+#include <Babylon/JsRuntime.h>
 
 namespace Babylon
 {
@@ -42,7 +42,6 @@ namespace Babylon
 
     void JsRuntime::Dispatch(std::function<void(Napi::Env)> function)
     {
-        std::scoped_lock lock{m_mutex};
         m_dispatchFunction([function = std::move(function)](Napi::Env env) {
             function(env);
 

--- a/Plugins/ChromeDevTools/CMakeLists.txt
+++ b/Plugins/ChromeDevTools/CMakeLists.txt
@@ -23,10 +23,12 @@ if (NAPI_JAVASCRIPT_ENGINE IN_LIST CHROME_DEVTOOLS_SUPPORTED_ENGINES AND NAPI_JA
     target_link_to_dependencies(ChromeDevTools PRIVATE v8inspector)
 endif()
 
-target_include_directories(ChromeDevTools INTERFACE "Include")
-target_include_directories(ChromeDevTools PRIVATE "Include/Babylon/Plugins")
+target_include_directories(ChromeDevTools
+    PUBLIC "Include")
 
-target_link_to_dependencies(ChromeDevTools PUBLIC JsRuntime)
+target_link_to_dependencies(ChromeDevTools
+    PUBLIC napi
+    PRIVATE JsRuntime)
 
 set_property(TARGET ChromeDevTools PROPERTY FOLDER Plugins)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Plugins/ChromeDevTools/Source/ChromeDevToolsJSI.cpp
+++ b/Plugins/ChromeDevTools/Source/ChromeDevToolsJSI.cpp
@@ -1,4 +1,4 @@
-#include "ChromeDevTools.h"
+#include <Babylon/Plugins/ChromeDevTools.h>
 
 #include <V8JsiRuntime.h>
 #include <Babylon/JsRuntime.h>

--- a/Plugins/ChromeDevTools/Source/ChromeDevToolsNull.cpp
+++ b/Plugins/ChromeDevTools/Source/ChromeDevToolsNull.cpp
@@ -1,4 +1,4 @@
-#include "ChromeDevTools.h"
+#include <Babylon/Plugins/ChromeDevTools.h>
 
 #include <Babylon/JsRuntime.h>
 

--- a/Plugins/ChromeDevTools/Source/ChromeDevToolsV8.cpp
+++ b/Plugins/ChromeDevTools/Source/ChromeDevToolsV8.cpp
@@ -1,4 +1,4 @@
-#include "ChromeDevTools.h"
+#include <Babylon/Plugins/ChromeDevTools.h>
 
 #include <V8InspectorAgent.h>
 #include <Babylon/JsRuntime.h>

--- a/Plugins/ExternalTexture/CMakeLists.txt
+++ b/Plugins/ExternalTexture/CMakeLists.txt
@@ -13,23 +13,17 @@ if (APPLE)
 endif()
 
 target_include_directories(ExternalTexture
-    PUBLIC "Include"
-    PRIVATE "Source")
+    PUBLIC "Include")
 
 target_link_to_dependencies(ExternalTexture
-    PRIVATE napi_extensions
-    PUBLIC JsRuntime
+    PUBLIC napi
     PUBLIC GraphicsDevice
+    PRIVATE napi_extensions
     PRIVATE JsRuntimeInternal
-    PRIVATE GraphicsDeviceContext
-    PRIVATE Graphics
-    PRIVATE bgfx
-    PRIVATE bimg
-    PRIVATE bx)
+    PRIVATE GraphicsDeviceContext)
 
 target_compile_definitions(ExternalTexture
-    PRIVATE NOMINMAX
-    PRIVATE ${GRAPHICS_API_UPPER})
+    PRIVATE NOMINMAX)
 
 set_property(TARGET ExternalTexture PROPERTY FOLDER Plugins)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Plugins/NativeCamera/CMakeLists.txt
+++ b/Plugins/NativeCamera/CMakeLists.txt
@@ -25,24 +25,24 @@ add_library(NativeCamera ${SOURCES})
 warnings_as_errors(NativeCamera)
 
 target_include_directories(NativeCamera
-    INTERFACE "Include"
-    PRIVATE "Include/Babylon/Plugins"
-    PRIVATE "Source/${PLATFORM}")
+    PUBLIC "Include")
 
 if(ANDROID)
-    set(EXTENSIONS AndroidExtensions)
+    set(ADDITIONAL_LIBRARIES
+        PRIVATE AndroidExtensions)
 elseif(APPLE)
-    set(EXTENSIONS "-framework CoreMedia -framework AVFoundation")
+    set(ADDITIONAL_LIBRARIES
+        PRIVATE "-framework CoreMedia -framework AVFoundation")
     set_target_properties(NativeCamera PROPERTIES
-        XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES
-    )
+        XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)
 endif()
 
 target_link_to_dependencies(NativeCamera
-    PUBLIC JsRuntime
+    PUBLIC napi
+    PRIVATE JsRuntimeInternal
     PRIVATE GraphicsDeviceContext
     PRIVATE napi_extensions
-    PRIVATE ${EXTENSIONS})
+    ${ADDITIONAL_LIBRARIES})
 
 set_property(TARGET NativeCamera PROPERTY FOLDER Plugins)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Plugins/NativeCamera/Source/Android/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Android/CameraDevice.cpp
@@ -1,5 +1,4 @@
 #include <napi/napi.h>
-#include "NativeCamera.h"
 #include "../CameraDevice.h"
 #include <string>
 #include <android/native_window_jni.h>

--- a/Plugins/NativeCamera/Source/Apple/CameraDevice.mm
+++ b/Plugins/NativeCamera/Source/Apple/CameraDevice.mm
@@ -5,7 +5,6 @@
 #import <MetalKit/MetalKit.h>
 #include <bgfx/bgfx.h>
 #include <bgfx/platform.h>
-#include "NativeCamera.h"
 #include <arcana/macros.h>
 #include <arcana/threading/task.h>
 #include <arcana/threading/dispatcher.h>

--- a/Plugins/NativeCamera/Source/MediaStream.h
+++ b/Plugins/NativeCamera/Source/MediaStream.h
@@ -39,12 +39,12 @@ namespace Babylon::Plugins
         uint32_t Height{0};
 
     private:
-        arcana::task<void, std::exception_ptr> ApplyInitialConstraintsAsync(Napi::Env env, Napi::Object constraints);
-        std::optional<std::pair<CameraDevice, const CameraTrack&>> FindBestCameraStream(Napi::Env env, Napi::Object constraints);
-        bool UpdateConstraints(Napi::Env env, Napi::Object constraints);
+        arcana::task<void, std::exception_ptr> ApplyInitialConstraintsAsync(Napi::Object constraints);
+        std::optional<std::pair<CameraDevice, const CameraTrack&>> FindBestCameraStream(Napi::Object constraints);
+        bool UpdateConstraints(Napi::Object constraints);
 
         // Capture CameraDevice in a shared_ptr because the iOS implementation relies on the `shared_from_this` syntax for async work
-        std::shared_ptr<CameraDevice> m_cameraDevice{nullptr};
+        std::shared_ptr<CameraDevice> m_cameraDevice{};
         JsRuntimeScheduler m_runtimeScheduler;
 
         Napi::ObjectReference m_currentConstraints{};

--- a/Plugins/NativeCamera/Source/NativeCamera.cpp
+++ b/Plugins/NativeCamera/Source/NativeCamera.cpp
@@ -1,6 +1,6 @@
+#include <Babylon/Plugins/NativeCamera.h>
 #include <Babylon/Graphics/Texture.h>
 #include <napi/napi_pointer.h>
-#include <NativeCamera.h>
 #include "NativeVideo.h"
 #include "MediaDevices.h"
 

--- a/Plugins/NativeCamera/Source/Unix/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Unix/CameraDevice.cpp
@@ -1,4 +1,3 @@
-#include "NativeCamera.h"
 #include "../CameraDevice.h"
 #include <napi/napi.h>
 #include <arcana/threading/affinity.h>

--- a/Plugins/NativeCamera/Source/Win32/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Win32/CameraDevice.cpp
@@ -1,4 +1,3 @@
-#include "NativeCamera.h"
 #include "../CameraDevice.h"
 #include <napi/napi.h>
 #include <arcana/threading/affinity.h>

--- a/Plugins/NativeCamera/Source/WinRT/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/WinRT/CameraDevice.cpp
@@ -1,4 +1,3 @@
-#include "NativeCamera.h"
 #include "../CameraDevice.h"
 #include <napi/napi.h>
 #include <arcana/threading/affinity.h>

--- a/Plugins/NativeCapture/CMakeLists.txt
+++ b/Plugins/NativeCapture/CMakeLists.txt
@@ -5,11 +5,11 @@ set(SOURCES
 add_library(NativeCapture ${SOURCES})
 warnings_as_errors(NativeCapture)
 
-target_include_directories(NativeCapture INTERFACE "Include")
-target_include_directories(NativeCapture PRIVATE "Include/Babylon/Plugins")
+target_include_directories(NativeCapture PUBLIC
+    "Include")
 
 target_link_to_dependencies(NativeCapture
-    PUBLIC JsRuntime
+    PUBLIC JsRuntimeInternal
     PRIVATE GraphicsDeviceContext
     PRIVATE napi_extensions)
 

--- a/Plugins/NativeCapture/Source/NativeCapture.cpp
+++ b/Plugins/NativeCapture/Source/NativeCapture.cpp
@@ -1,5 +1,4 @@
-#include "NativeCapture.h"
-
+#include <Babylon/Plugins/NativeCapture.h>
 #include <Babylon/JsRuntime.h>
 #include <Babylon/Graphics/DeviceContext.h>
 #include <Babylon/Graphics/FrameBuffer.h>

--- a/Plugins/NativeEngine/CMakeLists.txt
+++ b/Plugins/NativeEngine/CMakeLists.txt
@@ -33,8 +33,9 @@ target_include_directories(NativeEngine
     PRIVATE "${BIMG_DIR}/3rdparty")
 
 target_link_to_dependencies(NativeEngine
-    PUBLIC JsRuntime
-    INTERFACE GraphicsDevice
+    PUBLIC napi
+    PRIVATE JsRuntime
+    PRIVATE GraphicsDevice
     PRIVATE arcana
     PRIVATE bgfx
     PRIVATE bimg

--- a/Plugins/NativeInput/CMakeLists.txt
+++ b/Plugins/NativeInput/CMakeLists.txt
@@ -5,13 +5,13 @@ set(SOURCES
     "Source/Shared/DeviceInputSystem.cpp"
     "Source/Shared/DeviceInputSystem.h")
 
-if (ANDROID)
+if(ANDROID)
     set(SOURCES ${SOURCES}
         "Source/Android/NativeInput.cpp")
-elseif (IOS)
+elseif(IOS)
     set(SOURCES ${SOURCES}
         "Source/iOS/NativeInput.cpp")
-elseif (APPLE)
+elseif(APPLE)
     set(SOURCES ${SOURCES}
          "Source/macOS/NativeInput.cpp")
 elseif(UNIX)
@@ -28,7 +28,8 @@ warnings_as_errors(NativeInput)
 target_include_directories(NativeInput PUBLIC "Include")
 
 target_link_to_dependencies(NativeInput
-    PUBLIC JsRuntime
+    PUBLIC napi
+    PRIVATE JsRuntimeInternal
     PRIVATE arcana)
 
 set_property(TARGET NativeInput PROPERTY FOLDER Plugins)

--- a/Plugins/NativeOptimizations/CMakeLists.txt
+++ b/Plugins/NativeOptimizations/CMakeLists.txt
@@ -5,16 +5,16 @@ set(SOURCES
 add_library(NativeOptimizations ${SOURCES})
 warnings_as_errors(NativeOptimizations)
 
-if (APPLE)
+if(APPLE)
     set_target_properties(NativeOptimizations PROPERTIES
-        XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES
-    )
+        XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)
 endif()
 
 target_include_directories(NativeOptimizations PUBLIC "Include")
 
 target_link_to_dependencies(NativeOptimizations
-    PUBLIC JsRuntime)
+    PUBLIC napi
+    PRIVATE JsRuntimeInternal)
 
 set_property(TARGET NativeOptimizations PROPERTY FOLDER Plugins)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Plugins/NativeTracing/CMakeLists.txt
+++ b/Plugins/NativeTracing/CMakeLists.txt
@@ -7,14 +7,14 @@ warnings_as_errors(NativeTracing)
 
 if (APPLE)
     set_target_properties(NativeTracing PROPERTIES
-        XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES
-    )
+        XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)
 endif()
 
 target_include_directories(NativeTracing PUBLIC "Include")
 
 target_link_to_dependencies(NativeTracing
-    PUBLIC JsRuntime
+    PUBLIC napi
+    PRIVATE JsRuntimeInternal
     PRIVATE arcana
     PRIVATE napi_extensions)
 

--- a/Plugins/NativeXr/CMakeLists.txt
+++ b/Plugins/NativeXr/CMakeLists.txt
@@ -9,10 +9,11 @@ target_include_directories(NativeXr
     PUBLIC "Include")
 
 target_link_to_dependencies(NativeXr
+    PUBLIC napi
     PRIVATE arcana
     PRIVATE bgfx
     PRIVATE GraphicsDeviceContext
-    PRIVATE JsRuntime
+    PRIVATE JsRuntimeInternal
     PRIVATE napi_extensions
     PRIVATE xr)
 

--- a/Plugins/TestUtils/CMakeLists.txt
+++ b/Plugins/TestUtils/CMakeLists.txt
@@ -14,11 +14,12 @@ set(SOURCES
 add_library(TestUtils ${SOURCES})
 warnings_as_errors(TestUtils)
 
-target_include_directories(TestUtils INTERFACE "Include")
-target_include_directories(TestUtils PRIVATE "Source")
+target_include_directories(TestUtils PUBLIC
+    "Include")
 
 target_link_to_dependencies(TestUtils
-    PUBLIC JsRuntime
+    PUBLIC napi
+    PRIVATE JsRuntimeInternal
     PRIVATE GraphicsDevice
     PRIVATE GraphicsDeviceContext)
 

--- a/Plugins/TestUtils/Source/Android/TestUtilsImpl.cpp
+++ b/Plugins/TestUtils/Source/Android/TestUtilsImpl.cpp
@@ -1,4 +1,4 @@
-#include "TestUtilsImplData.h"
+#include "../TestUtilsImplData.h"
 
 namespace Babylon::Plugins::Internal
 {

--- a/Plugins/TestUtils/Source/Apple/TestUtilsImpl.mm
+++ b/Plugins/TestUtils/Source/Apple/TestUtilsImpl.mm
@@ -1,4 +1,4 @@
-#import "TestUtilsImplData.h"
+#import "../TestUtilsImplData.h"
 
 // can't externalize variable with ObjC++. Using a function instead.
 int errorCode{};

--- a/Plugins/TestUtils/Source/Unix/TestUtilsImpl.cpp
+++ b/Plugins/TestUtils/Source/Unix/TestUtilsImpl.cpp
@@ -1,4 +1,4 @@
-#include "TestUtilsImplData.h"
+#include "../TestUtilsImplData.h"
 #define XK_MISCELLANY
 #define XK_LATIN1
 #include <X11/keysymdef.h>

--- a/Plugins/TestUtils/Source/Win32/TestUtilsImpl.cpp
+++ b/Plugins/TestUtils/Source/Win32/TestUtilsImpl.cpp
@@ -1,4 +1,4 @@
-#include "TestUtilsImplData.h"
+#include "../TestUtilsImplData.h"
 #include <filesystem>
 #include <Windowsx.h>
 

--- a/Plugins/TestUtils/Source/WinRT/TestUtilsImpl.cpp
+++ b/Plugins/TestUtils/Source/WinRT/TestUtilsImpl.cpp
@@ -1,4 +1,4 @@
-#include "TestUtilsImplData.h"
+#include "../TestUtilsImplData.h"
 #include <winrt/windows.storage.h>
 
 namespace Babylon::Plugins::Internal

--- a/Polyfills/Canvas/CMakeLists.txt
+++ b/Polyfills/Canvas/CMakeLists.txt
@@ -21,7 +21,8 @@ set(ATLAS_SOURCES ${BGFX_DIR}/examples/common/cube_atlas.cpp)
 
 add_library(Canvas ${SOURCES} ${FONT_SOURCES} ${ATLAS_SOURCES} ${NANOVG_SOURCES})
 
-target_include_directories(Canvas PUBLIC "Include"
+target_include_directories(Canvas
+    PUBLIC "Include"
     PRIVATE "${BGFX_DIR}/3rdparty"
     PRIVATE "${BGFX_DIR}/examples/common"
     PRIVATE "${BGFX_DIR}/examples/common/nanovg")
@@ -31,7 +32,7 @@ target_link_to_dependencies(Canvas
     PRIVATE bgfx
     PRIVATE bimg
     PRIVATE bx
-    PRIVATE JsRuntime
+    PRIVATE JsRuntimeInternal
     PRIVATE GraphicsDeviceContext
     PRIVATE UrlLib
     PRIVATE napi_extensions)

--- a/Polyfills/Console/CMakeLists.txt
+++ b/Polyfills/Console/CMakeLists.txt
@@ -5,9 +5,11 @@ set(SOURCES
 add_library(Console ${SOURCES})
 warnings_as_errors(Console)
 
-target_include_directories(Console PUBLIC "Include")
+target_include_directories(Console
+    PUBLIC "Include")
 
-target_link_to_dependencies(Console PUBLIC napi)
+target_link_to_dependencies(Console
+    PUBLIC napi)
 
 set_property(TARGET Console PROPERTY FOLDER Polyfills)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Polyfills/Window/CMakeLists.txt
+++ b/Polyfills/Window/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(Window
 target_link_to_dependencies(Window
     PUBLIC napi
     PRIVATE base-n
-    PRIVATE JsRuntime
+    PRIVATE JsRuntimeInternal
     PRIVATE GraphicsDeviceContext)
 
 set_property(TARGET Window PROPERTY FOLDER Polyfills)

--- a/Polyfills/XMLHttpRequest/CMakeLists.txt
+++ b/Polyfills/XMLHttpRequest/CMakeLists.txt
@@ -6,10 +6,12 @@ set(SOURCES
 add_library(XMLHttpRequest ${SOURCES})
 warnings_as_errors(XMLHttpRequest)
 
-target_include_directories(XMLHttpRequest PUBLIC "Include")
+target_include_directories(XMLHttpRequest
+    PUBLIC "Include")
 
 target_link_to_dependencies(XMLHttpRequest
-    PUBLIC JsRuntime
+    PUBLIC napi
+    PRIVATE JsRuntimeInternal
     PRIVATE arcana
     PRIVATE UrlLib)
 


### PR DESCRIPTION
- Separate `JsRuntimeDispatcher` into its own target `JsRuntimeInternal` as it will depend on arcana in a future PR.
- Make the build style more consistent across different CMakeLists.txt