### PR TITLE
Update to latest bgfx.cmake

### DIFF
--- a/.github/jobs/ios.yml
+++ b/.github/jobs/ios.yml
@@ -1,8 +1,7 @@
 parameters:
   name: ''
   vmImage: ''
-  xCodeVersion: ''
-  macOSCodename: ''
+  xcodeVersion: ''
   deploymentTarget: '12'
 
 jobs:
@@ -17,8 +16,8 @@ jobs:
         vmImage: ${{ parameters.vmImage }}
 
     - script: |
-        sudo xcode-select --switch /Applications/Xcode_${{ parameters.xCodeVersion }}.app/Contents/Developer
-      displayName: 'Select XCode ${{ parameters.xCodeVersion }}'
+        sudo xcode-select --switch /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
+      displayName: 'Select Xcode ${{ parameters.xcodeVersion }}'
 
     - script: |
         mkdir buildiOS

--- a/.github/jobs/macos.yml
+++ b/.github/jobs/macos.yml
@@ -1,9 +1,8 @@
 parameters:
   name: ''
   vmImage: ''
-  xCodeVersion: ''
-  macOSCodename: ''
-  
+  xcodeVersion: ''
+
 jobs:
   - job: ${{ parameters.name }}
     timeoutInMinutes: 30
@@ -16,8 +15,8 @@ jobs:
         vmImage: ${{ parameters.vmImage }}
 
     - script: |
-        sudo xcode-select --switch /Applications/Xcode_${{ parameters.xCodeVersion }}.app/Contents/Developer
-      displayName: 'Select XCode ${{ parameters.xCodeVersion }}'
+        sudo xcode-select --switch /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
+      displayName: 'Select XCode ${{ parameters.xcodeVersion }}'
 
     - script: |
         mkdir buildmacOS
@@ -46,4 +45,4 @@ jobs:
     - script: |
         cd buildmacOS/Apps/UnitTests/RelWithDebInfo
         ./UnitTests
-      displayName: 'Run UnitTests MacOS'
+      displayName: 'Run UnitTests macOS'

--- a/Apps/Playground/Android/app/CMakeLists.txt
+++ b/Apps/Playground/Android/app/CMakeLists.txt
@@ -1,42 +1,21 @@
-cmake_minimum_required(VERSION 3.13.2)
-# set targetPlatform, will be passed in from gradle when this sample is completed
-# openGL Supportability
-# platform         status
-#   (0 12)           ES2/ES3 not supported
-#   [12, 18)         ES2 only; for ES3, app do dynamic load/detection
-#                    this applies to the situations that:
-#                        - minimum API is set to less than 18. In this case
-#                          there is no ES3 header/lib support inside NDK
-#                        - the built APK might be running on newer API phones
-#                    with dynamic loading of ES3, the same APK would still be able
-#                    to use ES3. Otherwise, app would stuck with ES2 even phone is
-#                    is newer than the minimum API level (for example, Android-27 etc).
-#
-#   [18, 24)         ES2 & ES3
-#                    If app is built to only support API-18 or later,
-#                    set minimum api level to 18 is good enough, NDK supprts ES3
-#                    with the right header and lib files. No need to use ES3 dynamic
-#                    detection.
-#   [24, infinite)   ES2 & ES3 & Vulkan
-project(BabylonNative)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
-set(BABYLON_NATIVE_PLATFORM "Android")
+cmake_minimum_required(VERSION 3.18)
+
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-add_library(javascript_engine SHARED IMPORTED GLOBAL)
-set_target_properties(javascript_engine PROPERTIES IMPORTED_LOCATION "${ANDROID_JSENGINE_LIBPATH}/${ANDROID_ABI}/lib${ANDROID_JSENGINE_LIBNAME}.so")
-target_include_directories(javascript_engine INTERFACE "${ANDROID_JSENGINE_INCPATH}")
+project(BabylonNative)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/src/")
+get_filename_component(PLAYGROUND_DIR "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+get_filename_component(REPO_ROOT_DIR "${PLAYGROUND_DIR}/../.." ABSOLUTE)
 
-set(BABYLON_NATIVE_PLAYGROUND_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
-add_subdirectory(${BABYLON_NATIVE_PLAYGROUND_DIR}/../../ ${BABYLON_NATIVE_PLAYGROUND_DIR}/../../build/Android_${CMAKE_ANDROID_ARCH_ABI}/)
+add_subdirectory(${REPO_ROOT_DIR} "${CMAKE_CURRENT_BINARY_DIR}/BabylonNative")
+
 
 add_library(BabylonNativeJNI SHARED
     src/main/cpp/BabylonNativeJNI.cpp)
 
 target_include_directories(BabylonNativeJNI
-    PRIVATE ${BABYLON_NATIVE_PLAYGROUND_DIR}/Shared)
+    PRIVATE ${PLAYGROUND_DIR}/Shared)
 
 target_link_libraries(BabylonNativeJNI
     GLESv3

--- a/Apps/Playground/Android/app/build.gradle
+++ b/Apps/Playground/Android/app/build.gradle
@@ -42,7 +42,6 @@ android {
                     "-DGRAPHICS_API=${graphics_api}",
                     "-DARCORE_LIBPATH=${arcore_libpath}/jni",
                     "-DNAPI_JAVASCRIPT_ENGINE=${jsEngine}",
-                    "-DJSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR=ON",
                     "-DBABYLON_NATIVE_BUILD_APPS=ON",
                     "-DCMAKE_UNITY_BUILD=${unity_build}"
             }
@@ -71,6 +70,7 @@ android {
         cmake {
             version '3.19.6+'
             path 'CMakeLists.txt'
+            buildStagingDirectory "../../../../Build/Android"
         }
     }
     packagingOptions {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ FetchContent_Declare(base-n
     GIT_TAG 7573e77c0b9b0e8a5fb63d96dbde212c921993b4)
 FetchContent_Declare(bgfx.cmake
     GIT_REPOSITORY https://github.com/BabylonJS/bgfx.cmake.git
-    GIT_TAG 756234edf3105d6551fdfccd67570962d1641ef9)
+    GIT_TAG 345e3e28a9912983fc64d1dcb4da22a445afe3fd)
 FetchContent_Declare(CMakeExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/CMakeExtensions.git
     GIT_TAG ea28b7689530bfdc4905806f27ecf7e8ed4b5419)

--- a/Polyfills/Canvas/Source/nanovg_babylon.cpp
+++ b/Polyfills/Canvas/Source/nanovg_babylon.cpp
@@ -270,14 +270,7 @@ namespace
         gl->u_params          = bgfx::createUniform("u_params",          bgfx::UniformType::Vec4);
         gl->s_tex             = bgfx::createUniform("s_tex",             bgfx::UniformType::Sampler);
 
-        if (bgfx::getRendererType() == bgfx::RendererType::Direct3D9)
-        {
-            gl->u_halfTexel   = bgfx::createUniform("u_halfTexel",       bgfx::UniformType::Vec4);
-        }
-        else
-        {
-            gl->u_halfTexel.idx = bgfx::kInvalidHandle;
-        }
+        gl->u_halfTexel.idx = bgfx::kInvalidHandle;
 
         s_nvgLayout
             .begin()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,30 +16,23 @@ jobs:
 # Apple
   - template: .github/jobs/macos.yml
     parameters:
-      name: MacOS_Xcode1341
-      vmImage: 'macOS-latest'
-      xCodeVersion: 13.4.1
+      name: MacOS_Xcode153
+      vmImage: 'macOS-14'
+      xCodeVersion: 15.3
 
   - template: .github/jobs/ios.yml
     parameters:
-      name: iOS_Xcode1341_iOS155
-      vmImage: 'macOS-latest'
-      xCodeVersion: 13.4.1
-      deploymentTarget: 15.5
-
-  - template: .github/jobs/ios.yml
-    parameters:
-      name: iOS_Xcode142_iOS162
-      vmImage: 'macOS-latest'
-      xCodeVersion: 14.2
+      name: iOS_Xcode153_iOS162
+      vmImage: 'macOS-14'
+      xCodeVersion: 15.3
       deploymentTarget: 16.2
 
   - template: .github/jobs/ios.yml
     parameters:
-      name: iOS_Xcode15_iOS17
-      vmImage: 'macOS-13'
-      xCodeVersion: 15.0
-      deploymentTarget: 17.0
+      name: iOS_Xcode153_iOS172
+      vmImage: 'macOS-14'
+      xCodeVersion: 15.3
+      deploymentTarget: 17.2
 
 # WIN32
   - template: .github/jobs/win32.yml


### PR DESCRIPTION
See https://forum.babylonjs.com/t/pixel-8-pro-crash/48956. Specifically, the fix that makes the code work is https://github.com/bkaradzic/bgfx/pull/3187.

This change also:
- Cleans up the Android build such that the build output goes to the `Build/Android` folder.
- Update CI to latest Xcode since the old compilers no longer compile with latest bgfx.