### PR TITLE
Fix flash and image orientation for iOS image capture

### DIFF
--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -81,6 +81,7 @@ CreateBoxAsync(scene).then(function () {
 
         scene.meshes[0].setEnabled(false);
         var plane = BABYLON.MeshBuilder.CreatePlane("plane", {size: 1, sideOrientation: BABYLON.Mesh.DOUBLESIDE});
+        // Mirror the plane vertically since invertY is not supported for textures in Babylon Native.
         plane.rotation.y = Math.PI;
         plane.rotation.z = Math.PI;
 
@@ -105,13 +106,17 @@ CreateBoxAsync(scene).then(function () {
                     const imageCapture = new ImageCapture(stream.getVideoTracks()[0]);
                     console.log(`Capabilities: ${JSON.stringify(imageCapture.getPhotoCapabilities(), null, 2)}`);
                     console.log(`Settings: ${JSON.stringify(imageCapture.getPhotoSettings(), null, 2)}`);
-                    imageCapture.takePhoto({fillLightMode: "off"}).then((blob) => {
+                    imageCapture.takePhoto({fillLightMode: "flash"}).then((blob) => {
                         console.log(`takePhoto finished with a blob of size ${blob.size} and type '${blob.type}'`);
                         blob.arrayBuffer().then((buffer) => {
                             const imageData = new Uint8Array(buffer);
                             console.log(`Retrieved photo ArrayBuffer of size ${imageData.byteLength}`);
                             console.log(`JPEG header bytes should be 0xff, 0xd8, 0xff.`);
                             console.log(`Header bytes are 0x${imageData[0].toString(16)}, 0x${imageData[1].toString(16)}, 0x${imageData[2].toString(16)}`);
+
+                            // Un-mirror the plane since the photo is not mirrored (this matches WebAPI behavior).
+                            plane.rotation.y = 0;
+                            plane.rotation.z = 0;
 
                             const imageTexture = new BABYLON.Texture("data:fromblob", scene, true, undefined, undefined, undefined, undefined, imageData);
                             mat.emissiveTexture = imageTexture;

--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -105,7 +105,7 @@ CreateBoxAsync(scene).then(function () {
                     const imageCapture = new ImageCapture(stream.getVideoTracks()[0]);
                     console.log(`Capabilities: ${JSON.stringify(imageCapture.getPhotoCapabilities(), null, 2)}`);
                     console.log(`Settings: ${JSON.stringify(imageCapture.getPhotoSettings(), null, 2)}`);
-                    imageCapture.takePhoto().then((blob) => {
+                    imageCapture.takePhoto({fillLightMode: "off"}).then((blob) => {
                         console.log(`takePhoto finished with a blob of size ${blob.size} and type '${blob.type}'`);
                         blob.arrayBuffer().then((buffer) => {
                             const imageData = new Uint8Array(buffer);

--- a/Apps/Playground/iOS/Info.plist
+++ b/Apps/Playground/iOS/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>NSCameraUsageDescription</key>
 	<string>Need camera permission for XR</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Need photo library permission for debug code to save photo captures</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -33,6 +35,7 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>

--- a/Plugins/NativeCamera/Source/Apple/CameraDevice.mm
+++ b/Plugins/NativeCamera/Source/Apple/CameraDevice.mm
@@ -3,7 +3,6 @@
 #endif
 
 #import <MetalKit/MetalKit.h>
-//#import <Photos/Photos.h>
 #include <napi/napi.h>
 #include <bgfx/bgfx.h>
 #include <bgfx/platform.h>
@@ -1001,7 +1000,7 @@ namespace Babylon::Plugins
 
         // Saving the photo to storage can be helpful for testing and diagnosing any photo issues. To do so:
         // 1. In the Playground target, go to Build Phases, scroll down to Link Binary with Libraries, and add Photos.framework
-        // 2. Uncomment #import <Photos/Photos.h> at the top of this file
+        // 2. Add #import <Photos/Photos.h> at the top of this file
         // 3. Uncomment the block below
         /*
         [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{

--- a/Plugins/NativeCamera/Source/ImageCapture.cpp
+++ b/Plugins/NativeCamera/Source/ImageCapture.cpp
@@ -39,6 +39,7 @@ namespace Babylon::Plugins::Internal
             for (FillLightMode fillLightMode : fillLightModes)
             {
                 arrayJS.Set(index, FillLightModeToString(fillLightMode));
+                index++;
             }
 
             return arrayJS;


### PR DESCRIPTION
`ImageCapture` was implemented for iOS a while back, but had a few outstanding bugs that are addressed in this PR:
1. Flash modes were not working - there were actually two bugs here, the first being that we were trying to get supported flash modes from the `AVPhotoCaptureOutput` before we actually created the `AVPhotoCaptureOutput` (oops), and second there was a missing line to increment the current index when populating the flash modes array.
2. There was no code to deal with image rotation, so the created image was always sideways (I believe based on the orientation of the physical camera sensor relative to the orientation of the device).

So the changes here are to fix the issues of bullet 1 and add code for bullet 2.

I also made some small changes to experience.js to reflect the missing support for invertY on Textures in BN which otherwise makes it confusing why the code is the way it is.

EDIT: Regarding image rotation, I realized my fix for this was not really correct. What actually happens with ImageCapture in the browser (at least in Chrome on Android), which is similar to what camera apps typically do, is that the image data itself is not rotated when the photo is taken. Rather, it just includes correct Orientation metadata (e.g. jpeg metadata), and code that reads that image is supposed to respect the Orientation metadata. For example, the Photos app on iOS or Windows reads this metadata when loading a jpeg and does the rotation when displaying the image. Similarly, when a jpeg is used as a texture in Babylon.js, the loading path relies on the browser respecting the Orientation metadata when loading the image data. This means what really needs to happen is:
1. We need to ensure the correct Orientation metadata is included in photo capture (achieved by the new change that sets `photoOutputConnection.videoOrientation`).
2. We need the Babylon Native image parsing code path to respect the Orientation metadata, which bimg already gives us, we were just ignoring it (new change that rotates the image data during image parsing if needed).