### PR TITLE
Add ability to override texture format in ExternalTexture

### DIFF
--- a/Core/Graphics/Include/RendererType/D3D11/Babylon/Graphics/RendererType.h
+++ b/Core/Graphics/Include/RendererType/D3D11/Babylon/Graphics/RendererType.h
@@ -6,6 +6,7 @@ namespace Babylon::Graphics
 {
     using DeviceT = ID3D11Device*;
     using TextureT = ID3D11Resource*;
+    using TextureFormatT = DXGI_FORMAT;
 
     struct DeviceConfiguration
     {

--- a/Core/Graphics/Include/RendererType/D3D12/Babylon/Graphics/RendererType.h
+++ b/Core/Graphics/Include/RendererType/D3D12/Babylon/Graphics/RendererType.h
@@ -6,6 +6,7 @@ namespace Babylon::Graphics
 {
     using DeviceT = ID3D12Device*;
     using TextureT = ID3D12Resource*;
+    using TextureFormatT = DXGI_FORMAT;
 
     struct DeviceConfiguration
     {

--- a/Core/Graphics/Include/RendererType/Metal/Babylon/Graphics/RendererType.h
+++ b/Core/Graphics/Include/RendererType/Metal/Babylon/Graphics/RendererType.h
@@ -6,6 +6,7 @@ namespace Babylon::Graphics
 {
     using DeviceT = id<MTLDevice>;
     using TextureT = id<MTLTexture>;
+    using TextureFormatT = MTLPixelFormat;
 
     struct DeviceConfiguration
     {

--- a/Core/Graphics/Include/RendererType/OpenGL/Babylon/Graphics/RendererType.h
+++ b/Core/Graphics/Include/RendererType/OpenGL/Babylon/Graphics/RendererType.h
@@ -6,6 +6,7 @@ namespace Babylon::Graphics
 {
     using DeviceT = EGLContext;
     using TextureT = unsigned int;
+    using TextureFormatT = unsigned int;
 
     struct DeviceConfiguration
     {

--- a/Install/Install.cmake
+++ b/Install/Install.cmake
@@ -86,7 +86,7 @@ install_targets(napi)
 install_include_for_targets(napi)
 
 if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8" AND JSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR)
-    install_targets(v8inspector)
+    install_targets(llhttp_static v8inspector)
 endif()
 
 # Manually install the JSI headers

--- a/Plugins/ExternalTexture/Include/Babylon/Plugins/ExternalTexture.h
+++ b/Plugins/ExternalTexture/Include/Babylon/Plugins/ExternalTexture.h
@@ -3,6 +3,7 @@
 #include <Babylon/JsRuntime.h>
 #include <Babylon/Graphics/RendererType.h>
 #include <memory>
+#include <optional>
 
 namespace Babylon::Plugins
 {
@@ -10,7 +11,7 @@ namespace Babylon::Plugins
     {
     public:
         // NOTE: Must call from the Graphics thread.
-        ExternalTexture(Graphics::TextureT);
+        ExternalTexture(Graphics::TextureT, std::optional<Graphics::TextureFormatT> = {});
         ~ExternalTexture();
 
         // Copy semantics
@@ -34,7 +35,7 @@ namespace Babylon::Plugins
         // Updates to a new texture.
         // Texture attributes (width, height, format, etc.) must match.
         // NOTE: Must call from the Graphics thread.
-        void Update(Graphics::TextureT);
+        void Update(Graphics::TextureT, std::optional<Graphics::TextureFormatT> = {});
 
     private:
         class Impl;

--- a/Plugins/ExternalTexture/Source/ExternalTexture_D3D11.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_D3D11.cpp
@@ -158,8 +158,8 @@ namespace Babylon::Plugins
     {
     public:
         // Implemented in ExternalTexture_Shared.h
-        Impl(Graphics::TextureT);
-        void Update(Graphics::TextureT);
+        Impl(Graphics::TextureT, std::optional<Graphics::TextureFormatT>);
+        void Update(Graphics::TextureT, std::optional<Graphics::TextureFormatT>);
 
         uintptr_t Ptr() const
         {
@@ -167,7 +167,7 @@ namespace Babylon::Plugins
         }
 
     private:
-        static void GetInfo(Graphics::TextureT ptr, Info& info)
+        static void GetInfo(Graphics::TextureT ptr, std::optional<Graphics::TextureFormatT> overrideFormat, Info& info)
         {
             winrt::com_ptr<ID3D11Resource> resource;
             resource.copy_from(ptr);
@@ -196,13 +196,14 @@ namespace Babylon::Plugins
                 }
             }
 
+            DXGI_FORMAT targetFormat = overrideFormat.has_value() ? overrideFormat.value() : desc.Format;
             for (int i = 0; i < BX_COUNTOF(s_textureFormat); ++i)
             {
                 const auto& format = s_textureFormat[i];
-                if (format.m_fmt == desc.Format || format.m_fmtSrgb == desc.Format)
+                if (format.m_fmt == targetFormat || format.m_fmtSrgb == targetFormat)
                 {
                     info.Format = static_cast<bgfx::TextureFormat::Enum>(i);
-                    if (format.m_fmtSrgb == desc.Format)
+                    if (format.m_fmtSrgb == targetFormat)
                     {
                         info.Flags |= BGFX_TEXTURE_SRGB;
                     }

--- a/Plugins/ExternalTexture/Source/ExternalTexture_D3D12.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_D3D12.cpp
@@ -158,8 +158,8 @@ namespace Babylon::Plugins
     {
     public:
         // Implemented in ExternalTexture_Shared.h
-        Impl(Graphics::TextureT);
-        void Update(Graphics::TextureT);
+        Impl(Graphics::TextureT, std::optional<Graphics::TextureFormatT>);
+        void Update(Graphics::TextureT, std::optional<Graphics::TextureFormatT>);
 
         uintptr_t Ptr() const
         {
@@ -167,7 +167,7 @@ namespace Babylon::Plugins
         }
 
     private:
-        static void GetInfo(Graphics::TextureT ptr, Info& info)
+        static void GetInfo(Graphics::TextureT ptr, std::optional<Graphics::TextureFormatT> overrideFormat, Info& info)
         {
             D3D12_RESOURCE_DESC desc = ptr->GetDesc();
 
@@ -190,13 +190,14 @@ namespace Babylon::Plugins
                 }
             }
 
+            DXGI_FORMAT targetFormat = overrideFormat.has_value() ? overrideFormat.value() : desc.Format;
             for (int i = 0; i < BX_COUNTOF(s_textureFormat); ++i)
             {
                 const auto& format = s_textureFormat[i];
-                if (format.m_fmt == desc.Format || format.m_fmtSrgb == desc.Format)
+                if (format.m_fmt == targetFormat || format.m_fmtSrgb == targetFormat)
                 {
                     info.Format = static_cast<bgfx::TextureFormat::Enum>(i);
-                    if (format.m_fmtSrgb == desc.Format)
+                    if (format.m_fmtSrgb == targetFormat)
                     {
                         info.Flags |= BGFX_TEXTURE_SRGB;
                     }

--- a/Plugins/ExternalTexture/Source/ExternalTexture_Metal.mm
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Metal.mm
@@ -144,8 +144,8 @@ namespace Babylon::Plugins
     {
     public:
         // Implemented in ExternalTexture_Shared.h
-        Impl(Graphics::TextureT);
-        void Update(Graphics::TextureT);
+        Impl(Graphics::TextureT, std::optional<Graphics::TextureFormatT>);
+        void Update(Graphics::TextureT, std::optional<Graphics::TextureFormatT>);
 
         uintptr_t Ptr() const
         {
@@ -153,7 +153,7 @@ namespace Babylon::Plugins
         }
 
     private:
-        static void GetInfo(Graphics::TextureT ptr, Info& info)
+        static void GetInfo(Graphics::TextureT ptr, std::optional<Graphics::TextureFormatT> overrideFormat, Info& info)
         {
             if (ptr.textureType != MTLTextureType2D && ptr.textureType != MTLTextureType2DMultisample)
             {
@@ -174,14 +174,14 @@ namespace Babylon::Plugins
                 }
             }
 
-            const auto pixelFormat = ptr.pixelFormat;
+            const auto targetFormat = overrideFormat.has_value() ? overrideFormat.value() : descptr.pixelFormat;
             for (size_t i = 0; i < BX_COUNTOF(s_textureFormat); ++i)
             {
                 const auto& format = s_textureFormat[i];
-                if (format.m_fmt == pixelFormat || format.m_fmtSrgb == pixelFormat)
+                if (format.m_fmt == targetFormat || format.m_fmtSrgb == targetFormat)
                 {
                     info.Format = static_cast<bgfx::TextureFormat::Enum>(i);
-                    if (format.m_fmtSrgb == pixelFormat)
+                    if (format.m_fmtSrgb == targetFormat)
                     {
                         info.Flags |= BGFX_TEXTURE_SRGB;
                     }

--- a/Plugins/ExternalTexture/Source/ExternalTexture_OpenGL.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_OpenGL.cpp
@@ -24,7 +24,7 @@ namespace Babylon::Plugins
         }
 
     private:
-        static void GetInfo(Graphics::TextureT ptr, std::optional<Graphics::TextureFormatT> overrideFormat, Info& info)
+        static void GetInfo(Graphics::TextureT, std::optional<Graphics::TextureFormatT>, Info&)
         {
             throw std::runtime_error{"not implemented"};
         }

--- a/Plugins/ExternalTexture/Source/ExternalTexture_OpenGL.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_OpenGL.cpp
@@ -15,8 +15,8 @@ namespace Babylon::Plugins
     {
     public:
         // Implemented in ExternalTexture_Shared.h
-        Impl(Graphics::TextureT);
-        void Update(Graphics::TextureT);
+        Impl(Graphics::TextureT, std::optional<Graphics::TextureFormatT>);
+        void Update(Graphics::TextureT, std::optional<Graphics::TextureFormatT>);
 
         uintptr_t Ptr() const
         {
@@ -24,7 +24,7 @@ namespace Babylon::Plugins
         }
 
     private:
-        void GetInfo(Graphics::TextureT, Info&)
+        static void GetInfo(Graphics::TextureT ptr, std::optional<Graphics::TextureFormatT> overrideFormat, Info& info)
         {
             throw std::runtime_error{"not implemented"};
         }

--- a/Plugins/ExternalTexture/Source/ExternalTexture_Shared.h
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Shared.h
@@ -2,9 +2,9 @@
 
 namespace Babylon::Plugins
 {
-    ExternalTexture::Impl::Impl(Graphics::TextureT ptr)
+    ExternalTexture::Impl::Impl(Graphics::TextureT ptr, std::optional<Graphics::TextureFormatT> overrideFormat)
     {
-        GetInfo(ptr, m_info);
+        GetInfo(ptr, overrideFormat, m_info);
 
         if (m_info.MipLevels != 1 && m_info.MipLevels != 0 && !IsFullMipChain(m_info.MipLevels, m_info.Width, m_info.Height))
         {
@@ -14,10 +14,10 @@ namespace Babylon::Plugins
         Assign(ptr);
     }
 
-    void ExternalTexture::Impl::Update(Graphics::TextureT ptr)
+    void ExternalTexture::Impl::Update(Graphics::TextureT ptr, std::optional<Graphics::TextureFormatT> overrideFormat)
     {
         Info info;
-        GetInfo(ptr, info);
+        GetInfo(ptr, overrideFormat, info);
 
         if (info.Width != m_info.Width || info.Height != m_info.Height || info.MipLevels != m_info.MipLevels)
         {
@@ -31,8 +31,8 @@ namespace Babylon::Plugins
         UpdateHandles(Ptr());
     }
 
-    ExternalTexture::ExternalTexture(Graphics::TextureT ptr)
-        : m_impl{std::make_unique<Impl>(ptr)}
+    ExternalTexture::ExternalTexture(Graphics::TextureT ptr, std::optional<Graphics::TextureFormatT> overrideFormat)
+        : m_impl{std::make_unique<Impl>(ptr, overrideFormat)}
     {
     }
 
@@ -112,8 +112,8 @@ namespace Babylon::Plugins
         return promise;
     }
 
-    void ExternalTexture::Update(Graphics::TextureT ptr)
+    void ExternalTexture::Update(Graphics::TextureT ptr, std::optional<Graphics::TextureFormatT> overrideFormat)
     {
-        m_impl->Update(ptr);
+        m_impl->Update(ptr, overrideFormat);
     }
 }


### PR DESCRIPTION
In D3D, some textures have multiple planes (e.g., NV12). In order to access these planes, the format for the D3D shader resource view must be different than the format of the texture. See NV12 section of the [DXGI_FORMAT doc](https://learn.microsoft.com/en-us/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format). This change makes it possible to override the texture format to something different than the one from the texture itself when creating the external texture.