### PR TITLE
Update ios-cmake to 4.4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ FetchContent_Declare(cmake-extensions
     GIT_TAG efe7101be5e04391b9e55f68a01d534f54d3026e)
 FetchContent_Declare(ios-cmake
     GIT_REPOSITORY https://github.com/leetal/ios-cmake.git
-    GIT_TAG 04d91f6675dabb3c97df346a32f6184b0a7ef845)
+    GIT_TAG 4.4.1)
 FetchContent_Declare(arcana
     GIT_REPOSITORY https://github.com/microsoft/arcana.cpp.git
     GIT_TAG f2757396e80bc4169f2ddb938ce25367a98ffdd0)


### PR DESCRIPTION
This resolves an issue with building for iOS Simulator on Apple Silicon.