### PR TITLE
Update polyfills documentation links

### DIFF
--- a/Documentation/Polyfills.md
+++ b/Documentation/Polyfills.md
@@ -1,10 +1,8 @@
 # Babylon Native Polyfills
-Babylon Native Polyfills add support for certain JavaScript browser APIs, such as [`canvas`](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API) and [`window`](https://developer.mozilla.org/en-US/docs/Web/API/console). They do not attempt to fulfill the web specification exactly, nor do they mirror the behavior of browsers. The polyfills only provide functionality that is either required by Babylon.js, or would be frequently used by Babylon developers.
+Babylon Native Polyfills add support for certain JavaScript browser APIs, such as [`canvas`](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API) and [`window`](https://developer.mozilla.org/en-US/docs/Web/API/Window). They do not attempt to fulfill the web specification exactly, nor do they mirror the behavior of browsers. The polyfills only provide functionality that is either required by Babylon.js, or would be frequently used by Babylon developers.
 
 The polyfills are still in an early stage and are subject to change.
 
 At the moment, we are using the following polyfills:
-* [Canvas](../Polyfills/Canvas/readme.md)
-* [Console](../Polyfills/Console/readme.md)
-* [Window](../Polyfills/Window/readme.md)
-* [XMLHttpRequest](../Polyfills/XMLHttpRequest/readme.md)
+* [Canvas](../Polyfills/Canvas/Readme.md)
+* [Window](../Polyfills/Window/Readme.md)


### PR DESCRIPTION
### Description:
This pull request updates the Babylon Native Polyfills documentation to correct broken links and update references to the polyfills currently in use.

### Changes Made:
1. Corrected the link to the `window` API in the documentation.
2. Removed non-existent polyfill references for `Console` and `XMLHttpRequest`.
3. Corrected the paths for existing polyfill documentation links for `Canvas` and `Window`.

### Updated Documentation:

**Old:**
```markdown
# Babylon Native Polyfills
Babylon Native Polyfills add support for certain JavaScript browser APIs, such as [`canvas`](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API) and [`window`](https://developer.mozilla.org/en-US/docs/Web/API/console). They do not attempt to fulfill the web specification exactly, nor do they mirror the behavior of browsers. The polyfills only provide functionality that is either required by Babylon.js, or would be frequently used by Babylon developers.

The polyfills are still in an early stage and are subject to change.

At the moment, we are using the following polyfills:
* [Canvas](../Polyfills/Canvas/readme.md)
* [Console](../Polyfills/Console/readme.md)
* [Window](../Polyfills/Window/readme.md)
* [XMLHttpRequest](../Polyfills/XMLHttpRequest/readme.md)
```

**New:**
```markdown
# Babylon Native Polyfills
Babylon Native Polyfills add support for certain JavaScript browser APIs, such as [`canvas`](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API) and [`window`](https://developer.mozilla.org/en-US/docs/Web/API/Window). They do not attempt to fulfill the web specification exactly, nor do they mirror the behavior of browsers. The polyfills only provide functionality that is either required by Babylon.js, or would be frequently used by Babylon developers.

The polyfills are still in an early stage and are subject to change.

At the moment, we are using the following polyfills:
* [Canvas](../Polyfills/Canvas/Readme.md)
* [Window](../Polyfills/Window/Readme.md)
```

### Rationale:
- The link to the `window` API was incorrectly pointing to the `console` API.
- References to non-existent polyfills have been removed to avoid confusion.
- Paths to the `Canvas` and `Window` polyfill documentation have been corrected to ensure accurate navigation.

