### PR TITLE
fix npm install for android app

### DIFF
--- a/Apps/Playground/Android/app/build.gradle
+++ b/Apps/Playground/Android/app/build.gradle
@@ -42,7 +42,8 @@ android {
                     "-DGRAPHICS_API=${graphics_api}",
                     "-DARCORE_LIBPATH=${arcore_libpath}/jni",
                     "-DNAPI_JAVASCRIPT_ENGINE=${jsEngine}",
-                    "-DJSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR=ON"
+                    "-DJSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR=ON",
+                    "-DBABYLON_NATIVE_BUILD_APPS=ON",
                     "-DCMAKE_UNITY_BUILD=${unity_build}"
             }
         }

--- a/Apps/UnitTests/Android/app/build.gradle
+++ b/Apps/UnitTests/Android/app/build.gradle
@@ -29,7 +29,7 @@ android {
                     "-DANDROID_STL=c++_shared",
                     "-DNAPI_JAVASCRIPT_ENGINE=${jsEngine}",
                     "-DJSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR=ON",
-                    "-DBABYLON_NATIVE_BUILD_APPS=ON",
+                    "-DBABYLON_NATIVE_BUILD_APPS=ON"
                 )
             }
         }

--- a/Apps/UnitTests/Android/app/build.gradle
+++ b/Apps/UnitTests/Android/app/build.gradle
@@ -29,6 +29,7 @@ android {
                     "-DANDROID_STL=c++_shared",
                     "-DNAPI_JAVASCRIPT_ENGINE=${jsEngine}",
                     "-DJSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR=ON",
+                    "-DBABYLON_NATIVE_BUILD_APPS=ON",
                 )
             }
         }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ if(DEFINED EXTENSIONS_DIRS)
     endforeach()
 endif()
 
-if(BABYLON_NATIVE_BUILD_APPS)
+if(BABYLON_NATIVE_BUILD_APPS OR ANDROID)
     add_subdirectory(Apps)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ if(DEFINED EXTENSIONS_DIRS)
     endforeach()
 endif()
 
-if(BABYLON_NATIVE_BUILD_APPS OR ANDROID)
+if(BABYLON_NATIVE_BUILD_APPS)
     add_subdirectory(Apps)
 endif()
 


### PR DESCRIPTION
follow up https://forum.babylonjs.com/t/build-failed-on-windows-for-android-apk/45026/7
npm install was not called on Android because `PROJECT_IS_TOP_LEVEL` is false is Apps cmake is only evaluated when true.
Fixed by forcing Apps folder evaluation on Android.