### PR TITLE
Allow device loss handle

### DIFF
--- a/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
+++ b/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
@@ -79,11 +79,14 @@ namespace Babylon::Graphics
         Device(Device&&) noexcept;
         Device& operator=(Device&&) noexcept;
 
+        static uintptr_t GetID();
+
         // Note: This API contract is subject to change in coming versions.
         // Features and functionalities will be added and
         // method and structure might change.
 
         void UpdateWindow(WindowT window);
+        void UpdateDevice(DeviceT device);
         void UpdateSize(size_t width, size_t height);
         void UpdateMSAA(uint8_t value);
         void UpdateAlphaPremultiplied(bool enabled);

--- a/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
+++ b/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
@@ -79,8 +79,6 @@ namespace Babylon::Graphics
         Device(Device&&) noexcept;
         Device& operator=(Device&&) noexcept;
 
-        static uintptr_t GetID();
-
         // Note: This API contract is subject to change in coming versions.
         // Features and functionalities will be added and
         // method and structure might change.

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
@@ -105,6 +105,7 @@ namespace Babylon::Graphics
         size_t GetWidth() const;
         size_t GetHeight() const;
         float GetDevicePixelRatio();
+        uintptr_t GetDeviceId() const;
 
         using CaptureCallbackTicketT = arcana::ticketed_collection<std::function<void(const BgfxCallback::CaptureData&)>>::ticket;
         CaptureCallbackTicketT AddCaptureCallback(std::function<void(const BgfxCallback::CaptureData&)> callback);

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
@@ -105,6 +105,8 @@ namespace Babylon::Graphics
         size_t GetWidth() const;
         size_t GetHeight() const;
         float GetDevicePixelRatio();
+
+        //Note: This is an index that changes when bgfx gets reset. It should be used to validate that resource handles created using bgfx remain valid on destruction.
         uintptr_t GetDeviceId() const;
 
         using CaptureCallbackTicketT = arcana::ticketed_collection<std::function<void(const BgfxCallback::CaptureData&)>>::ticket;

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/FrameBuffer.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/FrameBuffer.h
@@ -65,6 +65,7 @@ namespace Babylon::Graphics
 
 
         bool m_disposed{false};
+        uintptr_t m_graphicsID;
 
         Rect GetBgfxScissor(float x, float y, float width, float height) const;
         void SetBgfxViewPortAndScissor(bgfx::Encoder& encoder, const Rect& viewPort, const Rect& scissor);

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/FrameBuffer.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/FrameBuffer.h
@@ -65,7 +65,7 @@ namespace Babylon::Graphics
 
 
         bool m_disposed{false};
-        uintptr_t m_graphicsID;
+        uintptr_t m_deviceID;
 
         Rect GetBgfxScissor(float x, float y, float width, float height) const;
         void SetBgfxViewPortAndScissor(bgfx::Encoder& encoder, const Rect& viewPort, const Rect& scissor);

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
@@ -46,6 +46,6 @@ namespace Babylon::Graphics
         bgfx::TextureFormat::Enum m_format{bgfx::TextureFormat::Enum::Unknown};
         uint64_t m_flags{BGFX_TEXTURE_NONE};
         uint32_t m_samplerFlags{BGFX_SAMPLER_NONE};
-        uintptr_t m_graphicsID;
+        uintptr_t  m_deviceID;
     };
 }

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
@@ -7,7 +7,7 @@ namespace Babylon::Graphics
     class Texture final
     {
     public:
-        Texture() = default;
+        Texture();
         ~Texture();
 
         Texture(const Texture&) = delete;
@@ -46,5 +46,6 @@ namespace Babylon::Graphics
         bgfx::TextureFormat::Enum m_format{bgfx::TextureFormat::Enum::Unknown};
         uint64_t m_flags{BGFX_TEXTURE_NONE};
         uint32_t m_samplerFlags{BGFX_SAMPLER_NONE};
+        uintptr_t m_graphicsID;
     };
 }

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
@@ -4,10 +4,12 @@
 
 namespace Babylon::Graphics
 {
+    class DeviceContext;
+
     class Texture final
     {
     public:
-        Texture();
+        Texture(DeviceContext& deviceContext);
         ~Texture();
 
         Texture(const Texture&) = delete;
@@ -47,5 +49,6 @@ namespace Babylon::Graphics
         uint64_t m_flags{BGFX_TEXTURE_NONE};
         uint32_t m_samplerFlags{BGFX_SAMPLER_NONE};
         uintptr_t  m_deviceID;
+        DeviceContext& m_deviceContext;
     };
 }

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
@@ -48,7 +48,7 @@ namespace Babylon::Graphics
         bgfx::TextureFormat::Enum m_format{bgfx::TextureFormat::Enum::Unknown};
         uint64_t m_flags{BGFX_TEXTURE_NONE};
         uint32_t m_samplerFlags{BGFX_SAMPLER_NONE};
-        uintptr_t  m_deviceID;
+        uintptr_t m_deviceID;
         DeviceContext& m_deviceContext;
     };
 }

--- a/Core/Graphics/Source/Device.cpp
+++ b/Core/Graphics/Source/Device.cpp
@@ -14,11 +14,6 @@ namespace Babylon::Graphics
     Device::Device(Device&&) noexcept = default;
     Device& Device::operator=(Device&&) noexcept = default;
 
-    uintptr_t Device::GetID()
-    {
-       return DeviceImpl::GetId();
-    }
-
     void Device::UpdateDevice(DeviceT device) 
     {
        m_impl->UpdateDevice(device);

--- a/Core/Graphics/Source/Device.cpp
+++ b/Core/Graphics/Source/Device.cpp
@@ -14,6 +14,16 @@ namespace Babylon::Graphics
     Device::Device(Device&&) noexcept = default;
     Device& Device::operator=(Device&&) noexcept = default;
 
+    uintptr_t Device::GetID()
+    {
+       return DeviceImpl::GetId();
+    }
+
+    void Device::UpdateDevice(DeviceT device) 
+    {
+       m_impl->UpdateDevice(device);
+    }
+
     void Device::UpdateWindow(WindowT window)
     {
         m_impl->UpdateWindow(window);

--- a/Core/Graphics/Source/DeviceContext.cpp
+++ b/Core/Graphics/Source/DeviceContext.cpp
@@ -119,4 +119,9 @@ namespace Babylon::Graphics
         std::scoped_lock lock{m_textureHandleToInfoMutex};
         return m_textureHandleToInfo[handle.idx];
     }
+
+    uintptr_t DeviceContext::GetDeviceId() const
+    {
+       return m_graphicsImpl.GetId();
+    }
 }

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -19,6 +19,7 @@
 namespace
 {
     constexpr auto JS_GRAPHICS_NAME = "_Graphics";
+    uintptr_t g_bgfxId = 0;
 }
 
 namespace Babylon::Graphics
@@ -49,6 +50,11 @@ namespace Babylon::Graphics
         DisableRendering();
     }
 
+    uintptr_t DeviceImpl::GetId()
+    {
+       return g_bgfxId;
+    }
+
     void DeviceImpl::UpdateWindow(WindowT window)
     {
         std::scoped_lock lock{m_state.Mutex};
@@ -56,6 +62,12 @@ namespace Babylon::Graphics
         ConfigureBgfxPlatformData(m_state.Bgfx.InitState.platformData, window);
         ConfigureBgfxRenderType(m_state.Bgfx.InitState.platformData, m_state.Bgfx.InitState.type);
         m_state.Resolution.DevicePixelRatio = GetDevicePixelRatio(window);
+    }
+
+    void DeviceImpl::UpdateDevice(DeviceT device)
+    {
+       std::scoped_lock lock{ m_state.Mutex };
+       m_state.Bgfx.InitState.platformData.context = device;
     }
 
     void DeviceImpl::UpdateSize(size_t width, size_t height)
@@ -147,6 +159,7 @@ namespace Babylon::Graphics
             auto& init{m_state.Bgfx.InitState};
             bgfx::setPlatformData(init.platformData);
             bgfx::init(init);
+            g_bgfxId++;
 
             m_state.Bgfx.Initialized = true;
             m_state.Bgfx.Dirty = false;

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -19,7 +19,6 @@
 namespace
 {
     constexpr auto JS_GRAPHICS_NAME = "_Graphics";
-    uintptr_t g_bgfxId = 0;
 }
 
 namespace Babylon::Graphics
@@ -27,6 +26,7 @@ namespace Babylon::Graphics
     DeviceImpl::DeviceImpl(const Configuration& config)
         : m_bgfxCallback{[this](const auto& data) { CaptureCallback(data); }}
         , m_context{*this}
+        , m_bgfxId{0}
     {
         std::scoped_lock lock{m_state.Mutex};
         m_state.Bgfx.Initialized = false;
@@ -50,9 +50,9 @@ namespace Babylon::Graphics
         DisableRendering();
     }
 
-    uintptr_t DeviceImpl::GetId()
+    uintptr_t DeviceImpl::GetId() const
     {
-       return g_bgfxId;
+       return m_bgfxId;
     }
 
     void DeviceImpl::UpdateWindow(WindowT window)
@@ -159,7 +159,7 @@ namespace Babylon::Graphics
             auto& init{m_state.Bgfx.InitState};
             bgfx::setPlatformData(init.platformData);
             bgfx::init(init);
-            g_bgfxId++;
+            m_bgfxId++;
 
             m_state.Bgfx.Initialized = true;
             m_state.Bgfx.Dirty = false;

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -159,7 +159,6 @@ namespace Babylon::Graphics
             auto& init{m_state.Bgfx.InitState};
             bgfx::setPlatformData(init.platformData);
             bgfx::init(init);
-            m_bgfxId++;
 
             m_state.Bgfx.Initialized = true;
             m_state.Bgfx.Dirty = false;
@@ -192,6 +191,7 @@ namespace Babylon::Graphics
 
             bgfx::shutdown();
             m_state.Bgfx.Initialized = false;
+            m_bgfxId++;
 
             m_renderThreadAffinity = {};
         }

--- a/Core/Graphics/Source/DeviceImpl.h
+++ b/Core/Graphics/Source/DeviceImpl.h
@@ -38,10 +38,8 @@ namespace Babylon::Graphics
         DeviceImpl(DeviceImpl&&) noexcept = delete;
         DeviceImpl& operator=(DeviceImpl&&) noexcept = delete;
 
-        static uintptr_t GetId();
 
         /* ********** BEGIN DEVICE CONTRACT ********** */
-
         void UpdateWindow(WindowT window);
         void UpdateDevice(DeviceT device);
         void UpdateSize(size_t width, size_t height);
@@ -70,6 +68,8 @@ namespace Babylon::Graphics
         float GetDevicePixelRatio() const;
 
         PlatformInfo GetPlatformInfo() const;
+
+        uintptr_t GetId() const;
 
         /* ********** END DEVICE CONTRACT ********** */
 
@@ -162,5 +162,6 @@ namespace Babylon::Graphics
         std::mutex m_updateSafeTimespansMutex{};
 
         DeviceContext m_context;
+        uintptr_t m_bgfxId = 0;
     };
 }

--- a/Core/Graphics/Source/DeviceImpl.h
+++ b/Core/Graphics/Source/DeviceImpl.h
@@ -38,9 +38,12 @@ namespace Babylon::Graphics
         DeviceImpl(DeviceImpl&&) noexcept = delete;
         DeviceImpl& operator=(DeviceImpl&&) noexcept = delete;
 
+        static uintptr_t GetId();
+
         /* ********** BEGIN DEVICE CONTRACT ********** */
 
         void UpdateWindow(WindowT window);
+        void UpdateDevice(DeviceT device);
         void UpdateSize(size_t width, size_t height);
         void UpdateMSAA(uint8_t value);
         void UpdateAlphaPremultiplied(bool enabled);

--- a/Core/Graphics/Source/FrameBuffer.cpp
+++ b/Core/Graphics/Source/FrameBuffer.cpp
@@ -14,7 +14,7 @@ namespace Babylon::Graphics
         , m_hasDepth{hasDepth}
         , m_hasStencil{hasStencil}
         , m_disposed{false}
-        , m_deviceID{Babylon::Graphics::Device::GetID()}
+        , m_deviceID{context.GetDeviceId()}
     {
     }
 
@@ -135,7 +135,7 @@ namespace Babylon::Graphics
             return;
         }
 
-        if (bgfx::isValid(m_handle) && m_deviceID == Device::GetID())
+        if (bgfx::isValid(m_handle) && m_deviceID == m_context.GetDeviceId())
         {
             bgfx::destroy(m_handle);
         }

--- a/Core/Graphics/Source/FrameBuffer.cpp
+++ b/Core/Graphics/Source/FrameBuffer.cpp
@@ -14,7 +14,7 @@ namespace Babylon::Graphics
         , m_hasDepth{hasDepth}
         , m_hasStencil{hasStencil}
         , m_disposed{false}
-        , m_graphicsID{Babylon::Graphics::Device::GetID()}
+        , m_deviceID{Babylon::Graphics::Device::GetID()}
     {
     }
 
@@ -135,7 +135,7 @@ namespace Babylon::Graphics
             return;
         }
 
-        if (bgfx::isValid(m_handle) && m_graphicsID == Device::GetID())
+        if (bgfx::isValid(m_handle) && m_deviceID == Device::GetID())
         {
             bgfx::destroy(m_handle);
         }

--- a/Core/Graphics/Source/FrameBuffer.cpp
+++ b/Core/Graphics/Source/FrameBuffer.cpp
@@ -14,6 +14,7 @@ namespace Babylon::Graphics
         , m_hasDepth{hasDepth}
         , m_hasStencil{hasStencil}
         , m_disposed{false}
+        , m_graphicsID{Babylon::Graphics::Device::GetID()}
     {
     }
 
@@ -134,7 +135,7 @@ namespace Babylon::Graphics
             return;
         }
 
-        if (bgfx::isValid(m_handle))
+        if (bgfx::isValid(m_handle) && m_graphicsID == Babylon::Graphics::Device::GetID())
         {
             bgfx::destroy(m_handle);
         }

--- a/Core/Graphics/Source/FrameBuffer.cpp
+++ b/Core/Graphics/Source/FrameBuffer.cpp
@@ -135,7 +135,7 @@ namespace Babylon::Graphics
             return;
         }
 
-        if (bgfx::isValid(m_handle) && m_graphicsID == Babylon::Graphics::Device::GetID())
+        if (bgfx::isValid(m_handle) && m_graphicsID == Device::GetID())
         {
             bgfx::destroy(m_handle);
         }

--- a/Core/Graphics/Source/Texture.cpp
+++ b/Core/Graphics/Source/Texture.cpp
@@ -1,8 +1,16 @@
 #include "Texture.h"
 #include <cassert>
 
+#include "Babylon/Graphics/Device.h"
+
 namespace Babylon::Graphics
 {
+    Texture::Texture()
+       : m_graphicsID{Babylon::Graphics::Device::GetID()}
+    {
+
+    }
+
     Texture::~Texture()
     {
         Dispose();
@@ -10,7 +18,7 @@ namespace Babylon::Graphics
 
     void Texture::Dispose()
     {
-        if (m_ownsHandle && bgfx::isValid(m_handle))
+        if (m_ownsHandle && bgfx::isValid(m_handle) && m_graphicsID == Babylon::Graphics::Device::GetID())
         {
             bgfx::destroy(m_handle);
             m_handle = BGFX_INVALID_HANDLE;

--- a/Core/Graphics/Source/Texture.cpp
+++ b/Core/Graphics/Source/Texture.cpp
@@ -6,7 +6,7 @@
 namespace Babylon::Graphics
 {
     Texture::Texture()
-       : m_graphicsID{Babylon::Graphics::Device::GetID()}
+       : m_deviceID{Device::GetID()}
     {
     }
 
@@ -17,7 +17,7 @@ namespace Babylon::Graphics
 
     void Texture::Dispose()
     {
-        if (m_ownsHandle && bgfx::isValid(m_handle) && m_graphicsID == Babylon::Graphics::Device::GetID())
+        if (m_ownsHandle && bgfx::isValid(m_handle) && m_deviceID == Device::GetID())
         {
             bgfx::destroy(m_handle);
             m_handle = BGFX_INVALID_HANDLE;

--- a/Core/Graphics/Source/Texture.cpp
+++ b/Core/Graphics/Source/Texture.cpp
@@ -8,7 +8,6 @@ namespace Babylon::Graphics
     Texture::Texture()
        : m_graphicsID{Babylon::Graphics::Device::GetID()}
     {
-
     }
 
     Texture::~Texture()

--- a/Core/Graphics/Source/Texture.cpp
+++ b/Core/Graphics/Source/Texture.cpp
@@ -1,12 +1,12 @@
 #include "Texture.h"
+#include "DeviceContext.h"
 #include <cassert>
-
-#include "Babylon/Graphics/Device.h"
 
 namespace Babylon::Graphics
 {
-    Texture::Texture()
-       : m_deviceID{Device::GetID()}
+    Texture::Texture(DeviceContext& deviceContext)
+       : m_deviceID{deviceContext.GetDeviceId()}
+       , m_deviceContext{deviceContext}
     {
     }
 
@@ -17,7 +17,7 @@ namespace Babylon::Graphics
 
     void Texture::Dispose()
     {
-        if (m_ownsHandle && bgfx::isValid(m_handle) && m_deviceID == Device::GetID())
+        if (m_ownsHandle && bgfx::isValid(m_handle) && m_deviceID == m_deviceContext.GetDeviceId())
         {
             bgfx::destroy(m_handle);
             m_handle = BGFX_INVALID_HANDLE;

--- a/Plugins/ExternalTexture/Source/ExternalTexture_Shared.h
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Shared.h
@@ -78,7 +78,7 @@ namespace Babylon::Plugins
                     return;
                 }
 
-                arcana::make_task(context.AfterRenderScheduler(), arcana::cancellation_source::none(), [&runtime, deferred = std::move(deferred), handle, impl = std::move(impl)]() {
+                arcana::make_task(context.AfterRenderScheduler(), arcana::cancellation_source::none(), [&runtime, &context, deferred = std::move(deferred), handle, impl = std::move(impl)]() {
                     if (bgfx::overrideInternal(handle, impl->Ptr()) == 0)
                     {
                         runtime.Dispatch([deferred = std::move(deferred), handle](Napi::Env env) {
@@ -89,8 +89,8 @@ namespace Babylon::Plugins
                         return;
                     }
 
-                    runtime.Dispatch([deferred = std::move(deferred), handle, impl = std::move(impl)](Napi::Env env) {
-                        auto* texture = new Graphics::Texture{};
+                    runtime.Dispatch([deferred = std::move(deferred), handle, &context, impl = std::move(impl)](Napi::Env env) {
+                        auto* texture = new Graphics::Texture{context};
                         texture->Attach(handle, true, impl->Width(), impl->Height(), impl->HasMips(), 1, impl->Format(), impl->Flags());
 
                         impl->AddHandle(texture->Handle());

--- a/Plugins/NativeEngine/Source/IndexBuffer.cpp
+++ b/Plugins/NativeEngine/Source/IndexBuffer.cpp
@@ -1,13 +1,14 @@
 #include "IndexBuffer.h"
-#include "Babylon/Graphics/Device.h"
+#include "Babylon/Graphics/DeviceContext.h"
 
 namespace Babylon
 {
-    IndexBuffer::IndexBuffer(gsl::span<uint8_t> bytes, uint16_t flags, bool dynamic)
+    IndexBuffer::IndexBuffer(gsl::span<uint8_t> bytes, uint16_t flags, bool dynamic, Graphics::DeviceContext& deviceContext)
         : m_bytes{{bytes.data(), bytes.data() + bytes.size()}}
         , m_flags{flags}
         , m_dynamic{dynamic}
-        , m_deviceID{Graphics::Device::GetID()}
+        , m_deviceID{deviceContext.GetDeviceId()}
+        , m_deviceContext{deviceContext}
     {
     }
 
@@ -23,7 +24,7 @@ namespace Babylon
             return;
         }
 
-        if (bgfx::isValid(m_handle) && m_deviceID == Graphics::Device::GetID())
+        if (bgfx::isValid(m_handle) && m_deviceID == m_deviceContext.GetDeviceId())
         {
             if (m_dynamic)
             {

--- a/Plugins/NativeEngine/Source/IndexBuffer.cpp
+++ b/Plugins/NativeEngine/Source/IndexBuffer.cpp
@@ -7,7 +7,7 @@ namespace Babylon
         : m_bytes{{bytes.data(), bytes.data() + bytes.size()}}
         , m_flags{flags}
         , m_dynamic{dynamic}
-        , m_graphicsID{Babylon::Graphics::Device::GetID()}
+        , m_deviceID{Graphics::Device::GetID()}
     {
     }
 
@@ -23,7 +23,7 @@ namespace Babylon
             return;
         }
 
-        if (bgfx::isValid(m_handle) && m_graphicsID == Babylon::Graphics::Device::GetID())
+        if (bgfx::isValid(m_handle) && m_deviceID == Graphics::Device::GetID())
         {
             if (m_dynamic)
             {

--- a/Plugins/NativeEngine/Source/IndexBuffer.cpp
+++ b/Plugins/NativeEngine/Source/IndexBuffer.cpp
@@ -1,4 +1,5 @@
 #include "IndexBuffer.h"
+#include "Babylon/Graphics/Device.h"
 
 namespace Babylon
 {
@@ -6,6 +7,7 @@ namespace Babylon
         : m_bytes{{bytes.data(), bytes.data() + bytes.size()}}
         , m_flags{flags}
         , m_dynamic{dynamic}
+        , m_graphicsID{Babylon::Graphics::Device::GetID()}
     {
     }
 
@@ -21,7 +23,7 @@ namespace Babylon
             return;
         }
 
-        if (bgfx::isValid(m_handle))
+        if (bgfx::isValid(m_handle) && m_graphicsID == Babylon::Graphics::Device::GetID())
         {
             if (m_dynamic)
             {

--- a/Plugins/NativeEngine/Source/IndexBuffer.h
+++ b/Plugins/NativeEngine/Source/IndexBuffer.h
@@ -35,6 +35,6 @@ namespace Babylon
         };
 
         bool m_disposed{};
-        uintptr_t m_graphicsID;
+        uintptr_t  m_deviceID;
     };
 }

--- a/Plugins/NativeEngine/Source/IndexBuffer.h
+++ b/Plugins/NativeEngine/Source/IndexBuffer.h
@@ -35,5 +35,6 @@ namespace Babylon
         };
 
         bool m_disposed{};
+        uintptr_t m_graphicsID;
     };
 }

--- a/Plugins/NativeEngine/Source/IndexBuffer.h
+++ b/Plugins/NativeEngine/Source/IndexBuffer.h
@@ -8,10 +8,15 @@
 
 namespace Babylon
 {
+    namespace Graphics 
+    {
+        class DeviceContext;
+    }
+
     class IndexBuffer final
     {
     public:
-        IndexBuffer(gsl::span<uint8_t> bytes, uint16_t flags, bool dynamic);
+        IndexBuffer(gsl::span<uint8_t> bytes, uint16_t flags, bool dynamic, Graphics::DeviceContext& deviceContext);
         ~IndexBuffer();
 
         IndexBuffer(const IndexBuffer&) = delete;
@@ -36,5 +41,6 @@ namespace Babylon
 
         bool m_disposed{};
         uintptr_t  m_deviceID;
+        Graphics::DeviceContext& m_deviceContext;
     };
 }

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -650,7 +650,7 @@ namespace Babylon
 
     Napi::Value NativeEngine::CreateVertexArray(const Napi::CallbackInfo& info)
     {
-        VertexArray* vertexArray = new VertexArray{};
+        VertexArray* vertexArray = new VertexArray{m_graphicsContext};
         return Napi::Pointer<VertexArray>::Create(info.Env(), vertexArray, Napi::NapiPointerDeleter(vertexArray));
     }
 
@@ -675,7 +675,7 @@ namespace Babylon
         const bool dynamic = info[4].As<Napi::Boolean>().Value();
 
         const uint16_t flags = (is32Bits ? BGFX_BUFFER_INDEX32 : 0);
-        IndexBuffer* indexBuffer = new IndexBuffer{gsl::make_span(static_cast<uint8_t*>(bytes.Data()) + byteOffset, byteLength), flags, dynamic};
+        IndexBuffer* indexBuffer = new IndexBuffer{gsl::make_span(static_cast<uint8_t*>(bytes.Data()) + byteOffset, byteLength), flags, dynamic, m_graphicsContext};
         return Napi::Pointer<IndexBuffer>::Create(info.Env(), indexBuffer, Napi::NapiPointerDeleter(indexBuffer));
     }
 
@@ -713,7 +713,7 @@ namespace Babylon
         const uint32_t byteLength = info[2].As<Napi::Number>().Uint32Value();
         const bool dynamic = info[3].As<Napi::Boolean>().Value();
 
-        VertexBuffer* vertexBuffer = new VertexBuffer(gsl::make_span(static_cast<uint8_t*>(bytes.Data()) + byteOffset, byteLength), dynamic);
+        VertexBuffer* vertexBuffer = new VertexBuffer(gsl::make_span(static_cast<uint8_t*>(bytes.Data()) + byteOffset, byteLength), dynamic, m_graphicsContext);
         return Napi::Pointer<VertexBuffer>::Create(info.Env(), vertexBuffer, Napi::NapiPointerDeleter(vertexBuffer));
     }
 
@@ -804,7 +804,7 @@ namespace Babylon
     {
         ShaderCompiler::BgfxShaderInfo shaderInfo = m_shaderCompiler.Compile(ProcessShaderCoordinates(vertexSource), ProcessSamplerFlip(fragmentSource));
 
-        std::unique_ptr<ProgramData> program = std::make_unique<ProgramData>();
+        std::unique_ptr<ProgramData> program = std::make_unique<ProgramData>(m_graphicsContext);
 
         static auto InitUniformInfos{
             [](bgfx::ShaderHandle shader, const std::unordered_map<std::string, uint8_t>& uniformStages, std::unordered_map<uint16_t, UniformInfo>& uniformInfos, std::unordered_map<std::string, uint16_t>& uniformNameToIndex) {
@@ -840,7 +840,7 @@ namespace Babylon
     {
         const std::string vertexSource = info[0].As<Napi::String>().Utf8Value();
         const std::string fragmentSource = info[1].As<Napi::String>().Utf8Value();
-        ProgramData* program = new ProgramData{};
+        ProgramData* program = new ProgramData{m_graphicsContext};
         Napi::Value jsProgram = Napi::Pointer<ProgramData>::Create(info.Env(), program, Napi::NapiPointerDeleter(program));
         try
         {
@@ -860,7 +860,7 @@ namespace Babylon
         const Napi::Function onSuccess = info[2].As<Napi::Function>();
         const Napi::Function onError = info[3].As<Napi::Function>();
 
-        ProgramData* program = new ProgramData{};
+        ProgramData* program = new ProgramData{m_graphicsContext};
         Napi::Value jsProgram = Napi::Pointer<ProgramData>::Create(info.Env(), program, Napi::NapiPointerDeleter(program));
 
         arcana::make_task(arcana::threadpool_scheduler, *m_cancellationSource,
@@ -1183,7 +1183,7 @@ namespace Babylon
 
     Napi::Value NativeEngine::CreateTexture(const Napi::CallbackInfo& info)
     {
-        Graphics::Texture* texture = new Graphics::Texture();
+        Graphics::Texture* texture = new Graphics::Texture(m_graphicsContext);
         return Napi::Pointer<Graphics::Texture>::Create(info.Env(), texture, Napi::NapiPointerDeleter(texture));
     }
 

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -11,6 +11,7 @@
 #include <Babylon/Graphics/DeviceContext.h>
 #include <Babylon/Graphics/BgfxCallback.h>
 #include <Babylon/Graphics/FrameBuffer.h>
+#include <Babylon/Graphics/Device.h>
 
 #include <napi/napi.h>
 
@@ -52,6 +53,7 @@ namespace Babylon
             , UniformNameToIndex{std::move(other.UniformNameToIndex)}
             , UniformInfos{std::move(other.UniformInfos)}
             , VertexAttributeLocations{std::move(other.VertexAttributeLocations)}
+            , GraphicsInstanceID{Babylon::Graphics::Device::GetDeviceInstanceID()}
         {
             other.Handle = BGFX_INVALID_HANDLE;
         }
@@ -74,7 +76,7 @@ namespace Babylon
 
         void Dispose()
         {
-            if (bgfx::isValid(Handle))
+            if (bgfx::isValid(Handle) && GraphicsInstanceID == Babylon::Graphics::Device::GetDeviceInstanceID())
             {
                 bgfx::destroy(Handle);
                 Handle = BGFX_INVALID_HANDLE;
@@ -93,6 +95,7 @@ namespace Babylon
         std::unordered_map<std::string, uint16_t> UniformNameToIndex{};
         std::unordered_map<uint16_t, UniformInfo> UniformInfos{};
         std::unordered_map<std::string, uint32_t> VertexAttributeLocations{};
+        uint32_t GraphicsInstanceID;
 
         void SetUniform(bgfx::UniformHandle handle, gsl::span<const float> data, size_t elementLength = 1)
         {

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -44,8 +44,9 @@ namespace Babylon
     struct ProgramData final
     {
         ProgramData(Graphics::DeviceContext& deviceContext) 
-           : DeviceContext{deviceContext}
-           , DeviceID {deviceContext.GetDeviceId()}
+           : DeviceID {deviceContext.GetDeviceId()}
+           , DeviceContext{deviceContext}
+
         {
 
         }

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -53,7 +53,7 @@ namespace Babylon
             , UniformNameToIndex{std::move(other.UniformNameToIndex)}
             , UniformInfos{std::move(other.UniformInfos)}
             , VertexAttributeLocations{std::move(other.VertexAttributeLocations)}
-            , GraphicsInstanceID{Babylon::Graphics::Device::GetDeviceInstanceID()}
+            , DeviceID{Babylon::Graphics::Device::GetID()}
         {
             other.Handle = BGFX_INVALID_HANDLE;
         }
@@ -76,7 +76,7 @@ namespace Babylon
 
         void Dispose()
         {
-            if (bgfx::isValid(Handle) && GraphicsInstanceID == Babylon::Graphics::Device::GetDeviceInstanceID())
+            if (bgfx::isValid(Handle) && DeviceID == Babylon::Graphics::Device::GetID())
             {
                 bgfx::destroy(Handle);
                 Handle = BGFX_INVALID_HANDLE;
@@ -95,7 +95,7 @@ namespace Babylon
         std::unordered_map<std::string, uint16_t> UniformNameToIndex{};
         std::unordered_map<uint16_t, UniformInfo> UniformInfos{};
         std::unordered_map<std::string, uint32_t> VertexAttributeLocations{};
-        uint32_t GraphicsInstanceID;
+        uintptr_t DeviceID;
 
         void SetUniform(bgfx::UniformHandle handle, gsl::span<const float> data, size_t elementLength = 1)
         {

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -11,7 +11,7 @@
 #include <Babylon/Graphics/DeviceContext.h>
 #include <Babylon/Graphics/BgfxCallback.h>
 #include <Babylon/Graphics/FrameBuffer.h>
-#include <Babylon/Graphics/Device.h>
+#include <Babylon/Graphics/DeviceContext.h>
 
 #include <napi/napi.h>
 
@@ -43,7 +43,13 @@ namespace Babylon
 
     struct ProgramData final
     {
-        ProgramData() = default;
+        ProgramData(Graphics::DeviceContext& deviceContext) 
+           : DeviceContext{deviceContext}
+           , DeviceID {deviceContext.GetDeviceId()}
+        {
+
+        }
+
         ProgramData(const ProgramData&) = delete;
         ProgramData& operator=(const ProgramData&) = delete;
 
@@ -53,7 +59,8 @@ namespace Babylon
             , UniformNameToIndex{std::move(other.UniformNameToIndex)}
             , UniformInfos{std::move(other.UniformInfos)}
             , VertexAttributeLocations{std::move(other.VertexAttributeLocations)}
-            , DeviceID{Babylon::Graphics::Device::GetID()}
+            , DeviceID{other.DeviceID}
+            , DeviceContext{other.DeviceContext}
         {
             other.Handle = BGFX_INVALID_HANDLE;
         }
@@ -76,7 +83,7 @@ namespace Babylon
 
         void Dispose()
         {
-            if (bgfx::isValid(Handle) && DeviceID == Babylon::Graphics::Device::GetID())
+            if (bgfx::isValid(Handle) && DeviceID == DeviceContext.GetDeviceId())
             {
                 bgfx::destroy(Handle);
                 Handle = BGFX_INVALID_HANDLE;
@@ -96,6 +103,7 @@ namespace Babylon
         std::unordered_map<uint16_t, UniformInfo> UniformInfos{};
         std::unordered_map<std::string, uint32_t> VertexAttributeLocations{};
         uintptr_t DeviceID;
+        Graphics::DeviceContext& DeviceContext;
 
         void SetUniform(bgfx::UniformHandle handle, gsl::span<const float> data, size_t elementLength = 1)
         {

--- a/Plugins/NativeEngine/Source/VertexArray.cpp
+++ b/Plugins/NativeEngine/Source/VertexArray.cpp
@@ -5,7 +5,7 @@
 namespace Babylon
 {
     VertexArray::VertexArray()
-       : m_graphicsID{ Babylon::Graphics::Device::GetID() }
+       : m_deviceID{Graphics::Device::GetID()}
     {
     }
 
@@ -23,7 +23,7 @@ namespace Babylon
 
         m_indexBufferRecord.Buffer = nullptr;
 
-        if(m_graphicsID == Babylon::Graphics::Device::GetID())
+        if( m_deviceID == Graphics::Device::GetID())
         {
            for( auto& pair : m_vertexBufferRecords )
            {

--- a/Plugins/NativeEngine/Source/VertexArray.cpp
+++ b/Plugins/NativeEngine/Source/VertexArray.cpp
@@ -1,11 +1,12 @@
 #include "VertexArray.h"
 #include <cassert>
-#include "Babylon/Graphics/Device.h"
+#include "Babylon/Graphics/DeviceContext.h"
 
 namespace Babylon
 {
-    VertexArray::VertexArray()
-       : m_deviceID{Graphics::Device::GetID()}
+    VertexArray::VertexArray(Graphics::DeviceContext& deviceContext)
+       : m_deviceID{deviceContext.GetDeviceId()}
+       , m_deviceContext{deviceContext}
     {
     }
 
@@ -23,7 +24,7 @@ namespace Babylon
 
         m_indexBufferRecord.Buffer = nullptr;
 
-        if( m_deviceID == Graphics::Device::GetID())
+        if( m_deviceID == m_deviceContext.GetDeviceId())
         {
            for( auto& pair : m_vertexBufferRecords )
            {

--- a/Plugins/NativeEngine/Source/VertexArray.cpp
+++ b/Plugins/NativeEngine/Source/VertexArray.cpp
@@ -1,8 +1,14 @@
 #include "VertexArray.h"
 #include <cassert>
+#include "Babylon/Graphics/Device.h"
 
 namespace Babylon
 {
+    VertexArray::VertexArray()
+       : m_graphicsID{ Babylon::Graphics::Device::GetID() }
+    {
+    }
+
     VertexArray::~VertexArray()
     {
         Dispose();
@@ -17,9 +23,12 @@ namespace Babylon
 
         m_indexBufferRecord.Buffer = nullptr;
 
-        for (auto& pair : m_vertexBufferRecords)
+        if(m_graphicsID == Babylon::Graphics::Device::GetID())
         {
-            bgfx::destroy(pair.second.LayoutHandle);
+           for( auto& pair : m_vertexBufferRecords )
+           {
+              bgfx::destroy(pair.second.LayoutHandle);
+           }
         }
 
         m_vertexBufferRecords.clear();

--- a/Plugins/NativeEngine/Source/VertexArray.h
+++ b/Plugins/NativeEngine/Source/VertexArray.h
@@ -6,10 +6,15 @@
 
 namespace Babylon
 {
+    namespace Graphics 
+    {
+        class DeviceContext;
+    }
+
     class VertexArray final
     {
     public:
-        VertexArray();
+        VertexArray(Graphics::DeviceContext& deviceContext);
         ~VertexArray();
 
         VertexArray(const VertexArray&) = delete;
@@ -42,5 +47,6 @@ namespace Babylon
 
         bool m_disposed{};
         uintptr_t m_deviceID;
+        Graphics::DeviceContext& m_deviceContext;
     };
 }

--- a/Plugins/NativeEngine/Source/VertexArray.h
+++ b/Plugins/NativeEngine/Source/VertexArray.h
@@ -9,7 +9,7 @@ namespace Babylon
     class VertexArray final
     {
     public:
-        VertexArray() = default;
+        VertexArray();
         ~VertexArray();
 
         VertexArray(const VertexArray&) = delete;
@@ -41,5 +41,6 @@ namespace Babylon
         std::map<bgfx::Attrib::Enum, VertexBuffer::InstanceVertexBufferRecord> m_vertexBufferInstanceRecords{};
 
         bool m_disposed{};
+        uintptr_t m_graphicsID;
     };
 }

--- a/Plugins/NativeEngine/Source/VertexArray.h
+++ b/Plugins/NativeEngine/Source/VertexArray.h
@@ -41,6 +41,6 @@ namespace Babylon
         std::map<bgfx::Attrib::Enum, VertexBuffer::InstanceVertexBufferRecord> m_vertexBufferInstanceRecords{};
 
         bool m_disposed{};
-        uintptr_t m_graphicsID;
+        uintptr_t m_deviceID;
     };
 }

--- a/Plugins/NativeEngine/Source/VertexBuffer.cpp
+++ b/Plugins/NativeEngine/Source/VertexBuffer.cpp
@@ -1,6 +1,6 @@
 #include "VertexBuffer.h"
 #include <cassert>
-#include "Babylon/Graphics/Device.h"
+#include "Babylon/Graphics/DeviceContext.h"
 
 namespace
 {
@@ -28,10 +28,11 @@ namespace
 
 namespace Babylon
 {
-    VertexBuffer::VertexBuffer(gsl::span<uint8_t> bytes, bool dynamic)
+    VertexBuffer::VertexBuffer(gsl::span<uint8_t> bytes, bool dynamic, Graphics::DeviceContext& deviceContext)
         : m_bytes{{bytes.data(), bytes.data() + bytes.size()}}
         , m_dynamic{dynamic}
-        , m_deviceID{Graphics::Device::GetID()}
+        , m_deviceID{deviceContext.GetDeviceId()}
+        , m_deviceContext{deviceContext}
     {
     }
 
@@ -47,7 +48,7 @@ namespace Babylon
             return;
         }
 
-        if (bgfx::isValid(m_handle) && m_deviceID == Graphics::Device::GetID())
+        if (bgfx::isValid(m_handle) && m_deviceID == m_deviceContext.GetDeviceId())
         {
             if (m_dynamic)
             {

--- a/Plugins/NativeEngine/Source/VertexBuffer.cpp
+++ b/Plugins/NativeEngine/Source/VertexBuffer.cpp
@@ -1,5 +1,6 @@
 #include "VertexBuffer.h"
 #include <cassert>
+#include "Babylon/Graphics/Device.h"
 
 namespace
 {
@@ -30,6 +31,7 @@ namespace Babylon
     VertexBuffer::VertexBuffer(gsl::span<uint8_t> bytes, bool dynamic)
         : m_bytes{{bytes.data(), bytes.data() + bytes.size()}}
         , m_dynamic{dynamic}
+        , m_graphicsID{ Babylon::Graphics::Device::GetID() }
     {
     }
 
@@ -45,7 +47,7 @@ namespace Babylon
             return;
         }
 
-        if (bgfx::isValid(m_handle))
+        if (bgfx::isValid(m_handle) && m_graphicsID == Babylon::Graphics::Device::GetID())
         {
             if (m_dynamic)
             {

--- a/Plugins/NativeEngine/Source/VertexBuffer.cpp
+++ b/Plugins/NativeEngine/Source/VertexBuffer.cpp
@@ -31,7 +31,7 @@ namespace Babylon
     VertexBuffer::VertexBuffer(gsl::span<uint8_t> bytes, bool dynamic)
         : m_bytes{{bytes.data(), bytes.data() + bytes.size()}}
         , m_dynamic{dynamic}
-        , m_graphicsID{ Babylon::Graphics::Device::GetID() }
+        , m_deviceID{Graphics::Device::GetID()}
     {
     }
 
@@ -47,7 +47,7 @@ namespace Babylon
             return;
         }
 
-        if (bgfx::isValid(m_handle) && m_graphicsID == Babylon::Graphics::Device::GetID())
+        if (bgfx::isValid(m_handle) && m_deviceID == Graphics::Device::GetID())
         {
             if (m_dynamic)
             {

--- a/Plugins/NativeEngine/Source/VertexBuffer.h
+++ b/Plugins/NativeEngine/Source/VertexBuffer.h
@@ -8,10 +8,15 @@
 
 namespace Babylon
 {
+    namespace Graphics 
+    {
+        class DeviceContext;
+    }
+
     class VertexBuffer final
     {
     public:
-        VertexBuffer(gsl::span<uint8_t> bytes, bool dynamic);
+        VertexBuffer(gsl::span<uint8_t> bytes, bool dynamic, Graphics::DeviceContext& deviceContext);
         ~VertexBuffer();
 
         VertexBuffer(const VertexBuffer&) = delete;
@@ -46,5 +51,6 @@ namespace Babylon
 
         bool m_disposed{};
         uintptr_t m_deviceID;
+        Graphics::DeviceContext& m_deviceContext;
     };
 }

--- a/Plugins/NativeEngine/Source/VertexBuffer.h
+++ b/Plugins/NativeEngine/Source/VertexBuffer.h
@@ -45,5 +45,6 @@ namespace Babylon
         };
 
         bool m_disposed{};
+        uintptr_t m_graphicsID;
     };
 }

--- a/Plugins/NativeEngine/Source/VertexBuffer.h
+++ b/Plugins/NativeEngine/Source/VertexBuffer.h
@@ -45,6 +45,6 @@ namespace Babylon
         };
 
         bool m_disposed{};
-        uintptr_t m_graphicsID;
+        uintptr_t m_deviceID;
     };
 }

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -142,7 +142,7 @@ namespace Babylon::Polyfills::Internal
     {
         if (!m_texture)
         {
-            m_texture = std::make_unique<Graphics::Texture>();
+            m_texture = std::make_unique<Graphics::Texture>(m_graphicsContext);
         }
 
         m_texture->Attach(bgfx::getTexture(m_frameBuffer->Handle()), false, m_width, m_height, false, 1, bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT);


### PR DESCRIPTION
This PR implements changes to Babylon Native that allow it to properly handle graphics device loss scenarios. When the graphics device currently been used by Babylon Native gets invalidated the correct workflow will be to call ```Babylon::Graphics::Device::DisableRendering``` recreate the graphics device infrastructure, use the new API ```Babylon::Graphics::Device::UpdateDevice``` to  give the new device to Babylon Native and than call ```Babylon::Graphics::Device::EnableRendering``` to start bgfx again with a new device. 

This also requires Babylon.js to be notified that the current device context was lost and re-created. This can be done by calling:

```
   engine._contextWasLost = true;
   engine._restoreEngineAfterContextLost(() => { });
``` 

This will force Babylon.js to recreate all graphics resources again and destroy the old ones. Since some bgfx resources have their lifetime bound to Babylon.js managed objects, it is important to check that the current instance of bgfx running when the resources get destroyed is the same as the one they were created with, for that I'm now adding a ```graphicsId``` attribute to those objects to hold that information. If the graphicsId been used by the Graphics device is no longer the same that existed when the object was created, this means that bgfx was reset and the handler is no longer valid. 