### PR TITLE
External texture fixes for Apple

### DIFF
--- a/Plugins/ExternalTexture/Source/ExternalTexture_Base.h
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Base.h
@@ -81,16 +81,6 @@ namespace Babylon::Plugins
             uint16_t MipLevels{};
             bgfx::TextureFormat::Enum Format{bgfx::TextureFormat::Unknown};
             uint64_t Flags{};
-
-            bool operator==(const Info& other)
-            {
-                return Width == other.Width && Height == other.Height && MipLevels == other.MipLevels && Format == other.Format && Flags == other.Flags;
-            }
-
-            bool operator!=(const Info& other)
-            {
-                return !operator==(other);
-            }
         };
 
         Info m_info{};

--- a/Plugins/ExternalTexture/Source/ExternalTexture_D3D11.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_D3D11.cpp
@@ -167,7 +167,7 @@ namespace Babylon::Plugins
         }
 
     private:
-        void GetInfo(Graphics::TextureT ptr, Info& info)
+        static void GetInfo(Graphics::TextureT ptr, Info& info)
         {
             winrt::com_ptr<ID3D11Resource> resource;
             resource.copy_from(ptr);

--- a/Plugins/ExternalTexture/Source/ExternalTexture_D3D12.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_D3D12.cpp
@@ -167,7 +167,7 @@ namespace Babylon::Plugins
         }
 
     private:
-        void GetInfo(Graphics::TextureT ptr, Info& info)
+        static void GetInfo(Graphics::TextureT ptr, Info& info)
         {
             D3D12_RESOURCE_DESC desc = ptr->GetDesc();
 

--- a/Plugins/ExternalTexture/Source/ExternalTexture_Metal.mm
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Metal.mm
@@ -153,7 +153,7 @@ namespace Babylon::Plugins
         }
 
     private:
-        void GetInfo(Graphics::TextureT ptr, Info& info)
+        static void GetInfo(Graphics::TextureT ptr, Info& info)
         {
             if (ptr.textureType != MTLTextureType2D && ptr.textureType != MTLTextureType2DMultisample)
             {
@@ -174,7 +174,7 @@ namespace Babylon::Plugins
                 }
             }
 
-            const auto pixelFormat = m_ptr.pixelFormat;
+            const auto pixelFormat = ptr.pixelFormat;
             for (size_t i = 0; i < BX_COUNTOF(s_textureFormat); ++i)
             {
                 const auto& format = s_textureFormat[i];

--- a/Plugins/ExternalTexture/Source/ExternalTexture_Shared.h
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Shared.h
@@ -18,12 +18,17 @@ namespace Babylon::Plugins
     {
         Info info;
         GetInfo(ptr, info);
-        if (info != m_info)
+
+        if (info.Width != m_info.Width || info.Height != m_info.Height || info.MipLevels != m_info.MipLevels)
         {
-            throw std::runtime_error{"Textures must have same info"};
+            throw std::runtime_error{"Textures must have same width, height, and mip levels"};
         }
 
+        m_info = info;
+
         Assign(ptr);
+
+        UpdateHandles(Ptr());
     }
 
     ExternalTexture::ExternalTexture(Graphics::TextureT ptr)


### PR DESCRIPTION
- Change `GetInfo` to static to avoid accidentally using class members
- Change `Update` function to only compare width and height and add missing assignment of `m_info` and `UpdateHandles` call