### PR TITLE
Changed thread affinity checks to be optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ project(BabylonNative)
 option(BABYLON_NATIVE_BUILD_APPS "Build Babylon Native apps." ${PROJECT_IS_TOP_LEVEL})
 option(BABYLON_NATIVE_INSTALL "Include the install target." ${PROJECT_IS_TOP_LEVEL})
 
-# WARNING: This is an experimental features. Only used it if you can ensure that you application will properly handle thread affinity. 
+# WARNING: This is experimental. Only use it if you can ensure that your application will properly handle thread affinity.
 option(BABYLON_NATIVE_CHECK_THREAD_AFFINITY "Checks thread safety in the graphics device calls. It can be removed if hosting application ensures thread coherence." ON)
 
 ## Plugins

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,8 @@ project(BabylonNative)
 # --------------------------------------------------
 option(BABYLON_NATIVE_BUILD_APPS "Build Babylon Native apps." ${PROJECT_IS_TOP_LEVEL})
 option(BABYLON_NATIVE_INSTALL "Include the install target." ${PROJECT_IS_TOP_LEVEL})
+
+# WARNING: This is an experimental features. Only used it if you can ensure that you application will properly handle thread affinity. 
 option(BABYLON_NATIVE_CHECK_THREAD_AFFINITY "Checks thread safety in the graphics device calls. It can be removed if hosting application ensures thread coherence." ON)
 
 ## Plugins

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ project(BabylonNative)
 # --------------------------------------------------
 option(BABYLON_NATIVE_BUILD_APPS "Build Babylon Native apps." ${PROJECT_IS_TOP_LEVEL})
 option(BABYLON_NATIVE_INSTALL "Include the install target." ${PROJECT_IS_TOP_LEVEL})
+option(BABYLON_NATIVE_CHECK_THREAD_AFFINITY "Checks thread safety in the graphics device calls. It can be removed if hosting application ensures thread coherence." ON)
 
 ## Plugins
 option(BABYLON_NATIVE_PLUGIN_EXTERNALTEXTURE "Include Babylon Native Plugin ExternalTexture." ON)

--- a/Core/Graphics/CMakeLists.txt
+++ b/Core/Graphics/CMakeLists.txt
@@ -87,3 +87,7 @@ target_link_libraries(GraphicsDeviceContext
 
 target_compile_definitions(GraphicsDeviceContext
     INTERFACE NOMINMAX)
+
+if(BABYLON_NATIVE_CHECK_THREAD_AFFINITY)
+    target_compile_definitions(Graphics PRIVATE BABYLON_NATIVE_CHECK_THREAD_AFFINITY=1)
+endif()

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -10,6 +10,12 @@
 #include <TargetConditionals.h>
 #endif
 
+#ifdef BABYLON_NATIVE_CHECK_THREAD_AFFINITY
+#define ASSERT_THREAD_AFFINITY(affinity) assert(affinity.check())
+#else
+#define ASSERT_THREAD_AFFINITY(affinity)
+#endif
+
 namespace
 {
     constexpr auto JS_GRAPHICS_NAME = "_Graphics";
@@ -155,7 +161,7 @@ namespace Babylon::Graphics
 
     void DeviceImpl::DisableRendering()
     {
-        assert(m_renderThreadAffinity.check());
+        ASSERT_THREAD_AFFINITY(m_renderThreadAffinity.check());
 
         std::scoped_lock lock{m_state.Mutex};
 
@@ -197,7 +203,7 @@ namespace Babylon::Graphics
 
     void DeviceImpl::SetDiagnosticOutput(std::function<void(const char* output)> diagnosticOutput)
     {
-        assert(m_renderThreadAffinity.check());
+        ASSERT_THREAD_AFFINITY(m_renderThreadAffinity.check());
         m_bgfxCallback.SetDiagnosticOutput(std::move(diagnosticOutput));
     }
 
@@ -205,7 +211,7 @@ namespace Babylon::Graphics
     {
         arcana::trace_region startRenderingRegion{"DeviceImpl::StartRenderingCurrentFrame"};
 
-        assert(m_renderThreadAffinity.check());
+        ASSERT_THREAD_AFFINITY(m_renderThreadAffinity.check());
 
         if (m_rendering)
         {
@@ -243,7 +249,7 @@ namespace Babylon::Graphics
 
         arcana::trace_region finishRenderingRegion{"DeviceImpl::FinishRenderingCurrentFrame"};
 
-        assert(m_renderThreadAffinity.check());
+        ASSERT_THREAD_AFFINITY(m_renderThreadAffinity.check());
 
         if (!m_rendering)
         {


### PR DESCRIPTION
In some integrations the application might want to call graphics call from multiple threads. This PR adds the possibility of making thread affinity checks configurable by CMake. 