### PR TITLE
Use new JsRuntimeHost `BABYLON_API` calling convention macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ FetchContent_Declare(ios-cmake
     GIT_TAG 4.4.1)
 FetchContent_Declare(JsRuntimeHost
     GIT_REPOSITORY https://github.com/BabylonJS/JsRuntimeHost.git
-    GIT_TAG ef3bb85d2e8e1ec314aaa2ff0df7fba360acd1b1)
+    GIT_TAG 66c863be8cedf2869a4e59ce99144417c78af73c)
 FetchContent_Declare(OpenXR-MixedReality
     GIT_REPOSITORY https://github.com/microsoft/OpenXR-MixedReality.git
     GIT_TAG 67424511525b96a36847f2a96d689d99e5879503)

--- a/Install/Install.cmake
+++ b/Install/Install.cmake
@@ -63,6 +63,8 @@ install_targets(UrlLib)
 # ----------------
 # Core
 # ----------------
+install_include_for_targets(Foundation)
+
 install_targets(JsRuntime)
 install_include_for_targets(JsRuntime)
 

--- a/Plugins/NativeCamera/Include/Babylon/Plugins/NativeCamera.h
+++ b/Plugins/NativeCamera/Include/Babylon/Plugins/NativeCamera.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Plugins::NativeCamera
 {
-    void Initialize(Napi::Env env);
+    void BABYLON_API Initialize(Napi::Env env);
 }

--- a/Plugins/NativeCamera/Source/NativeCamera.cpp
+++ b/Plugins/NativeCamera/Source/NativeCamera.cpp
@@ -48,7 +48,7 @@ namespace Babylon::Plugins::Internal
 
 namespace Babylon::Plugins::NativeCamera
 {
-    void Initialize(Napi::Env env)
+    void BABYLON_API Initialize(Napi::Env env)
     {
         Babylon::Plugins::NativeVideo::Initialize(env);
         Babylon::Plugins::MediaDevices::Initialize(env);

--- a/Plugins/NativeCapture/Include/Babylon/Plugins/NativeCapture.h
+++ b/Plugins/NativeCapture/Include/Babylon/Plugins/NativeCapture.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Plugins::NativeCapture
 {
-    void Initialize(Napi::Env env);
+    void BABYLON_API Initialize(Napi::Env env);
 }

--- a/Plugins/NativeCapture/Source/NativeCapture.cpp
+++ b/Plugins/NativeCapture/Source/NativeCapture.cpp
@@ -256,7 +256,7 @@ namespace Babylon::Plugins::Internal
 
 namespace Babylon::Plugins::NativeCapture
 {
-    void Initialize(Napi::Env env)
+    void BABYLON_API Initialize(Napi::Env env)
     {
         Babylon::Plugins::Internal::NativeCapture::Initialize(env);
     }

--- a/Plugins/NativeEngine/Include/Babylon/Plugins/NativeEngine.h
+++ b/Plugins/NativeEngine/Include/Babylon/Plugins/NativeEngine.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Plugins::NativeEngine
 {
-    void Initialize(Napi::Env env);
+    void BABYLON_API Initialize(Napi::Env env);
 }

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -400,7 +400,7 @@ namespace Babylon
         using CommandFunctionPointerT = void (NativeEngine::*)(NativeDataStream::Reader&);
     }
 
-    void NativeEngine::Initialize(Napi::Env env)
+    void BABYLON_API NativeEngine::Initialize(Napi::Env env)
     {
         // Initialize the JavaScript side.
         Napi::HandleScope scope{env};

--- a/Plugins/NativeInput/Include/Babylon/Plugins/NativeInput.h
+++ b/Plugins/NativeInput/Include/Babylon/Plugins/NativeInput.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Plugins
 {
@@ -9,8 +10,8 @@ namespace Babylon::Plugins
     public:
         // TODO: Ideally instances of these should be scoped to individual views within an env, but we don't yet support multi-view.
         // See https://github.com/BabylonJS/BabylonNative/issues/147
-        static NativeInput& CreateForJavaScript(Napi::Env);
-        static NativeInput& GetFromJavaScript(Napi::Env);
+        static NativeInput& BABYLON_API CreateForJavaScript(Napi::Env);
+        static NativeInput& BABYLON_API GetFromJavaScript(Napi::Env);
 
         void MouseDown(uint32_t buttonIndex, int32_t x, int32_t y);
         void MouseUp(uint32_t buttonIndex, int32_t x, int32_t y);

--- a/Plugins/NativeInput/Source/Shared/NativeInput.cpp
+++ b/Plugins/NativeInput/Source/Shared/NativeInput.cpp
@@ -42,13 +42,13 @@ namespace Babylon::Plugins
         env.Global().Set(JS_NATIVE_INPUT_NAME, nativeInput);
     }
 
-    NativeInput& NativeInput::CreateForJavaScript(Napi::Env env)
+    NativeInput& BABYLON_API NativeInput::CreateForJavaScript(Napi::Env env)
     {
         auto* nativeInput = new NativeInput(env);
         return *nativeInput;
     }
 
-    NativeInput& NativeInput::GetFromJavaScript(Napi::Env env)
+    NativeInput& BABYLON_API NativeInput::GetFromJavaScript(Napi::Env env)
     {
         return *env.Global().Get(JS_NATIVE_INPUT_NAME).As<Napi::External<NativeInput>>().Data();
     }

--- a/Plugins/NativeOptimizations/Include/Babylon/Plugins/NativeOptimizations.h
+++ b/Plugins/NativeOptimizations/Include/Babylon/Plugins/NativeOptimizations.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Plugins::NativeOptimizations
 {
-    void Initialize(Napi::Env env);
+    void BABYLON_API Initialize(Napi::Env env);
 }

--- a/Plugins/NativeOptimizations/Source/NativeOptimizations.cpp
+++ b/Plugins/NativeOptimizations/Source/NativeOptimizations.cpp
@@ -197,7 +197,7 @@ namespace
 
 namespace Babylon::Plugins::NativeOptimizations
 {
-    void Initialize(Napi::Env env)
+    void BABYLON_API Initialize(Napi::Env env)
     {
         auto nativeObject{JsRuntime::NativeObject::GetFromJavaScript(env)};
         nativeObject.Set("_TransformVector3Coordinates", Napi::Function::New(env, TransformVector3Coordinates, "_TransformVector3Coordinates"));

--- a/Plugins/NativeTracing/Include/Babylon/Plugins/NativeTracing.h
+++ b/Plugins/NativeTracing/Include/Babylon/Plugins/NativeTracing.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Plugins::NativeTracing
 {
-    void Initialize(Napi::Env env);
+    void BABYLON_API Initialize(Napi::Env env);
 }

--- a/Plugins/NativeTracing/Source/NativeTracing.cpp
+++ b/Plugins/NativeTracing/Source/NativeTracing.cpp
@@ -31,7 +31,7 @@ namespace
 
 namespace Babylon::Plugins::NativeTracing
 {
-    void Initialize(Napi::Env env)
+    void BABYLON_API Initialize(Napi::Env env)
     {
         auto nativeObject{JsRuntime::NativeObject::GetFromJavaScript(env)};
         nativeObject.Set("startPerformanceCounter", Napi::Function::New(env, StartPerformanceCounter, "startPerformanceCounter"));

--- a/Plugins/NativeXr/Include/Babylon/Plugins/NativeXr.h
+++ b/Plugins/NativeXr/Include/Babylon/Plugins/NativeXr.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Plugins
 {
@@ -17,7 +18,7 @@ namespace Babylon::Plugins
 
         ~NativeXr();
 
-        static NativeXr Initialize(Napi::Env env);
+        static NativeXr BABYLON_API Initialize(Napi::Env env);
 
         void UpdateWindow(void* windowPtr);
         void SetSessionStateChangedCallback(std::function<void(bool)> callback);

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -3517,7 +3517,7 @@ namespace Babylon
         {
         }
 
-        NativeXr NativeXr::Initialize(Napi::Env env)
+        NativeXr BABYLON_API NativeXr::Initialize(Napi::Env env)
         {
             auto impl{std::make_shared<Impl>(env)};
 

--- a/Plugins/TestUtils/Include/Babylon/Plugins/TestUtils.h
+++ b/Plugins/TestUtils/Include/Babylon/Plugins/TestUtils.h
@@ -6,5 +6,5 @@
 namespace Babylon::Plugins::TestUtils
 {
     extern int errorCode;
-    void Initialize(Napi::Env env, Graphics::WindowT window);
+    void BABYLON_API Initialize(Napi::Env env, Graphics::WindowT window);
 }

--- a/Plugins/TestUtils/Source/Win32/TestUtilsImpl.cpp
+++ b/Plugins/TestUtils/Source/Win32/TestUtilsImpl.cpp
@@ -52,7 +52,7 @@ namespace Babylon::Plugins::Internal
 
 namespace Babylon::Plugins::TestUtils
 {
-    void Initialize(Napi::Env env, Graphics::WindowT window)
+    void BABYLON_API Initialize(Napi::Env env, Graphics::WindowT window)
     {
         auto implData{std::make_shared<Internal::TestUtils::ImplData>(window)};
         Internal::TestUtils::CreateInstance(env, implData);

--- a/Plugins/TestUtils/Source/WinRT/TestUtilsImpl.cpp
+++ b/Plugins/TestUtils/Source/WinRT/TestUtilsImpl.cpp
@@ -27,7 +27,7 @@ namespace Babylon::Plugins::Internal
 
 namespace Babylon::Plugins::TestUtils
 {
-    void Initialize(Napi::Env env, Graphics::WindowT window)
+    void BABYLON_API Initialize(Napi::Env env, Graphics::WindowT window)
     {
         auto implData{std::make_shared<Internal::TestUtils::ImplData>(window)};
         Internal::TestUtils::CreateInstance(env, implData);

--- a/Polyfills/Canvas/Include/Babylon/Polyfills/Canvas.h
+++ b/Polyfills/Canvas/Include/Babylon/Polyfills/Canvas.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Polyfills
 {
@@ -20,7 +21,7 @@ namespace Babylon::Polyfills
         // This instance must live as long as the JS Runtime.
         // If JSRuntime is attached/detached (BabylonReactNative),
         // then this instance must live forever.
-        [[nodiscard]] static Canvas Initialize(Napi::Env env);
+        [[nodiscard]] static Canvas BABYLON_API Initialize(Napi::Env env);
 
         void FlushGraphicResources();
 

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -229,7 +229,7 @@ namespace Babylon::Polyfills
     {
     }
 
-    Canvas Canvas::Initialize(Napi::Env env)
+    Canvas BABYLON_API Canvas::Initialize(Napi::Env env)
     {
         auto impl{std::make_shared<Canvas::Impl>(env)};
 

--- a/Polyfills/Window/Include/Babylon/Polyfills/Window.h
+++ b/Polyfills/Window/Include/Babylon/Polyfills/Window.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Polyfills::Window
 {
-    void Initialize(Napi::Env env);
+    void BABYLON_API Initialize(Napi::Env env);
 }

--- a/Polyfills/Window/Source/Window.cpp
+++ b/Polyfills/Window/Source/Window.cpp
@@ -125,7 +125,7 @@ namespace Babylon::Polyfills::Internal
 
 namespace Babylon::Polyfills::Window
 {
-    void Initialize(Napi::Env env)
+    void BABYLON_API Initialize(Napi::Env env)
     {
         Internal::Window::Initialize(env);
     }


### PR DESCRIPTION
Without explicit calling convention modifers, consumers are required to compile with the same calling convention used in the released binaries. If a consumer compiles with the `__stdcall` calling convention, the linker won't resolve the function calls because the released binaries are built with the default `__cdecl` calling convention.

This change fixes the issue using an overridable `BABYLON_API` macro defined as `__cdecl` by default on Windows platforms or defined as empty on non-Windows platforms.

See also https://github.com/BabylonJS/JsRuntimeHost/pull/86.