### PR TITLE
fix xrView visibility iOS

### DIFF
--- a/Apps/Playground/iOS/ViewController.swift
+++ b/Apps/Playground/iOS/ViewController.swift
@@ -126,7 +126,7 @@ class ViewController: UIViewController {
 extension ViewController: MTKViewDelegate {
     func draw(in view: MTKView) {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-        xrView.isHidden = appDelegate._bridge?.isXRActive() ?? false
+        xrView.isHidden = !(appDelegate._bridge?.isXRActive() ?? false)
         appDelegate._bridge?.render()
     }
     


### PR DESCRIPTION
Fix bug introduced with https://github.com/BabylonJS/BabylonNative/pull/1368 
xrView.isHidden was not the intended value.
I've kept the syntax proposed by @okwasniewski
idk if it's the 'correct' and standard way to do it.
cc @Allan121

fixes #1379 