### PR TITLE
Pull in latest JSRuntimeHost with JSC reference management fixes

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -192,6 +192,13 @@ demo app, click on the project selector and find `Playground` in the list of pos
 selections. The `Play` button will subsequently allow you to build, run, and debug
 the selected Babylon Native demo app.
 
+### Troubleshooting
+```
+CMake Error at /Applications/CMake 2.app/Contents/share/cmake-3.26/Modules/Platform/iOS-Initialize.cmake:4 (message):
+   is not an iOS SDK
+```
+If you see an error like this, it might be because you have updated Xcode and/or installed a new version of the iOS SDK since last time CMake was run. Try cleaning (e.g. `git clean -dxff`, but back up any changes you want to keep) and re-running the CMake command.
+
 ## **Building on macOS, Targeting visionOS**
 
 _Follow the steps from [All Development Platforms](#all-development-platforms) before proceeding._

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ FetchContent_Declare(ios-cmake
     GIT_TAG 4.5.0)
 FetchContent_Declare(JsRuntimeHost
     GIT_REPOSITORY https://github.com/BabylonJS/JsRuntimeHost.git
-    GIT_TAG 4638802193e55bc4b9eb702b94d2f7b12acf3d52)
+    GIT_TAG 5cb464449c60eb127797ab0834d1cd0b6349aa67)
 FetchContent_Declare(OpenXR-MixedReality
     GIT_REPOSITORY https://github.com/microsoft/OpenXR-MixedReality.git
     GIT_TAG 67424511525b96a36847f2a96d689d99e5879503)


### PR DESCRIPTION
And add a troubleshooting section to iOS build instructions.