### PR TITLE
Fix ninja build when using gcc or clang

### DIFF
--- a/Dependencies/UrlLib/Source/UrlRequest_Unix.cpp
+++ b/Dependencies/UrlLib/Source/UrlRequest_Unix.cpp
@@ -12,7 +12,9 @@ namespace
     {
         if (code != CURLE_OK)
         {
-            throw std::runtime_error{(std::stringstream{} << "CURL call failed with code (" << code << ")").str()};
+            std::stringstream message;
+            message << "CURL call failed with code (" << code << ")";
+            throw std::runtime_error{message.str()};
         }
     }
 
@@ -20,7 +22,9 @@ namespace
     {
         if (code != CURLUE_OK)
         {
-            throw std::runtime_error{(std::stringstream{} << "CURLU call failed with code (" << code << ")").str()};
+            std::stringstream message;
+            message << "CURLU call failed with code (" << code << ")";
+            throw std::runtime_error{message.str()};
         }
     }
 }


### PR DESCRIPTION
Fixes issue where running ninja after building with either gcc or clang on Ubuntu would throw the following error:

‘class std::basic_ostream<char>’ has no member named ‘str’

Related discussion:
https://stackoverflow.com/questions/59473325/no-member-named-str-in-stdbasic-ostreamchar-with-gcc-and-clang-but-no-p

Tested with
gcc 9.4.0
clang 10.0.0-4ubuntu1