### PR TITLE
Fix ExternalTexture_Metal.mm for make BabylonReactNative working on macOS

### DIFF
--- a/Plugins/ExternalTexture/Source/ExternalTexture_Metal.mm
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Metal.mm
@@ -114,7 +114,9 @@ namespace
         { MTLPixelFormatDepth32Float,                   MTLPixelFormatInvalid                       }, // D32F
         { MTLPixelFormatStencil8,                       MTLPixelFormatInvalid                       }, // D0S8
     };
+  #ifndef TARGET_OS_OSX
     BX_STATIC_ASSERT(bgfx::TextureFormat::Count == BX_COUNTOF(s_textureFormat));
+  #endif
 }
 
 // clang-format on


### PR DESCRIPTION
Just added `#ifndef TARGET_OS_OSX` and `#endif`, to able BabylonReactNative to work on macOS.