### PR TITLE
Update to Babylon.js 7.12.0

### DIFF
--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -101,6 +101,9 @@
             currentScene = null;
             engine.setHardwareScalingLevel(1);
 
+            // This is necessary because of https://github.com/BabylonJS/Babylon.js/pull/15217 so that each test starts fresh.
+            engine.releaseEffects();
+
             done(testRes);
         });
     }

--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -8,11 +8,11 @@
       "name": "BabylonNative",
       "version": "0.0.1",
       "dependencies": {
-        "babylonjs": "^7.7.2",
-        "babylonjs-gltf2interface": "^7.7.2",
-        "babylonjs-gui": "^7.7.2",
-        "babylonjs-loaders": "^7.7.2",
-        "babylonjs-materials": "^7.7.2",
+        "babylonjs": "^7.12.0",
+        "babylonjs-gltf2interface": "^7.12.0",
+        "babylonjs-gui": "^7.12.0",
+        "babylonjs-loaders": "^7.12.0",
+        "babylonjs-materials": "^7.12.0",
         "chai": "^4.3.4",
         "jsc-android": "^241213.1.0",
         "mocha": "^9.2.2",
@@ -80,39 +80,39 @@
       }
     },
     "node_modules/babylonjs": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-7.7.2.tgz",
-      "integrity": "sha512-AemUouWTXi1lELOOlMucpk597u6q1XjjFQw788Z/xbiIHMQFZtf+Jp45wYcxYH8dzqExhQW4y2gvXHWEstIShQ==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-7.12.0.tgz",
+      "integrity": "sha512-ZtGlJdtcLROTxdm/9Y/67yyrv/0prRzCGwzVAEugVXdU8/ZNWrkBjq/q+1BoSsoEGZSo2+xsyLjNafm/bCTuWA==",
       "hasInstallScript": true
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-7.7.2.tgz",
-      "integrity": "sha512-ABNWCbJgDME6KIW57MHzf1oJY3R0HhuWERhdmeYBcGmhiXuTrZRNyWeGRTMBmFpdHNDVHzsz1Uf1W+/G/Y3UEQ=="
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-7.12.0.tgz",
+      "integrity": "sha512-uyQO8DQm4X5z24SSyQU0G1M/hQBaA9qDP8rU0ly3IW+WT+K9JpuZxE7wKFO7Ig7UkMafdCJ6UHCam7iscALzYw=="
     },
     "node_modules/babylonjs-gui": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-7.7.2.tgz",
-      "integrity": "sha512-n/GYi/dO7FgEnEJm4MQEiNiJ9Sy/4+W+ref/2yecw66mBaHntGXPJ2HlQTxDMco79pRDwvR7RASq6gbtXoUUqw==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-7.12.0.tgz",
+      "integrity": "sha512-yyJer0IlLrp7cm7PhXLuBcFIZlawL63H2fpelukAxPfe/6MsB8PCDtLkrlwSTTvz1B6Q3k9KwI1yhPRA4eWMHA==",
       "dependencies": {
-        "babylonjs": "^7.7.2"
+        "babylonjs": "^7.12.0"
       }
     },
     "node_modules/babylonjs-loaders": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-7.7.2.tgz",
-      "integrity": "sha512-n9ox96ldfPwwsoqFUZ5OQnbuA46F6R4CS39o40yJoj6Wf/EEUNCuqSuBv2in0tVWTP/yLQ9/cpSzL2kXQK2ZYg==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-7.12.0.tgz",
+      "integrity": "sha512-IOXx0h1FSjMh4V3MKEteHePrRA9T28ich1a5zMGIi9mSdftcft6xW9/YRjlhVENn/8S7zEsz+mmthTmIx/YjMw==",
       "dependencies": {
-        "babylonjs": "^7.7.2",
-        "babylonjs-gltf2interface": "^7.7.2"
+        "babylonjs": "^7.12.0",
+        "babylonjs-gltf2interface": "^7.12.0"
       }
     },
     "node_modules/babylonjs-materials": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-7.7.2.tgz",
-      "integrity": "sha512-EUebux/5wjDkRl/hPiY6oQf3QjdKAQVBi+hOEMA6bxUu2H1V0Uzme59kyG8EwFUdWrNMI0ZsYITEIaPKmhjpcA==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-7.12.0.tgz",
+      "integrity": "sha512-GpHaJPfLF2Rh8dD13zBwL8+REqwiLOLhNSUPZaue4XXugHimImIf0zFwfXDUTdzxLgNLRQdbOVOEHr1IK+tWaw==",
       "dependencies": {
-        "babylonjs": "^7.7.2"
+        "babylonjs": "^7.12.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1038,38 +1038,38 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "babylonjs": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-7.7.2.tgz",
-      "integrity": "sha512-AemUouWTXi1lELOOlMucpk597u6q1XjjFQw788Z/xbiIHMQFZtf+Jp45wYcxYH8dzqExhQW4y2gvXHWEstIShQ=="
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-7.12.0.tgz",
+      "integrity": "sha512-ZtGlJdtcLROTxdm/9Y/67yyrv/0prRzCGwzVAEugVXdU8/ZNWrkBjq/q+1BoSsoEGZSo2+xsyLjNafm/bCTuWA=="
     },
     "babylonjs-gltf2interface": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-7.7.2.tgz",
-      "integrity": "sha512-ABNWCbJgDME6KIW57MHzf1oJY3R0HhuWERhdmeYBcGmhiXuTrZRNyWeGRTMBmFpdHNDVHzsz1Uf1W+/G/Y3UEQ=="
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-7.12.0.tgz",
+      "integrity": "sha512-uyQO8DQm4X5z24SSyQU0G1M/hQBaA9qDP8rU0ly3IW+WT+K9JpuZxE7wKFO7Ig7UkMafdCJ6UHCam7iscALzYw=="
     },
     "babylonjs-gui": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-7.7.2.tgz",
-      "integrity": "sha512-n/GYi/dO7FgEnEJm4MQEiNiJ9Sy/4+W+ref/2yecw66mBaHntGXPJ2HlQTxDMco79pRDwvR7RASq6gbtXoUUqw==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-7.12.0.tgz",
+      "integrity": "sha512-yyJer0IlLrp7cm7PhXLuBcFIZlawL63H2fpelukAxPfe/6MsB8PCDtLkrlwSTTvz1B6Q3k9KwI1yhPRA4eWMHA==",
       "requires": {
-        "babylonjs": "^7.7.2"
+        "babylonjs": "^7.12.0"
       }
     },
     "babylonjs-loaders": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-7.7.2.tgz",
-      "integrity": "sha512-n9ox96ldfPwwsoqFUZ5OQnbuA46F6R4CS39o40yJoj6Wf/EEUNCuqSuBv2in0tVWTP/yLQ9/cpSzL2kXQK2ZYg==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-7.12.0.tgz",
+      "integrity": "sha512-IOXx0h1FSjMh4V3MKEteHePrRA9T28ich1a5zMGIi9mSdftcft6xW9/YRjlhVENn/8S7zEsz+mmthTmIx/YjMw==",
       "requires": {
-        "babylonjs": "^7.7.2",
-        "babylonjs-gltf2interface": "^7.7.2"
+        "babylonjs": "^7.12.0",
+        "babylonjs-gltf2interface": "^7.12.0"
       }
     },
     "babylonjs-materials": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-7.7.2.tgz",
-      "integrity": "sha512-EUebux/5wjDkRl/hPiY6oQf3QjdKAQVBi+hOEMA6bxUu2H1V0Uzme59kyG8EwFUdWrNMI0ZsYITEIaPKmhjpcA==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-7.12.0.tgz",
+      "integrity": "sha512-GpHaJPfLF2Rh8dD13zBwL8+REqwiLOLhNSUPZaue4XXugHimImIf0zFwfXDUTdzxLgNLRQdbOVOEHr1IK+tWaw==",
       "requires": {
-        "babylonjs": "^7.7.2"
+        "babylonjs": "^7.12.0"
       }
     },
     "balanced-match": {

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -6,11 +6,11 @@
     "getNightly": "node scripts/getNightly.js"
   },
   "dependencies": {
-    "babylonjs": "^7.7.2",
-    "babylonjs-gltf2interface": "^7.7.2",
-    "babylonjs-gui": "^7.7.2",
-    "babylonjs-loaders": "^7.7.2",
-    "babylonjs-materials": "^7.7.2",
+    "babylonjs": "^7.12.0",
+    "babylonjs-gltf2interface": "^7.12.0",
+    "babylonjs-gui": "^7.12.0",
+    "babylonjs-loaders": "^7.12.0",
+    "babylonjs-materials": "^7.12.0",
     "chai": "^4.3.4",
     "jsc-android": "^241213.1.0",
     "mocha": "^9.2.2",


### PR DESCRIPTION
Due to https://github.com/BabylonJS/Babylon.js/pull/15217, we have to call `engine.releaseEffects` before every test to make sure it starts fresh.