### PR TITLE
Update Babylon.js to 6.21.2

### DIFF
--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -8,11 +8,11 @@
       "name": "BabylonNative",
       "version": "0.0.1",
       "dependencies": {
-        "babylonjs": "^6.21.1",
-        "babylonjs-gltf2interface": "^6.21.1",
-        "babylonjs-gui": "^6.21.1",
-        "babylonjs-loaders": "^6.21.1",
-        "babylonjs-materials": "^6.21.1",
+        "babylonjs": "^6.21.2",
+        "babylonjs-gltf2interface": "^6.21.2",
+        "babylonjs-gui": "^6.21.2",
+        "babylonjs-loaders": "^6.21.2",
+        "babylonjs-materials": "^6.21.2",
         "chai": "^4.3.4",
         "jsc-android": "^241213.1.0",
         "mocha": "^9.2.2",
@@ -80,39 +80,39 @@
       }
     },
     "node_modules/babylonjs": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-6.21.1.tgz",
-      "integrity": "sha512-uCMzjXIkPf66BwDVPy9JNGIQj7ooIwmJxcsu5SW86GlMLSYenpSjZuz8C1bs6rRltfy+z/fXyAT+roRG7Je89w==",
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-6.21.2.tgz",
+      "integrity": "sha512-1+vdRYpDbmE5SZtGojQS7TXtvIhFayziyzeq/02pg4nOIB5MxGWTIRegXXoU14+l3lNC7sTvBgtai4XWQBrh+A==",
       "hasInstallScript": true
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-6.21.1.tgz",
-      "integrity": "sha512-MYbT3d+17GHjQFGT29WOgxDMQKmer3WYb0o4WNo6gFOcHliE94FKoNeii8jAxrxvcHQI+kaQ6thl+imv4EUphg=="
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-6.21.2.tgz",
+      "integrity": "sha512-468UO8BxAlOqcm/sufbsl3SLefwx5AlVEftxJZUzBJWsB4QbvvbIRI05T3iZqClYx+MQofJ1Z4ZimHaz+3voGw=="
     },
     "node_modules/babylonjs-gui": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-6.21.1.tgz",
-      "integrity": "sha512-gSb1jc59jAtamvqbLmBl9bfHtJm4E/cJ0SEEVpDEjm6AY9Smq/vo724gVgXwVKJABmtwlArSgUrxK4hhjmB2Sw==",
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-6.21.2.tgz",
+      "integrity": "sha512-M6uiXNAIQbl5fU1+Wn7FPSFH5TfR7wI5axtusckwFHVKw79LF99XqlRYNWWAvVzCvTo58m5+8E3soFk8CS1vOw==",
       "dependencies": {
-        "babylonjs": "^6.21.1"
+        "babylonjs": "^6.21.2"
       }
     },
     "node_modules/babylonjs-loaders": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-6.21.1.tgz",
-      "integrity": "sha512-Sl2vx36D2K3Fu1gOt8LaJLLn28dIr6QAuiLbrxpEUAcJFCsogAk7dEv/QOUmaxWKzgzduRoLmUTA2+3Plf+Pqw==",
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-6.21.2.tgz",
+      "integrity": "sha512-cQaesQ/muRic32LhG23Ap65qRzcqXQCUdZhjlndtso+Ox/QkUKudwnEG3F24DshoLIMhfNSYk/4nEg4y9zh9/w==",
       "dependencies": {
-        "babylonjs": "^6.21.1",
-        "babylonjs-gltf2interface": "^6.21.1"
+        "babylonjs": "^6.21.2",
+        "babylonjs-gltf2interface": "^6.21.2"
       }
     },
     "node_modules/babylonjs-materials": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-6.21.1.tgz",
-      "integrity": "sha512-0CgK5LJB4xz+ic7ELCwLZVorLoO1IAl/Cl6gYLJ3QaaIK5zAPig5oO0gRp9yOihucw1c+m8EUFl7OpMDY6uPSA==",
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-6.21.2.tgz",
+      "integrity": "sha512-ICmkVL9Yft6hbiWcEj7yTCGJ7KC/jNd422KuzethngcQutiu68JGh/Z9qBCqz+RoZEh3pxWc1TsRjScASJYELg==",
       "dependencies": {
-        "babylonjs": "^6.21.1"
+        "babylonjs": "^6.21.2"
       }
     },
     "node_modules/balanced-match": {
@@ -1022,38 +1022,38 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "babylonjs": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-6.21.1.tgz",
-      "integrity": "sha512-uCMzjXIkPf66BwDVPy9JNGIQj7ooIwmJxcsu5SW86GlMLSYenpSjZuz8C1bs6rRltfy+z/fXyAT+roRG7Je89w=="
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-6.21.2.tgz",
+      "integrity": "sha512-1+vdRYpDbmE5SZtGojQS7TXtvIhFayziyzeq/02pg4nOIB5MxGWTIRegXXoU14+l3lNC7sTvBgtai4XWQBrh+A=="
     },
     "babylonjs-gltf2interface": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-6.21.1.tgz",
-      "integrity": "sha512-MYbT3d+17GHjQFGT29WOgxDMQKmer3WYb0o4WNo6gFOcHliE94FKoNeii8jAxrxvcHQI+kaQ6thl+imv4EUphg=="
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-6.21.2.tgz",
+      "integrity": "sha512-468UO8BxAlOqcm/sufbsl3SLefwx5AlVEftxJZUzBJWsB4QbvvbIRI05T3iZqClYx+MQofJ1Z4ZimHaz+3voGw=="
     },
     "babylonjs-gui": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-6.21.1.tgz",
-      "integrity": "sha512-gSb1jc59jAtamvqbLmBl9bfHtJm4E/cJ0SEEVpDEjm6AY9Smq/vo724gVgXwVKJABmtwlArSgUrxK4hhjmB2Sw==",
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-6.21.2.tgz",
+      "integrity": "sha512-M6uiXNAIQbl5fU1+Wn7FPSFH5TfR7wI5axtusckwFHVKw79LF99XqlRYNWWAvVzCvTo58m5+8E3soFk8CS1vOw==",
       "requires": {
-        "babylonjs": "^6.21.1"
+        "babylonjs": "^6.21.2"
       }
     },
     "babylonjs-loaders": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-6.21.1.tgz",
-      "integrity": "sha512-Sl2vx36D2K3Fu1gOt8LaJLLn28dIr6QAuiLbrxpEUAcJFCsogAk7dEv/QOUmaxWKzgzduRoLmUTA2+3Plf+Pqw==",
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-6.21.2.tgz",
+      "integrity": "sha512-cQaesQ/muRic32LhG23Ap65qRzcqXQCUdZhjlndtso+Ox/QkUKudwnEG3F24DshoLIMhfNSYk/4nEg4y9zh9/w==",
       "requires": {
-        "babylonjs": "^6.21.1",
-        "babylonjs-gltf2interface": "^6.21.1"
+        "babylonjs": "^6.21.2",
+        "babylonjs-gltf2interface": "^6.21.2"
       }
     },
     "babylonjs-materials": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-6.21.1.tgz",
-      "integrity": "sha512-0CgK5LJB4xz+ic7ELCwLZVorLoO1IAl/Cl6gYLJ3QaaIK5zAPig5oO0gRp9yOihucw1c+m8EUFl7OpMDY6uPSA==",
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-6.21.2.tgz",
+      "integrity": "sha512-ICmkVL9Yft6hbiWcEj7yTCGJ7KC/jNd422KuzethngcQutiu68JGh/Z9qBCqz+RoZEh3pxWc1TsRjScASJYELg==",
       "requires": {
-        "babylonjs": "^6.21.1"
+        "babylonjs": "^6.21.2"
       }
     },
     "balanced-match": {

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -6,11 +6,11 @@
     "getNightly": "node scripts/getNightly.js"
   },
   "dependencies": {
-    "babylonjs": "^6.21.1",
-    "babylonjs-gltf2interface": "^6.21.1",
-    "babylonjs-gui": "^6.21.1",
-    "babylonjs-loaders": "^6.21.1",
-    "babylonjs-materials": "^6.21.1",
+    "babylonjs": "^6.21.2",
+    "babylonjs-gltf2interface": "^6.21.2",
+    "babylonjs-gui": "^6.21.2",
+    "babylonjs-loaders": "^6.21.2",
+    "babylonjs-materials": "^6.21.2",
     "chai": "^4.3.4",
     "jsc-android": "^241213.1.0",
     "mocha": "^9.2.2",


### PR DESCRIPTION
This PR will update the version of Babylon.js used to 6.21.2.  The purpose for this is to address the following bugs:
- https://github.com/BabylonJS/BabylonNative/issues/1222
- https://github.com/BabylonJS/BabylonNative/issues/1223