### PR TITLE
Fix texture copy when using multiple canvas

### DIFF
--- a/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
@@ -121,6 +121,7 @@ namespace Babylon::Graphics
         TextureInfo GetTextureInfo(bgfx::TextureHandle handle);
         static bx::AllocatorI& GetDefaultAllocator() { return m_allocator; }
 
+        void Blit(bgfx::Encoder& encoder, bgfx::TextureHandle dst, uint16_t dstX, uint16_t dstY, bgfx::TextureHandle src, uint16_t srcX = 0, uint16_t srcY = 0, uint16_t width = UINT16_MAX, uint16_t height = UINT16_MAX);
     private:
         friend UpdateToken;
 

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
@@ -122,7 +122,7 @@ namespace Babylon::Graphics
         static bx::AllocatorI& GetDefaultAllocator() { return m_allocator; }
 
         // call following method when a submit call is associated with the current acquired viewId
-        void SetViewAsUsed();
+        void InvalidateView();
         void Blit(bgfx::Encoder& encoder, bgfx::TextureHandle dst, uint16_t dstX, uint16_t dstY, bgfx::TextureHandle src, uint16_t srcX = 0, uint16_t srcY = 0, uint16_t width = UINT16_MAX, uint16_t height = UINT16_MAX);
     private:
         friend UpdateToken;

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
@@ -121,6 +121,8 @@ namespace Babylon::Graphics
         TextureInfo GetTextureInfo(bgfx::TextureHandle handle);
         static bx::AllocatorI& GetDefaultAllocator() { return m_allocator; }
 
+        // call following method when a submit call is associated with the current acquired viewId
+        void SetViewAsUsed();
         void Blit(bgfx::Encoder& encoder, bgfx::TextureHandle dst, uint16_t dstX, uint16_t dstY, bgfx::TextureHandle src, uint16_t srcX = 0, uint16_t srcY = 0, uint16_t width = UINT16_MAX, uint16_t height = UINT16_MAX);
     private:
         friend UpdateToken;
@@ -131,5 +133,8 @@ namespace Babylon::Graphics
         std::mutex m_textureHandleToInfoMutex{};
 
         static inline bx::DefaultAllocator m_allocator{};
+
+        bool m_currentViewIsUsed{false};
+        bgfx::ViewId m_lastAcquiredViewId{bgfx::kInvalidHandle};
     };
 }

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/FrameBuffer.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/FrameBuffer.h
@@ -41,7 +41,6 @@ namespace Babylon::Graphics
         void SetScissor(bgfx::Encoder& encoder, float x, float y, float width, float height);
         void Submit(bgfx::Encoder& encoder, bgfx::ProgramHandle programHandle, uint8_t flags);
         void SetStencil(bgfx::Encoder& encoder, uint32_t stencilState);
-        void Blit(bgfx::Encoder& encoder, bgfx::TextureHandle dst, uint16_t dstX, uint16_t dstY, bgfx::TextureHandle src, uint16_t srcX = 0, uint16_t srcY = 0, uint16_t width = UINT16_MAX, uint16_t height = UINT16_MAX);
 
         bool HasDepth() const { return m_hasDepth; }
         bool HasStencil() const { return m_hasStencil; }

--- a/Core/Graphics/Source/DeviceContext.cpp
+++ b/Core/Graphics/Source/DeviceContext.cpp
@@ -140,7 +140,7 @@ namespace Babylon::Graphics
         encoder.blit(viewId, dst, dstX, dstY, src, srcX, srcY, width, height);
     }
 
-    void DeviceContext::SetViewAsUsed()
+    void DeviceContext::InvalidateView()
     {
         m_currentViewIsUsed = true;
     }

--- a/Core/Graphics/Source/DeviceContext.cpp
+++ b/Core/Graphics/Source/DeviceContext.cpp
@@ -129,4 +129,11 @@ namespace Babylon::Graphics
     {
        return m_graphicsImpl.GetId();
     }
+
+    void DeviceContext::Blit(bgfx::Encoder& encoder, bgfx::TextureHandle dst, uint16_t dstX, uint16_t dstY, bgfx::TextureHandle src, uint16_t srcX, uint16_t srcY, uint16_t width, uint16_t height)
+    {
+        // Increment viewId so blit happens after the last drawcall of the last viewId
+        auto viewId = AcquireNewViewId(encoder);
+        encoder.blit(viewId, dst, dstX, dstY, src, srcX, srcY, width, height);
+    }
 }

--- a/Core/Graphics/Source/FrameBuffer.cpp
+++ b/Core/Graphics/Source/FrameBuffer.cpp
@@ -112,6 +112,7 @@ namespace Babylon::Graphics
         m_bgfxScissor = {};
 
         encoder.touch(m_viewId.value());
+        m_deviceContext.InvalidateView();
     }
 
     void FrameBuffer::SetViewPort(bgfx::Encoder& encoder, float x, float y, float width, float height)
@@ -130,7 +131,7 @@ namespace Babylon::Graphics
     {
         SetBgfxViewPortAndScissor(encoder, m_desiredViewPort, m_desiredScissor);
         encoder.submit(m_viewId.value(), programHandle, 0, flags);
-        m_deviceContext.SetViewAsUsed();
+        m_deviceContext.InvalidateView();
     }
 
     void FrameBuffer::SetStencil(bgfx::Encoder& encoder, uint32_t stencilState)

--- a/Core/Graphics/Source/FrameBuffer.cpp
+++ b/Core/Graphics/Source/FrameBuffer.cpp
@@ -130,6 +130,7 @@ namespace Babylon::Graphics
     {
         SetBgfxViewPortAndScissor(encoder, m_desiredViewPort, m_desiredScissor);
         encoder.submit(m_viewId.value(), programHandle, 0, flags);
+        m_deviceContext.SetViewAsUsed();
     }
 
     void FrameBuffer::SetStencil(bgfx::Encoder& encoder, uint32_t stencilState)

--- a/Core/Graphics/Source/FrameBuffer.cpp
+++ b/Core/Graphics/Source/FrameBuffer.cpp
@@ -132,13 +132,6 @@ namespace Babylon::Graphics
         encoder.submit(m_viewId.value(), programHandle, 0, flags);
     }
 
-    void FrameBuffer::Blit(bgfx::Encoder& encoder, bgfx::TextureHandle dst, uint16_t dstX, uint16_t dstY, bgfx::TextureHandle src, uint16_t srcX, uint16_t srcY, uint16_t width, uint16_t height)
-    {
-        // In order for Blit to work properly we need to force the creation of a new ViewID.
-        SetBgfxViewPortAndScissor(encoder, m_desiredViewPort, m_desiredScissor);
-        encoder.blit(m_viewId.value(), dst, dstX, dstY, src, srcX, srcY, width, height);
-    }
-
     void FrameBuffer::SetStencil(bgfx::Encoder& encoder, uint32_t stencilState)
     {
         encoder.setStencil(m_hasStencil ? stencilState : 0);

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1435,7 +1435,9 @@ namespace Babylon
         arcana::make_task(m_update.Scheduler(), *m_cancellationSource, [this, textureDestination, textureSource, cancellationSource = m_cancellationSource]() {
             return arcana::make_task(m_runtimeScheduler, *m_cancellationSource, [this, textureDestination, textureSource, updateToken = m_update.GetUpdateToken(), cancellationSource = m_cancellationSource]() {
                 bgfx::Encoder* encoder = m_update.GetUpdateToken().GetEncoder();
-                GetBoundFrameBuffer(*encoder).Blit(*encoder, textureDestination->Handle(), 0, 0, textureSource->Handle());
+                auto& boundFramebuffer = GetBoundFrameBuffer(*encoder);
+                boundFramebuffer.Bind(*encoder);
+                boundFramebuffer.Blit(*encoder, textureDestination->Handle(), 0, 0, textureSource->Handle());
             }).then(arcana::inline_scheduler, *m_cancellationSource, [this, cancellationSource{m_cancellationSource}](const arcana::expected<void, std::exception_ptr>& result) {
                 if (!cancellationSource->cancelled() && result.has_error())
                 {


### PR DESCRIPTION
There is an issue when using multiple dynamic textures (Canvas). Only the 1st one is properly displayed.
`GLTF Node NegativeScale (0)` validation test looks like this:

![image](https://github.com/user-attachments/assets/7d5455fd-6a93-4015-ac15-d2188bf83a7a)

A Renderdoc capture gives this call trace:

![image](https://github.com/user-attachments/assets/e89d090a-ae1f-4ccb-bf0d-7da86ba852e3)

Texture copies are all done at the same time in bgfx, at the end of sorted drawcalls of a viewid : https://github.com/bkaradzic/bgfx/blob/4602a01ce51611183d8ae8e320ca0f5305b79cb8/src/renderer_d3d11.cpp#L5739

All blit commands are submitted with the same ViewID. Which is confirmed when looking at this:
https://github.com/BabylonJS/BabylonNative/blob/9379cf3c41eedbf3001d4f1e3872ced9a04e818e/Plugins/NativeEngine/Source/NativeEngine.cpp#L1438

Solution is incrementing ViewID in `Blit` and moving the call into DeviceContext as it doesn't rely on FrameBuffer state.

Result:

![image](https://github.com/user-attachments/assets/eb8e08d2-4d3e-47b1-ad32-b3dab83370d5)



