### PR TITLE
flipping happens after rendering

### DIFF
--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -32,7 +32,7 @@ namespace Babylon::Graphics
 
         auto& init = m_state.Bgfx.InitState;
         init.type = s_bgfxRenderType;
-        init.resolution.reset = BGFX_RESET_VSYNC | BGFX_RESET_MAXANISOTROPY | BGFX_RESET_FLIP_AFTER_RENDER | BGFX_RESET_FLUSH_AFTER_RENDER;
+        init.resolution.reset = BGFX_RESET_VSYNC | BGFX_RESET_MAXANISOTROPY | BGFX_RESET_FLIP_AFTER_RENDER;
         init.resolution.maxFrameLatency = 1;
 
         init.callback = &m_bgfxCallback;

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -32,12 +32,8 @@ namespace Babylon::Graphics
 
         auto& init = m_state.Bgfx.InitState;
         init.type = s_bgfxRenderType;
-        init.resolution.reset = BGFX_RESET_VSYNC | BGFX_RESET_MAXANISOTROPY;
+        init.resolution.reset = BGFX_RESET_VSYNC | BGFX_RESET_MAXANISOTROPY | BGFX_RESET_FLIP_AFTER_RENDER | BGFX_RESET_FLUSH_AFTER_RENDER;
         init.resolution.maxFrameLatency = 1;
-        if (s_bgfxFlipAfterRender)
-        {
-            init.resolution.reset |= BGFX_RESET_FLIP_AFTER_RENDER;
-        }
 
         init.callback = &m_bgfxCallback;
 

--- a/Core/Graphics/Source/DeviceImpl.h
+++ b/Core/Graphics/Source/DeviceImpl.h
@@ -98,7 +98,6 @@ namespace Babylon::Graphics
     private:
         friend class UpdateToken;
 
-        static const bool s_bgfxFlipAfterRender;
         static const bgfx::RendererType::Enum s_bgfxRenderType;
         static void ConfigureBgfxPlatformData(bgfx::PlatformData& pd, WindowT window);
         static void ConfigureBgfxRenderType(bgfx::PlatformData& pd, bgfx::RendererType::Enum& renderType);

--- a/Core/Graphics/Source/DeviceImpl_Android.cpp
+++ b/Core/Graphics/Source/DeviceImpl_Android.cpp
@@ -6,8 +6,6 @@
 
 namespace Babylon::Graphics
 {
-    const bool DeviceImpl::s_bgfxFlipAfterRender = false;
-
     void DeviceImpl::ConfigureBgfxPlatformData(bgfx::PlatformData& pd, WindowT window)
     {
         pd.nwh = window;

--- a/Core/Graphics/Source/DeviceImpl_Unix.cpp
+++ b/Core/Graphics/Source/DeviceImpl_Unix.cpp
@@ -3,8 +3,6 @@
 
 namespace Babylon::Graphics
 {
-    const bool DeviceImpl::s_bgfxFlipAfterRender = false;
-
     void DeviceImpl::ConfigureBgfxPlatformData(bgfx::PlatformData& pd, WindowT window)
     {
         pd.nwh = reinterpret_cast<void*>(window);

--- a/Core/Graphics/Source/DeviceImpl_Win32.cpp
+++ b/Core/Graphics/Source/DeviceImpl_Win32.cpp
@@ -4,8 +4,6 @@
 
 namespace Babylon::Graphics
 {
-    const bool DeviceImpl::s_bgfxFlipAfterRender = false;
-
     void DeviceImpl::ConfigureBgfxPlatformData(bgfx::PlatformData& pd, WindowT window)
     {
         pd.nwh = window;

--- a/Core/Graphics/Source/DeviceImpl_WinRT.cpp
+++ b/Core/Graphics/Source/DeviceImpl_WinRT.cpp
@@ -7,8 +7,6 @@
 
 namespace Babylon::Graphics
 {
-    const bool DeviceImpl::s_bgfxFlipAfterRender = false;
-
     void DeviceImpl::ConfigureBgfxPlatformData(bgfx::PlatformData& pd, WindowT window)
     {
         // Assume window is a xaml swap chain panel if not a core window.

--- a/Core/Graphics/Source/DeviceImpl_iOS.mm
+++ b/Core/Graphics/Source/DeviceImpl_iOS.mm
@@ -3,8 +3,6 @@
 
 namespace Babylon::Graphics
 {
-    const bool DeviceImpl::s_bgfxFlipAfterRender = true;
-
     void DeviceImpl::ConfigureBgfxPlatformData(bgfx::PlatformData& pd, WindowT window)
     {
         pd.nwh = window;

--- a/Core/Graphics/Source/DeviceImpl_macOS.mm
+++ b/Core/Graphics/Source/DeviceImpl_macOS.mm
@@ -3,8 +3,6 @@
 
 namespace Babylon::Graphics
 {
-    const bool DeviceImpl::s_bgfxFlipAfterRender = true;
-
     void DeviceImpl::ConfigureBgfxPlatformData(bgfx::PlatformData& pd, WindowT window)
     {
         pd.nwh = window;


### PR DESCRIPTION
bgfx default is to do page flip before rendering a new frame. So, rendering 1 frame is not enough to see rendering on screen.
This 1 frame latency was visible on Apple and fixed with this PR:
https://github.com/BabylonJS/BabylonNative/pull/525
Unfortunately, the issue has been reported on Windows as well. With this PR, flipping will always be after rendering.
Related posts: 
https://github.com/bkaradzic/bgfx/issues/339
