### PR TITLE
track XDisplay and propagate to bgfx

### DIFF
--- a/Core/Graphics/Include/Platform/Unix/Babylon/Graphics/Platform.h
+++ b/Core/Graphics/Include/Platform/Unix/Babylon/Graphics/Platform.h
@@ -2,7 +2,9 @@
 
 #include <X11/Xlib.h>
 
+#include <tuple>
+
 namespace Babylon::Graphics
 {
-    using WindowT = Window;
+    using WindowT = std::tuple<Window, Display*>;
 }

--- a/Core/Graphics/Source/DeviceImpl_Unix.cpp
+++ b/Core/Graphics/Source/DeviceImpl_Unix.cpp
@@ -5,19 +5,20 @@ namespace Babylon::Graphics
 {
     void DeviceImpl::ConfigureBgfxPlatformData(bgfx::PlatformData& pd, WindowT window)
     {
-        pd.nwh = reinterpret_cast<void*>(window);
+        pd.nwh = reinterpret_cast<void*>(std::get<0>(window));
+        pd.ndt = reinterpret_cast<void*>(std::get<1>(window));
     }
 
     void DeviceImpl::ConfigureBgfxRenderType(bgfx::PlatformData& /*pd*/, bgfx::RendererType::Enum& /*renderType*/)
     {
     }
 
-    float DeviceImpl::GetDevicePixelRatio(WindowT)
+    float DeviceImpl::GetDevicePixelRatio(WindowT window)
     {
         // TODO: We should persist a Display object instead of opening a new display.
         // See https://github.com/BabylonJS/BabylonNative/issues/625
 
-        auto display = XOpenDisplay(nullptr);
+        auto display = std::get<1>(window);
         auto screen = DefaultScreen(display);
 
         auto width = DisplayWidthMM(display, screen);


### PR DESCRIPTION
I'm not sure what opening these extra XDisplays does, but it appears to happen here and down in bgfx when the context is initialized.  Instead, store the display alongside the Window. 