### PR TITLE
Basic support of MSAA for render targets

### DIFF
--- a/Plugins/ExternalTexture/Source/ExternalTexture_Base.h
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Base.h
@@ -44,6 +44,23 @@ namespace Babylon::Plugins
             return mipLevel == static_cast<uint16_t>(std::floor(std::log2(std::max(static_cast<float>(width), static_cast<float>(height))) + 1));
         }
 
+        static auto RenderTargetSamplesToBgfxMsaaFlag(uint32_t renderTargetSamples)
+        {
+            switch (renderTargetSamples)
+            {
+                case 2:
+                    return BGFX_TEXTURE_RT_MSAA_X2;
+                case 4:
+                    return BGFX_TEXTURE_RT_MSAA_X4;
+                case 8:
+                    return BGFX_TEXTURE_RT_MSAA_X8;
+                case 16:
+                    return BGFX_TEXTURE_RT_MSAA_X16;
+            }
+
+            return BGFX_TEXTURE_NONE;
+        }
+
         void UpdateHandles(uintptr_t ptr)
         {
             std::scoped_lock lock{m_mutex};

--- a/Plugins/ExternalTexture/Source/ExternalTexture_D3D11.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_D3D11.cpp
@@ -189,6 +189,11 @@ namespace Babylon::Plugins
             if ((desc.BindFlags & D3D11_BIND_RENDER_TARGET) != 0)
             {
                 info.Flags |= BGFX_TEXTURE_RT;
+
+                if (desc.SampleDesc.Count > 1)
+                {
+                    info.Flags |= BGFX_TEXTURE_MSAA_SAMPLE | RenderTargetSamplesToBgfxMsaaFlag(desc.SampleDesc.Count);
+                }
             }
 
             for (int i = 0; i < BX_COUNTOF(s_textureFormat); ++i)

--- a/Plugins/ExternalTexture/Source/ExternalTexture_D3D12.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_D3D12.cpp
@@ -183,6 +183,11 @@ namespace Babylon::Plugins
             if ((desc.Flags & D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET) != 0)
             {
                 info.Flags |= BGFX_TEXTURE_RT;
+
+                if (desc.SampleDesc.Count > 1)
+                {
+                    info.Flags |= BGFX_TEXTURE_MSAA_SAMPLE | RenderTargetSamplesToBgfxMsaaFlag(desc.SampleDesc.Count);
+                }
             }
 
             for (int i = 0; i < BX_COUNTOF(s_textureFormat); ++i)

--- a/Plugins/ExternalTexture/Source/ExternalTexture_Metal.mm
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Metal.mm
@@ -136,7 +136,7 @@ namespace Babylon::Plugins
     private:
         void GetInfo(Graphics::TextureT ptr, Info& info)
         {
-            if (ptr.textureType != MTLTextureType2D)
+            if (ptr.textureType != MTLTextureType2D && ptr.textureType != MTLTextureType2DMultisample)
             {
                 throw std::runtime_error{"Unsupported texture type"};
             }
@@ -148,6 +148,11 @@ namespace Babylon::Plugins
             if ((ptr.usage & MTLTextureUsageRenderTarget) != 0)
             {
                 info.Flags |= BGFX_TEXTURE_RT;
+
+                if (ptr.sampleCount > 1)
+                {
+                    info.Flags |= BGFX_TEXTURE_MSAA_SAMPLE | RenderTargetSamplesToBgfxMsaaFlag(ptr.sampleCount);
+                }
             }
 
             const auto pixelFormat = m_ptr.pixelFormat;

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1569,7 +1569,10 @@ namespace Babylon
         }
 
         bgfx::FrameBufferHandle frameBufferHandle = bgfx::createFrameBuffer(numAttachments, attachments.data(), true);
-        assert(bgfx::isValid(frameBufferHandle));
+        if (!bgfx::isValid(frameBufferHandle))
+        {
+            throw Napi::Error::New(info.Env(), "Failed to create frame buffer");
+        }
 
         Graphics::FrameBuffer* frameBuffer = new Graphics::FrameBuffer(m_graphicsContext, frameBufferHandle, width, height, false, generateDepth, generateStencilBuffer);
         return Napi::Pointer<Graphics::FrameBuffer>::Create(info.Env(), frameBuffer, Napi::NapiPointerDeleter(frameBuffer));

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -289,6 +289,23 @@ namespace Babylon
             }
         }
 
+        auto RenderTargetSamplesToBgfxMsaaFlag(uint32_t renderTargetSamples)
+        {
+            switch (renderTargetSamples)
+            {
+                case 2:
+                    return BGFX_TEXTURE_RT_MSAA_X2;
+                case 4:
+                    return BGFX_TEXTURE_RT_MSAA_X4;
+                case 8:
+                    return BGFX_TEXTURE_RT_MSAA_X8;
+                case 16:
+                    return BGFX_TEXTURE_RT_MSAA_X16;
+            }
+
+            return BGFX_TEXTURE_NONE;
+        }
+
         using CommandFunctionPointerT = void (NativeEngine::*)(NativeDataStream::Reader&);
     }
 
@@ -1084,11 +1101,17 @@ namespace Babylon
         const bgfx::TextureFormat::Enum format = static_cast<bgfx::TextureFormat::Enum>(info[4].As<Napi::Number>().Uint32Value());
         const bool renderTarget = info[5].As<Napi::Boolean>();
         const bool srgb = info[6].As<Napi::Boolean>();
+        const uint32_t samples = info[7].IsUndefined() ? 1 : info[7].As<Napi::Number>().Uint32Value();
 
         auto flags = BGFX_TEXTURE_NONE;
         if (renderTarget)
         {
             flags |= BGFX_TEXTURE_RT;
+
+            if (samples > 1)
+            {
+                flags |= BGFX_TEXTURE_MSAA_SAMPLE | RenderTargetSamplesToBgfxMsaaFlag(samples);
+            }
         }
         if (srgb)
         {
@@ -1516,6 +1539,7 @@ namespace Babylon
         const uint16_t height = static_cast<uint16_t>(info[2].As<Napi::Number>().Uint32Value());
         const bool generateStencilBuffer = info[3].As<Napi::Boolean>();
         const bool generateDepth = info[4].As<Napi::Boolean>();
+        const uint32_t samples = info[5].IsUndefined() ? 1 : info[5].As<Napi::Number>().Uint32Value();
 
         std::array<bgfx::Attachment, 2> attachments{};
         uint8_t numAttachments = 0;
@@ -1533,14 +1557,15 @@ namespace Babylon
                 JsConsoleLogger::LogWarn(info.Env(), "Stencil without depth is not supported, assuming depth and stencil");
             }
 
+            auto flags = BGFX_TEXTURE_RT_WRITE_ONLY | RenderTargetSamplesToBgfxMsaaFlag(samples);
             const auto depthStencilFormat{generateStencilBuffer ? bgfx::TextureFormat::D24S8 : bgfx::TextureFormat::D32};
-            assert(bgfx::isTextureValid(0, false, 1, depthStencilFormat, BGFX_TEXTURE_RT));
+            assert(bgfx::isTextureValid(0, false, 1, depthStencilFormat, flags));
 
             // bgfx doesn't add flag D3D11_RESOURCE_MISC_GENERATE_MIPS for depth textures (missing that flag will crash D3D with resolving)
             // And not sure it makes sense to generate mipmaps from a depth buffer with exponential values.
             // only allows mipmaps resolve step when mipmapping is asked and for the color texture, not the depth.
             // https://github.com/bkaradzic/bgfx/blob/2c21f68998595fa388e25cb6527e82254d0e9bff/src/renderer_d3d11.cpp#L4525
-            attachments[numAttachments++].init(bgfx::createTexture2D(width, height, false, 1, depthStencilFormat, BGFX_TEXTURE_RT));
+            attachments[numAttachments++].init(bgfx::createTexture2D(width, height, false, 1, depthStencilFormat, flags));
         }
 
         bgfx::FrameBufferHandle frameBufferHandle = bgfx::createFrameBuffer(numAttachments, attachments.data(), true);


### PR DESCRIPTION
This is the native counter part to https://github.com/BabylonJS/Babylon.js/pull/14055.