### PR TITLE
Added configuration to enable/disable async shader compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ project(BabylonNative)
 # --------------------------------------------------
 option(BABYLON_NATIVE_BUILD_APPS "Build Babylon Native apps." ${PROJECT_IS_TOP_LEVEL})
 option(BABYLON_NATIVE_INSTALL "Include the install target." ${PROJECT_IS_TOP_LEVEL})
+option(BABYLON_NATIVE_ASYNC_SHADER_COMPILATION "Enables async shader compilation in Babylon Native" ON)
 
 ## Plugins
 option(BABYLON_NATIVE_PLUGIN_EXTERNALTEXTURE "Include Babylon Native Plugin ExternalTexture." ON)

--- a/Plugins/NativeEngine/CMakeLists.txt
+++ b/Plugins/NativeEngine/CMakeLists.txt
@@ -68,5 +68,9 @@ target_compile_definitions(NativeEngine
 target_compile_definitions(NativeEngine
     PRIVATE $<UPPER_CASE:${GRAPHICS_API}>)
 
+if(BABYLON_NATIVE_ASYNC_SHADER_COMPILATION)
+    target_compile_definitions(NativeEngine PRIVATE BABYLON_ASYNC_SHADER_COMPILATION)
+endif()
+
 set_property(TARGET NativeEngine PROPERTY FOLDER Plugins)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -570,7 +570,9 @@ namespace Babylon
                 InstanceMethod("updateDynamicVertexBuffer", &NativeEngine::UpdateDynamicVertexBuffer),
 
                 InstanceMethod("createProgram", &NativeEngine::CreateProgram),
+#ifdef BABYLON_ASYNC_SHADER_COMPILATION
                 InstanceMethod("createProgramAsync", &NativeEngine::CreateProgramAsync),
+#endif
                 InstanceMethod("getUniforms", &NativeEngine::GetUniforms),
                 InstanceMethod("getAttributes", &NativeEngine::GetAttributes),
 


### PR DESCRIPTION
Added a CMake variable that can control if async shader compilation will be used. Async shader compilation might be helpfull to be turned off when debugging shader related code or when performing validation tests in Debug mode. 