### PR TITLE
Make .png output directory if it doesn't exist

### DIFF
--- a/.github/jobs/win32.yml
+++ b/.github/jobs/win32.yml
@@ -56,8 +56,6 @@ jobs:
     
       - script: |
           cd build${{ variables.solutionName }}\Apps\Playground
-          mkdir Errors
-          mkdir Results
           cd RelWithDebInfo
           Playground app:///Scripts/validation_native.js 
         displayName: 'Validation Tests'

--- a/Plugins/TestUtils/Source/TestUtils.cpp
+++ b/Plugins/TestUtils/Source/TestUtils.cpp
@@ -26,6 +26,8 @@ namespace Babylon::Plugins::Internal
         bx::MemoryBlock mb(&allocator);
         bx::FileWriter writer;
         bx::FilePath filepath(filename.c_str());
+        bx::FilePath filedir(filepath.getPath());
+        bx::makeAll(filedir);
         bx::Error err;
         if (writer.open(filepath, false, &err))
         {


### PR DESCRIPTION
The `TestUtils::WritePNG` function silently fails if the given .png file's directory does not exist. This change creates the directory if it does not exist, yet, so opening the .png for write succeeds.