### PR TITLE
Remove Android xr double render

### DIFF
--- a/Apps/Playground/Android/gradle.properties
+++ b/Apps/Playground/Android/gradle.properties
@@ -11,3 +11,4 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+# jsEngine=JavaScriptCore

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -213,7 +213,7 @@ used by default if no engine is specified. To change the engine to JavaScriptCor
 the file `Apps\Playground\Android\gradle.properties` and add the following line:
 
 ```
-JSEngine=jsc
+jsEngine=JavaScriptCore
 ```
 
 Once the npm packages are installed, open the project located at

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ FetchContent_Declare(ios-cmake
     GIT_TAG 04d91f6675dabb3c97df346a32f6184b0a7ef845)
 FetchContent_Declare(JsRuntimeHost
     GIT_REPOSITORY https://github.com/BabylonJS/JsRuntimeHost.git
-    GIT_TAG 5fefa63d9af36df062ef7cb275ce97cac506057e)
+    GIT_TAG b3d4f2cb8c86fb55dc4e8ae78ba5f5a98a5be6ba)
 FetchContent_Declare(AndroidExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/AndroidExtensions.git
     GIT_TAG 883c4a286116e51ee989e39ee8e216d632997329)

--- a/Dependencies/xr/Source/ARCore/XR.cpp
+++ b/Dependencies/xr/Source/ARCore/XR.cpp
@@ -631,11 +631,6 @@ namespace xr
 
                 // Draw the quad
                 glDrawArrays(GL_TRIANGLE_STRIP, 0, VERTEX_COUNT);
-
-                // Present to the screen
-                // NOTE: For a yet to be determined reason, bgfx is also doing an eglSwapBuffers when running in the regular Android Babylon Native Playground playground app.
-                //       The "double" eglSwapBuffers causes rendering issues, so until we figure out this issue, comment out this line while testing in the regular playground app.
-                eglSwapBuffers(eglGetCurrentDisplay(), eglGetCurrentSurface(EGL_DRAW));
             }
         }
 


### PR DESCRIPTION
This code has been in the Android XR implementation forever, and was never understood. It did an explicit eglSwapBuffers to present to the screen, which was needed in Babylon React Native as somehow the bgfx rendering path was different between the two. Now, even in BRN this results in double rendering. Maybe this is a result of one of the bgfx updates. Since it seems to no longer be needed in any scenario, this PR removes it. Unfortunately XR on Android in the BN Playground is broken in a different way currently, so I have not been able to verify this works correctly in that scenario. But previously this code was incorrect in BN anyway, so I expect this is correct now in both BN and BRN.