### PR TITLE
Update to latest JsRuntimeHost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ FetchContent_Declare(ios-cmake
     GIT_TAG 04d91f6675dabb3c97df346a32f6184b0a7ef845)
 FetchContent_Declare(JsRuntimeHost
     GIT_REPOSITORY https://github.com/BabylonJS/JsRuntimeHost.git
-    GIT_TAG 5fefa63d9af36df062ef7cb275ce97cac506057e)
+    GIT_TAG b3d4f2cb8c86fb55dc4e8ae78ba5f5a98a5be6ba)
 FetchContent_Declare(AndroidExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/AndroidExtensions.git
     GIT_TAG 883c4a286116e51ee989e39ee8e216d632997329)


### PR DESCRIPTION
This brings in a small change that prevents an object copy due to a situation that prevents RVO (more details in the JsRuntimeHost PR for the commit): https://github.com/BabylonJS/JsRuntimeHost/commit/b3d4f2cb8c86fb55dc4e8ae78ba5f5a98a5be6ba