### PR TITLE
Async shader compilation + shutdown crash repro

### DIFF
--- a/Apps/UnitTests/Shared/Shared.cpp
+++ b/Apps/UnitTests/Shared/Shared.cpp
@@ -170,7 +170,7 @@ TEST(Shutdown, AsyncShaderCompilation)
 
     // this sleep makes sure shader is finished loading/compiling before exit.
     // Once shutdown is fixed, remove this sleep call.
-    std::this_thread::sleep_for(std::chrono::seconds(5));
+    std::this_thread::sleep_for(std::chrono::seconds(60));
 }
 
 TEST(Performance, Spheres)

--- a/Apps/UnitTests/Shared/Shared.cpp
+++ b/Apps/UnitTests/Shared/Shared.cpp
@@ -170,7 +170,7 @@ TEST(Shutdown, AsyncShaderCompilation)
 
     // this sleep makes sure shader is finished loading/compiling before exit.
     // Once shutdown is fixed, remove this sleep call.
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 }
 
 TEST(Performance, Spheres)

--- a/Apps/UnitTests/Shared/Shared.cpp
+++ b/Apps/UnitTests/Shared/Shared.cpp
@@ -98,6 +98,9 @@ TEST(JavaScript, All)
     EXPECT_EQ(exitCode, 0);
 }
 
+/*
+Repro for shutdown scenario
+Engine is shutdown before shader is finished compiling
 TEST(Shutdown, AsyncShaderCompilation)
 {
     std::promise<int32_t> exitCodePromise;
@@ -167,11 +170,8 @@ TEST(Shutdown, AsyncShaderCompilation)
 
     update.Finish();
     device.FinishRenderingCurrentFrame();
-
-    // this sleep makes sure shader is finished loading/compiling before exit.
-    // Once shutdown is fixed, remove this sleep call.
-    std::this_thread::sleep_for(std::chrono::seconds(60));
 }
+*/
 
 TEST(Performance, Spheres)
 {


### PR DESCRIPTION
Shutdown with async shader compilation crash repro. 
Left as commented code: I was unable to expect a crash with GoogleTest and adding a `sleep` call to get sufficient time for shaders to be compiled was unreliable.