### PR TITLE
Android D24S8 for depthbuffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ project(BabylonNative)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # --------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ project(BabylonNative)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # --------------------------------------------------

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1829,7 +1829,15 @@ namespace Babylon
             }
 
             auto flags = BGFX_TEXTURE_RT_WRITE_ONLY | RenderTargetSamplesToBgfxMsaaFlag(samples);
+#ifdef ANDROID
+            // On Android with Mali GPU (Oppo Find x5 lite, Google Pixel 8, Samsung Galaxy Tab Active 3, ...)
+            // D32 depth buffer gives glitches. Everything is fine with D24S8.
+            // see https://forum.babylonjs.com/t/post-processing-graphics-glitch/49523
+            // As 24bits should be enough for 99.99% cases, defaulting to that format on Android.
+            const auto depthStencilFormat{bgfx::TextureFormat::D24S8};
+#else
             const auto depthStencilFormat{generateStencilBuffer ? bgfx::TextureFormat::D24S8 : bgfx::TextureFormat::D32};
+#endif
             assert(bgfx::isTextureValid(0, false, 1, depthStencilFormat, flags));
             depthStencilTextureHandle = bgfx::createTexture2D(width, height, false, 1, depthStencilFormat, flags);
 


### PR DESCRIPTION
follow up https://forum.babylonjs.com/t/post-processing-graphics-glitch/49523/35
![image](https://github.com/BabylonJS/BabylonNative/assets/1312968/db779144-3d14-4f5d-b621-20e45923cc34)
tldr: glitches with Arm Mali GPU and 32b depth buffer.
fix: replace D32 with D24S8

fixes #1381 