### PR TITLE
Fix MSAA when using rendering pipelines

### DIFF
--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -8,11 +8,11 @@
       "name": "BabylonNative",
       "version": "0.0.1",
       "dependencies": {
-        "babylonjs": "^6.14.2",
-        "babylonjs-gltf2interface": "^6.14.2",
-        "babylonjs-gui": "^6.14.2",
-        "babylonjs-loaders": "^6.14.2",
-        "babylonjs-materials": "^6.14.2",
+        "babylonjs": "^6.20.2",
+        "babylonjs-gltf2interface": "^6.20.2",
+        "babylonjs-gui": "^6.20.2",
+        "babylonjs-loaders": "^6.20.2",
+        "babylonjs-materials": "^6.20.2",
         "chai": "^4.3.4",
         "jsc-android": "^241213.1.0",
         "mocha": "^9.2.2",
@@ -80,39 +80,39 @@
       }
     },
     "node_modules/babylonjs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-6.14.2.tgz",
-      "integrity": "sha512-yrYf0CqzqAYGLl2ZIe0WPcSGOyMFE3pLwqiNxCB9U6cy2nl+QjyPhH2tgmo/Cm8g+z3YfCNDmYIMj9SI71SGcw==",
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-6.20.2.tgz",
+      "integrity": "sha512-4CGKIDqC01vl3ArFzO2BHzx2f4E5AU0MEPijcSwUMJM004KHs8jrKXvmlceD53IX1TuuHcIHMEqLi4QT9Hx5vg==",
       "hasInstallScript": true
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-6.14.2.tgz",
-      "integrity": "sha512-WL/7ChhtLpF48SynjD0IhUSyHR5AgmQRylQ8wccvtznKqKfR9N+mHaeUt/o/LSrv1TgGHB0KTXiM0rQfDutEbw=="
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-6.20.2.tgz",
+      "integrity": "sha512-ZJrw0iYT6qZz5NiomY19DjNyWEkvEk7EHjpzl294MSPpqbS/U+ai2Wvw31rJ6KIdFRCoCSlAO9uM+KX7W7Suuw=="
     },
     "node_modules/babylonjs-gui": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-6.14.2.tgz",
-      "integrity": "sha512-ubpSIca/XieAoLy7tDfunRU3nWBbGDW/5rHT+U1FWEus2naOpk+Av8y2oNsgmPjWOiOV608HhmXfEtnQqP6cYQ==",
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-6.20.2.tgz",
+      "integrity": "sha512-TeYimyXyLoAifnt4Nc7hJUUKfBD3z9WhKojnpWX6X+yBiIsvyX3UzRxr2vIKOO3x41hUOSCnWaAraSR5EMDr8g==",
       "dependencies": {
-        "babylonjs": "^6.14.2"
+        "babylonjs": "^6.20.2"
       }
     },
     "node_modules/babylonjs-loaders": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-6.14.2.tgz",
-      "integrity": "sha512-NW/M4zszDDlN2yADon8alnRx9xysZISzM/CFrwSqynCWfSwbzqBBIaIx0XhViXl9JLZqKEiMUvJoEd437ggDPQ==",
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-6.20.2.tgz",
+      "integrity": "sha512-G2Tv+UT9DQUiotcNQ5A4DSmWF+TtpZHH/bnUxR1qxZMMYpGCenxx4dxzDT3mMjue7rrR9JwXINcOQrB+qqwRUg==",
       "dependencies": {
-        "babylonjs": "^6.14.2",
-        "babylonjs-gltf2interface": "^6.14.2"
+        "babylonjs": "^6.20.2",
+        "babylonjs-gltf2interface": "^6.20.2"
       }
     },
     "node_modules/babylonjs-materials": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-6.14.2.tgz",
-      "integrity": "sha512-4besJ+IRJq2Xgq84UOe1rjInQkYnY5FN3GH3hVtTv4KMxQfZnlIeuqRvAqhm5EqUY/TKDa14UJKDJJm3t+74hg==",
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-6.20.2.tgz",
+      "integrity": "sha512-rf+eT71gCofpS9OOlXl/cBbZWdhEfmGcv+6aaQWn0dUrYuRmDWQIcxKKg46Oq/9ll5XGqAA7q8ebDtbj0i1tAg==",
       "dependencies": {
-        "babylonjs": "^6.14.2"
+        "babylonjs": "^6.20.2"
       }
     },
     "node_modules/balanced-match": {
@@ -1022,38 +1022,38 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "babylonjs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-6.14.2.tgz",
-      "integrity": "sha512-yrYf0CqzqAYGLl2ZIe0WPcSGOyMFE3pLwqiNxCB9U6cy2nl+QjyPhH2tgmo/Cm8g+z3YfCNDmYIMj9SI71SGcw=="
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-6.20.2.tgz",
+      "integrity": "sha512-4CGKIDqC01vl3ArFzO2BHzx2f4E5AU0MEPijcSwUMJM004KHs8jrKXvmlceD53IX1TuuHcIHMEqLi4QT9Hx5vg=="
     },
     "babylonjs-gltf2interface": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-6.14.2.tgz",
-      "integrity": "sha512-WL/7ChhtLpF48SynjD0IhUSyHR5AgmQRylQ8wccvtznKqKfR9N+mHaeUt/o/LSrv1TgGHB0KTXiM0rQfDutEbw=="
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-6.20.2.tgz",
+      "integrity": "sha512-ZJrw0iYT6qZz5NiomY19DjNyWEkvEk7EHjpzl294MSPpqbS/U+ai2Wvw31rJ6KIdFRCoCSlAO9uM+KX7W7Suuw=="
     },
     "babylonjs-gui": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-6.14.2.tgz",
-      "integrity": "sha512-ubpSIca/XieAoLy7tDfunRU3nWBbGDW/5rHT+U1FWEus2naOpk+Av8y2oNsgmPjWOiOV608HhmXfEtnQqP6cYQ==",
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-6.20.2.tgz",
+      "integrity": "sha512-TeYimyXyLoAifnt4Nc7hJUUKfBD3z9WhKojnpWX6X+yBiIsvyX3UzRxr2vIKOO3x41hUOSCnWaAraSR5EMDr8g==",
       "requires": {
-        "babylonjs": "^6.14.2"
+        "babylonjs": "^6.20.2"
       }
     },
     "babylonjs-loaders": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-6.14.2.tgz",
-      "integrity": "sha512-NW/M4zszDDlN2yADon8alnRx9xysZISzM/CFrwSqynCWfSwbzqBBIaIx0XhViXl9JLZqKEiMUvJoEd437ggDPQ==",
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-6.20.2.tgz",
+      "integrity": "sha512-G2Tv+UT9DQUiotcNQ5A4DSmWF+TtpZHH/bnUxR1qxZMMYpGCenxx4dxzDT3mMjue7rrR9JwXINcOQrB+qqwRUg==",
       "requires": {
-        "babylonjs": "^6.14.2",
-        "babylonjs-gltf2interface": "^6.14.2"
+        "babylonjs": "^6.20.2",
+        "babylonjs-gltf2interface": "^6.20.2"
       }
     },
     "babylonjs-materials": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-6.14.2.tgz",
-      "integrity": "sha512-4besJ+IRJq2Xgq84UOe1rjInQkYnY5FN3GH3hVtTv4KMxQfZnlIeuqRvAqhm5EqUY/TKDa14UJKDJJm3t+74hg==",
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-6.20.2.tgz",
+      "integrity": "sha512-rf+eT71gCofpS9OOlXl/cBbZWdhEfmGcv+6aaQWn0dUrYuRmDWQIcxKKg46Oq/9ll5XGqAA7q8ebDtbj0i1tAg==",
       "requires": {
-        "babylonjs": "^6.14.2"
+        "babylonjs": "^6.20.2"
       }
     },
     "balanced-match": {

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -6,11 +6,11 @@
     "getNightly": "node scripts/getNightly.js"
   },
   "dependencies": {
-    "babylonjs": "^6.14.2",
-    "babylonjs-gltf2interface": "^6.14.2",
-    "babylonjs-gui": "^6.14.2",
-    "babylonjs-loaders": "^6.14.2",
-    "babylonjs-materials": "^6.14.2",
+    "babylonjs": "^6.20.2",
+    "babylonjs-gltf2interface": "^6.20.2",
+    "babylonjs-gui": "^6.20.2",
+    "babylonjs-loaders": "^6.20.2",
+    "babylonjs-materials": "^6.20.2",
     "chai": "^4.3.4",
     "jsc-android": "^241213.1.0",
     "mocha": "^9.2.2",

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1107,12 +1107,7 @@ namespace Babylon
         auto flags = BGFX_TEXTURE_NONE;
         if (renderTarget)
         {
-            flags |= BGFX_TEXTURE_RT;
-
-            if (samples > 1)
-            {
-                flags |= BGFX_TEXTURE_MSAA_SAMPLE | RenderTargetSamplesToBgfxMsaaFlag(samples);
-            }
+            flags |= BGFX_TEXTURE_RT | RenderTargetSamplesToBgfxMsaaFlag(samples);
         }
         if (srgb)
         {


### PR DESCRIPTION
Brings in changes from https://github.com/BabylonJS/Babylon.js/pull/14292 as part of the package version update.

The main fix was a misunderstanding of the `BGFX_TEXTURE_MSAA_SAMPLE` flag in bgfx and how textures are resolved. Thanks to @sebavan for explaining to me how texture resolving works.