### PR TITLE
Canvas Transforms:  getTransform setTransform, addPath (Path2D)

### DIFF
--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -72,6 +72,7 @@ namespace Babylon::Polyfills::Internal
                 InstanceMethod("strokeText", &Context::StrokeText),
                 InstanceMethod("createLinearGradient", &Context::CreateLinearGradient),
                 InstanceMethod("createRadialGradient", &Context::CreateRadialGradient),
+                InstanceMethod("getTransform", &Context::GetTransform),
                 InstanceMethod("setTransform", &Context::SetTransform),
                 InstanceMethod("transform", &Context::Transform),
                 InstanceMethod("dispose", &Context::Dispose),
@@ -410,6 +411,11 @@ namespace Babylon::Polyfills::Internal
                             args.roundRect.width, args.roundRect.height,
                             args.roundRect.radii);
                         break;
+                    case P2D_TRANSFORM:
+                        nvgTransform(*m_nvg,
+                            args.transform.a, args.transform.b, args.transform.c,
+                            args.transform.d, args.transform.e, args.transform.f);
+                        break;
                     default:
                         setDirty = false; // noop
                         break;
@@ -673,9 +679,32 @@ namespace Babylon::Polyfills::Internal
         return gradient;
     }
 
+    Napi::Value Context::GetTransform(const Napi::CallbackInfo&)
+    {
+        float xform[6];
+        nvgCurrentTransform(*m_nvg, xform);
+
+        Napi::Object obj = Napi::Object::New(Env());
+        obj.Set("a", xform[0]);
+        obj.Set("b", xform[1]);
+        obj.Set("c", xform[2]);
+        obj.Set("d", xform[3]);
+        obj.Set("e", xform[4]);
+        obj.Set("f", xform[5]);
+        return obj;
+    }
+
     void Context::SetTransform(const Napi::CallbackInfo& info)
     {
-        throw Napi::Error::New(info.Env(), "not implemented");
+        const auto a = info[0].As<Napi::Number>().FloatValue();
+        const auto b = info[1].As<Napi::Number>().FloatValue();
+        const auto c = info[2].As<Napi::Number>().FloatValue();
+        const auto d = info[3].As<Napi::Number>().FloatValue();
+        const auto e = info[4].As<Napi::Number>().FloatValue();
+        const auto f = info[5].As<Napi::Number>().FloatValue();
+        nvgResetTransform(*m_nvg);
+        nvgTransform(*m_nvg, a, b, c, d, e, f);
+        SetDirty();
     }
 
     void Context::Transform(const Napi::CallbackInfo& info)

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -49,6 +49,7 @@ namespace Babylon::Polyfills::Internal
         void StrokeText(const Napi::CallbackInfo&);
         Napi::Value CreateLinearGradient(const Napi::CallbackInfo&);
         Napi::Value CreateRadialGradient(const Napi::CallbackInfo&);
+        Napi::Value GetTransform(const Napi::CallbackInfo&);
         void SetTransform(const Napi::CallbackInfo&);
         void Transform(const Napi::CallbackInfo&);
         void QuadraticCurveTo(const Napi::CallbackInfo&);

--- a/Polyfills/Canvas/Source/Path2D.h
+++ b/Polyfills/Canvas/Source/Path2D.h
@@ -16,6 +16,7 @@ enum Path2DCommandTypes
     P2D_ELLIPSE = 7,
     P2D_RECT = 8,
     P2D_ROUNDRECT = 9,
+    P2D_TRANSFORM = 10,
 };
 
 struct Path2DClose {}; // TODO: don't bother if no args?
@@ -28,6 +29,7 @@ struct Path2DArcTo { float x1; float y1; float x2; float y2; float radius; };
 struct Path2DEllipse { float x; float y; float radiusX; float radiusY; float rotation; float startAngle; float endAngle; bool counterclockwise; };
 struct Path2DRect { float x; float y; float width; float height; };
 struct Path2DRoundRect { float x; float y; float width; float height; float radii; };
+struct Path2DTransform { float a; float b; float c; float d; float e; float f; };
 
 union Path2DCommandArgs
 {
@@ -41,6 +43,7 @@ union Path2DCommandArgs
     Path2DEllipse ellipse;
     Path2DRect rect;
     Path2DRoundRect roundRect;
+    Path2DTransform transform;
 };
 
 struct Path2DCommand


### PR DESCRIPTION
- https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/getTransform
- https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setTransform
- https://developer.mozilla.org/en-US/docs/Web/API/Path2D/addPath#transform

usage:
```
// Path 2D
let path = new _native.Path2D();
let path2 = new _native.Path2D("M 10,30 A 20, 20 0, 0, 1 50, 30 A 20, 20 0, 0, 1 90, 30 Q 90, 60 50, 90 Q 10, 60 10, 30 z");
path.addPath(path2, { a: 1, b: 0, c: 0, d: 1, e: 400, f: 0 }); // shift right 400
context.stroke(path);
```