### PR TITLE
Fix experience.js typo

### DIFF
--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -125,10 +125,9 @@ CreateBoxAsync(scene).then(function () {
     if (wireframe) {
         var material = new BABYLON.StandardMaterial("wireframe", scene);
         material.wireframe = true;
-        material.pointsCloud = true;
 
         for (var index = 0; index < scene.meshes.length; index++) {
-            scene.meshes[0].material = material;
+            scene.meshes[index].material = material;
         }
     }
 


### PR DESCRIPTION
This is basically a test PR :)

Changed wireframe section to display material's wireframe instead of point cloud. I believe it can only be one or the other, as far as `material.wireframe` and `material.pointcloud` go.

Also changed loop to use `index` instead of `0`. 
