### PR TITLE
Set CMake policy CMP0135 to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@ cmake_minimum_required(VERSION 3.18)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Set fetched URL contents to the time of extraction, not the timestamps in the archive.
-cmake_policy(SET CMP0135 NEW)
+if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+endif()
 
 include(FetchContent)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@
 cmake_minimum_required(VERSION 3.18)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+# Set fetched URL contents to the time of extraction, not the timestamps in the archive.
+cmake_policy(SET CMP0135 NEW)
+
 include(FetchContent)
 
 # Modules declaration


### PR DESCRIPTION
Sets fetched URL contents to the time of extraction, not the timestamps in the archive.

This is to prevent the CMake warning occurring due to the recently merged changes that fetch the googletest dependency as a .tar.gz URL.