### PR TITLE
Reuse current surface config

### DIFF
--- a/Apps/Playground/Android/app/build.gradle
+++ b/Apps/Playground/Android/app/build.gradle
@@ -63,6 +63,7 @@ android {
             signingConfig signingConfigs.debug
             minifyEnabled true
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            debuggable true
         }
     }
 

--- a/Apps/Playground/Android/build.gradle
+++ b/Apps/Playground/Android/build.gradle
@@ -5,7 +5,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
@@ -19,6 +18,5 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ FetchContent_Declare(JsRuntimeHost
     GIT_TAG 0b1e30c6db15adeb86a81c95cc9bd8ff42e30f2b)
 FetchContent_Declare(AndroidExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/AndroidExtensions.git
-    GIT_TAG 1a47db416ec2aae3f51b28b94f73e8f54e412d0d)
+    GIT_TAG 7fd1d3dadacc3f7d85b24bd6783f492cb5fb09b9)
 FetchContent_Declare(googletest
     URL "https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz")
 FetchContent_Declare(base-n


### PR DESCRIPTION
On some Android devices, XR in the BRN Playground flickers. It turns out this is because:
1. On some (or all?) devices, if eglMakeCurrent is called with an egl surface that was created with a different egl config than a surface previously made current in the given context, it will fail.
2. In xr.cpp, we manually construct an egl config for the XR surface.
3. When we setup the attributes used to choose an egl config, we do not specify an msaa attribute (we ignore msaa).
4. The BRN Playground sets msaa to 2.
5. BGFX chooses an egl config with the msaa=2 attribute.
6. xr.cpp chooses a different config.
7. The eglMakeCurrent call fails.
8. The OpenGLHelpers MakeCurrent function ignores error codes from eglMakeCurrent.
9. That silent failure leads to xr rendering to the same surface as the main Babylon Native rendering being done by bgfx.
10. It flickers because two things per frame are rendering to the same surface.

So the changes here are:
1. Update to a newer AndroidExtensions commit that includes a change to check for errors from eglMakeCurrent (to make this kind of thing easier to diagnose in the future).
2. Update xr.cpp to just query the config of the current surface and use the same one. BGFX will have been initialized by the time we get to this code, and bgfx initialization includes creating the surface and making it current.

Couple small unrelated changes:
1. I also removed jCenter from the gradle files since it is deprecated and there was a warning.
2. I made the release build variant debuggable.