### PR TITLE
Fix ownership of color texture when creating a frame buffer

### DIFF
--- a/Core/Graphics/InternalInclude/Babylon/Graphics/FrameBuffer.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/FrameBuffer.h
@@ -41,7 +41,7 @@ namespace Babylon::Graphics
         void SetScissor(bgfx::Encoder& encoder, float x, float y, float width, float height);
         void Submit(bgfx::Encoder& encoder, bgfx::ProgramHandle programHandle, uint8_t flags);
         void SetStencil(bgfx::Encoder& encoder, uint32_t stencilState);
-        void Blit(bgfx::Encoder& encoder, bgfx::TextureHandle _dst, uint16_t _dstX, uint16_t _dstY, bgfx::TextureHandle _src, uint16_t _srcX = 0, uint16_t _srcY = 0, uint16_t _width = UINT16_MAX, uint16_t _height = UINT16_MAX);
+        void Blit(bgfx::Encoder& encoder, bgfx::TextureHandle dst, uint16_t dstX, uint16_t dstY, bgfx::TextureHandle src, uint16_t srcX = 0, uint16_t srcY = 0, uint16_t width = UINT16_MAX, uint16_t height = UINT16_MAX);
 
         bool HasDepth() const { return m_hasDepth; }
         bool HasStencil() const { return m_hasStencil; }

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
@@ -26,7 +26,6 @@ namespace Babylon::Graphics
         void UpdateCube(uint16_t layer, uint8_t side, uint8_t mip, uint16_t x, uint16_t y, uint16_t width, uint16_t height, const bgfx::Memory* mem, uint16_t pitch = UINT16_MAX);
 
         void Attach(bgfx::TextureHandle handle, bool ownsHandle, uint16_t width, uint16_t height, bool hasMips, uint16_t numLayers, bgfx::TextureFormat::Enum format, uint64_t flags);
-        void Disown();
 
         bgfx::TextureHandle Handle() const;
         uint16_t Width() const;

--- a/Core/Graphics/Source/Texture.cpp
+++ b/Core/Graphics/Source/Texture.cpp
@@ -84,12 +84,6 @@ namespace Babylon::Graphics
         m_flags = flags;
     }
 
-    void Texture::Disown()
-    {
-        assert(m_ownsHandle);
-        m_ownsHandle = false;
-    }
-
     bgfx::TextureHandle Texture::Handle() const
     {
         return m_handle;


### PR DESCRIPTION
The changes in https://github.com/BabylonJS/Babylon.js/pull/15052 exposes a problem in native where the output texture of the BRDF post process will be destroyed causing a crash in bgfx.

In the previous code, the `NativeEngine::CreateFrameBuffer` took ownership of the color texture passed in as an argument. This is wrong because the texture might still be needed after the frame buffer dies. Specifically, [the BRDF post process that expands the RGBD env texture](https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/core/src/Misc/rgbdTextureTools.ts#L98) is where it fails.

The new code will not take ownership of the color texture but will still delete the generated depth/stencil texture in the finalizer if necessary. The calling code will destroy the color texture when appropriate.