### PR TITLE
ammo/recast init do not depend on document anymore

### DIFF
--- a/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/Playground/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -135,7 +135,6 @@ extern "C"
             });
 
             scriptLoader.emplace(*runtime);
-            scriptLoader->Eval("document = {}", "");
             scriptLoader->LoadScript("app:///Scripts/ammo.js");
             scriptLoader->LoadScript("app:///Scripts/recast.js");
             scriptLoader->LoadScript("app:///Scripts/babylon.max.js");

--- a/Apps/Playground/UWP/App.cpp
+++ b/Apps/Playground/UWP/App.cpp
@@ -407,7 +407,6 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
     });
 
     Babylon::ScriptLoader loader{*m_runtime};
-    loader.Eval("document = {}", "");
     loader.LoadScript("app:///Scripts/ammo.js");
     // Commenting out recast.js for now as v8jsi is incompatible with asm.js.
     // loader.LoadScript("app:///Scripts/recast.js");

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -158,7 +158,6 @@ namespace
         });
 
         Babylon::ScriptLoader loader{*runtime};
-        loader.Eval("document = {}", "");
         loader.LoadScript("app:///Scripts/ammo.js");
         // Commenting out recast.js for now because v8jsi is incompatible with asm.js.
         // loader.LoadScript("app:///Scripts/recast.js");

--- a/Apps/Playground/X11/App.cpp
+++ b/Apps/Playground/X11/App.cpp
@@ -104,7 +104,6 @@ namespace
 
 
         Babylon::ScriptLoader loader{*runtime};
-        loader.Eval("document = {}", "");
         loader.LoadScript(moduleRootUrl + "/Scripts/ammo.js");
         loader.LoadScript(moduleRootUrl + "/Scripts/recast.js");
         loader.LoadScript(moduleRootUrl + "/Scripts/babylon.max.js");

--- a/Apps/Playground/iOS/LibNativeBridge.mm
+++ b/Apps/Playground/iOS/LibNativeBridge.mm
@@ -93,7 +93,6 @@ bool isXrActive{};
     });
 
     Babylon::ScriptLoader loader{ *runtime };
-    loader.Eval("document = {}", "");
     loader.LoadScript("app:///Scripts/ammo.js");
     loader.LoadScript("app:///Scripts/recast.js");
     loader.LoadScript("app:///Scripts/babylon.max.js");

--- a/Apps/Playground/macOS/ViewController.mm
+++ b/Apps/Playground/macOS/ViewController.mm
@@ -132,7 +132,6 @@ Babylon::Plugins::NativeInput* nativeInput{};
     });
 
     Babylon::ScriptLoader loader{ *runtime };
-    loader.Eval("document = {}", "");
     loader.LoadScript("app:///Scripts/ammo.js");
     loader.LoadScript("app:///Scripts/recast.js");
     loader.LoadScript("app:///Scripts/babylon.max.js");

--- a/Apps/ValidationTests/Android/app/src/main/cpp/BabylonNativeJNI.cpp
+++ b/Apps/ValidationTests/Android/app/src/main/cpp/BabylonNativeJNI.cpp
@@ -111,7 +111,6 @@ extern "C"
             });
 
             scriptLoader.emplace(*runtime);
-            scriptLoader->Eval("document = {}", "");
             scriptLoader->LoadScript("app:///Scripts/ammo.js");
             scriptLoader->LoadScript("app:///Scripts/recast.js");
             scriptLoader->LoadScript("app:///Scripts/babylon.max.js");

--- a/Apps/ValidationTests/UWP/App.cpp
+++ b/Apps/ValidationTests/UWP/App.cpp
@@ -245,7 +245,6 @@ void App::RestartRuntime(Windows::Foundation::Rect bounds)
     });
 
     Babylon::ScriptLoader loader{*m_runtime};
-    loader.Eval("document = {}", "");
     loader.LoadScript("app:///Scripts/babylon.max.js");
     loader.LoadScript("app:///Scripts/babylonjs.loaders.js");
     loader.LoadScript("app:///Scripts/babylon.glTF2FileLoader.js");

--- a/Apps/ValidationTests/X11/App.cpp
+++ b/Apps/ValidationTests/X11/App.cpp
@@ -101,7 +101,6 @@ namespace
         });
 
         Babylon::ScriptLoader loader{*runtime};
-        loader.Eval("document = {}", "");
         loader.LoadScript(moduleRootUrl + "/Scripts/babylon.max.js");
         loader.LoadScript(moduleRootUrl + "/Scripts/babylonjs.loaders.js");
         loader.LoadScript(moduleRootUrl + "/Scripts/babylonjs.materials.js");


### PR DESCRIPTION
fixes #793 
Loading ammo/recast does not need document anymore.