### PR TITLE
Improve parsing of the "font" field

### DIFF
--- a/Polyfills/Canvas/CMakeLists.txt
+++ b/Polyfills/Canvas/CMakeLists.txt
@@ -108,6 +108,8 @@ set(SOURCES
     "Source/MeasureText.h"
     "Source/Gradient.cpp"
     "Source/Gradient.h"
+    "Source/Font.cpp"
+    "Source/Font.h"
     "Source/nanosvg.h"
     "Source/nanovg/nanovg.cpp"
     "Source/nanovg/nanovg.h"

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -849,7 +849,7 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value Context::GetFont(const Napi::CallbackInfo& info)
     {
-        return Napi::Value::From(Env(), (std::string)m_font);
+        return Napi::Value::From(Env(), static_cast<std::string>(m_font));
     }
 
     void Context::SetFont(const Napi::CallbackInfo& info, const Napi::Value& value)

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -864,7 +864,6 @@ namespace Babylon::Polyfills::Internal
         {
             return;
         }
-        m_font = *font;
 
         nvgFontSize(*m_nvg, font->Size);
         if (m_fonts.find(font->Family) == m_fonts.end())
@@ -876,6 +875,8 @@ namespace Babylon::Polyfills::Internal
         {
             m_currentFontId = m_fonts.at(font->Family);
         }
+
+        m_font = std::move(*font);
     }
 
     Napi::Value Context::GetLetterSpacing(const Napi::CallbackInfo& info)

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -5,6 +5,7 @@
 #include <Babylon/Graphics/DeviceContext.h>
 #include "Image.h"
 #include "Path2D.h"
+#include "Font.h"
 
 struct NVGcontext;
 
@@ -90,7 +91,7 @@ namespace Babylon::Polyfills::Internal
         NativeCanvas* m_canvas;
         std::shared_ptr<NVGcontext*> m_nvg;
 
-        std::string m_font{};
+        Font m_font;
         std::variant<std::string, CanvasGradient*> m_fillStyle{};
         std::string m_strokeStyle{};
         std::string m_lineCap{};  // 'butt', 'round', 'square'

--- a/Polyfills/Canvas/Source/Font.cpp
+++ b/Polyfills/Canvas/Source/Font.cpp
@@ -3,14 +3,17 @@
 
 #include "Font.h"
 
+namespace
+{
+    auto STYLE_REGEX = std::regex(R"(^\s*(normal|italic)\s)");
+    auto WEIGHT_REGEX = std::regex(R"(^\s*(normal|bold|\d+)\s)");
+    auto SIZE_REGEX = std::regex(R"(^\s*((?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?)px\s)");
+    auto FAMILY_IDENT_REGEX = std::regex(R"(^\s*((?:[\w-]|\\.)+))");
+    auto FAMILY_STRING_REGEX = std::regex(R"(^\s*(["'])((?:[^\\]|\\.)*?)\1)");
+}
+
 namespace Babylon::Polyfills::Internal
 {
-    static auto STYLE_REGEX = std::regex(R"(^\s*(normal|italic)\s)");
-    static auto WEIGHT_REGEX = std::regex(R"(^\s*(normal|bold|\d+)\s)");
-    static auto SIZE_REGEX = std::regex(R"(^\s*((?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?)px\s)");
-    static auto FAMILY_IDENT_REGEX = std::regex(R"(^\s*((?:[\w-]|\\.)+))");
-    static auto FAMILY_STRING_REGEX = std::regex(R"(^\s*(["'])((?:[^\\]|\\.)*?)\1)");
-
     std::optional<Font> Font::Parse(const std::string& fontString)
     {
         Font font;

--- a/Polyfills/Canvas/Source/Font.cpp
+++ b/Polyfills/Canvas/Source/Font.cpp
@@ -25,7 +25,7 @@ namespace Babylon::Polyfills::Internal
         {
             if (!foundStyle && std::regex_search(begin, end, match, STYLE_REGEX))
             {
-                end = match[0].second;
+                begin = match[0].second;
                 foundStyle = true;
                 if (match[1] == "italic")
                 {
@@ -34,7 +34,7 @@ namespace Babylon::Polyfills::Internal
             }
             else if (!foundWeight && std::regex_search(begin, end, match, WEIGHT_REGEX))
             {
-                end = match[0].second;
+                begin = match[0].second;
                 foundWeight = true;
                 if (match[1] == "bold")
                 {
@@ -55,7 +55,7 @@ namespace Babylon::Polyfills::Internal
         {
             return std::nullopt;
         }
-        end = match[0].second;
+        begin = match[0].second;
         font.Size = std::stof(match[1]);
 
         if (std::regex_search(begin, end, match, FAMILY_IDENT_REGEX))

--- a/Polyfills/Canvas/Source/Font.cpp
+++ b/Polyfills/Canvas/Source/Font.cpp
@@ -1,0 +1,94 @@
+#include <regex>
+#include <sstream>
+
+#include "Font.h"
+
+namespace Babylon::Polyfills::Internal
+{
+    static auto STYLE_REGEX = std::regex(R"(^\s*(normal|italic)\s)");
+    static auto WEIGHT_REGEX = std::regex(R"(^\s*(normal|bold|\d+)\s)");
+    static auto SIZE_REGEX = std::regex(R"(^\s*((?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?)px\s)");
+    static auto FAMILY_IDENT_REGEX = std::regex(R"(^\s*((?:[\w-]|\\.)+))");
+    static auto FAMILY_STRING_REGEX = std::regex(R"(^\s*(["'])((?:[^\\]|\\.)*?)\1)");
+
+    std::optional<Font> Font::Parse(const std::string& fontString)
+    {
+        Font font;
+        auto begin = fontString.cbegin();
+        auto end = fontString.cend();
+        std::smatch match;
+
+        // The style and weight can be in any order
+        bool foundStyle = false;
+        bool foundWeight = false;
+        while (!foundStyle || !foundWeight)
+        {
+            if (!foundStyle && std::regex_search(begin, end, match, STYLE_REGEX))
+            {
+                end = match[0].second;
+                foundStyle = true;
+                if (match[1] == "italic")
+                {
+                    font.Style = FontStyle::Italic;
+                }
+            }
+            else if (!foundWeight && std::regex_search(begin, end, match, WEIGHT_REGEX))
+            {
+                end = match[0].second;
+                foundWeight = true;
+                if (match[1] == "bold")
+                {
+                    font.Weight = BOLD_WEIGHT;
+                }
+                else
+                {
+                    font.Weight = std::stoi(match[1]);
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        if (!std::regex_search(begin, end, match, SIZE_REGEX))
+        {
+            return std::nullopt;
+        }
+        end = match[0].second;
+        font.Size = std::stof(match[1]);
+
+        if (std::regex_search(begin, end, match, FAMILY_IDENT_REGEX))
+        {
+            font.Family = match[1];
+        }
+        else if (std::regex_search(begin, end, match, FAMILY_STRING_REGEX))
+        {
+            // The first capture group is used for the quotation mark (" or ')
+            font.Family = match[2];
+        }
+        else
+        {
+            return std::nullopt;
+        }
+
+        return font;
+    }
+
+    Font::operator std::string() const
+    {
+        std::ostringstream stream;
+        if (Style == FontStyle::Italic)
+        {
+            stream << "italic ";
+        }
+
+        if (Weight != NORMAL_WEIGHT)
+        {
+            stream << Weight << " ";
+        }
+
+        stream << Size << "px \"" << Family << "\"";
+        return stream.str();
+    }
+}

--- a/Polyfills/Canvas/Source/Font.h
+++ b/Polyfills/Canvas/Source/Font.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <string>
+#include <optional>
+
+namespace Babylon::Polyfills::Internal
+{
+    enum class FontStyle
+    {
+        Normal,
+        Italic,
+    };
+
+    struct Font
+    {
+    private:
+        static constexpr int NORMAL_WEIGHT = 400;
+        static constexpr int BOLD_WEIGHT = 700;
+
+    public:
+        FontStyle Style = FontStyle::Normal;
+        int Weight = NORMAL_WEIGHT;
+        float Size = 10;
+        std::string Family = "sans-serif";
+
+        operator std::string() const;
+
+        static std::optional<Font> Parse(const std::string& fontString);
+    };
+}


### PR DESCRIPTION
This improves the handling of the "font" field on the context to properly parse out weight/style/size. Currently weight and style are unused since the font map only takes the family name into consideration.