### PR TITLE
Canvas and Context

### DIFF
--- a/Apps/UnitTests/Scripts/tests.js
+++ b/Apps/UnitTests/Scripts/tests.js
@@ -15,6 +15,20 @@ describe("RequestFile", function () {
     });
 });
 
+describe("CanvasAndContext", function () {
+    const engine = new BABYLON.NativeEngine();
+    const scene = new BABYLON.Scene(engine);
+
+    var texSize = 512;
+    var dynamicTexture = new BABYLON.DynamicTexture("dynamic texture", texSize, scene);
+    var context = dynamicTexture.getContext();
+    var otherContext = dynamicTexture.getContext();
+
+    expect(context).to.equal(context.canvas.getContext());
+    expect(context).to.equal(otherContext);
+    expect(context).to.equal(otherContext.canvas.getContext());
+});
+
 describe("ColorParsing", function () {
     expect(_native.Canvas.parseColor("")).to.equal(0);
     expect(_native.Canvas.parseColor("transparent")).to.equal(0);

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -15,14 +15,15 @@ namespace Babylon::Polyfills::Internal
 {
     static constexpr auto JS_CONSTRUCTOR_NAME = "Canvas";
 
-    void NativeCanvas::CreateInstance(Napi::Env env)
+    void NativeCanvas::Initialize(Napi::Env env)
     {
         Napi::HandleScope scope{env};
 
         Napi::Function func = DefineClass(
             env,
             JS_CONSTRUCTOR_NAME,
-            {StaticMethod("loadTTFAsync", &NativeCanvas::LoadTTFAsync),
+            {
+                StaticMethod("loadTTFAsync", &NativeCanvas::LoadTTFAsync),
                 InstanceAccessor("width", &NativeCanvas::GetWidth, &NativeCanvas::SetWidth),
                 InstanceAccessor("height", &NativeCanvas::GetHeight, &NativeCanvas::SetHeight),
                 InstanceMethod("getContext", &NativeCanvas::GetContext),
@@ -77,7 +78,11 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value NativeCanvas::GetContext(const Napi::CallbackInfo& info)
     {
-        return Context::CreateInstance(info.Env(), this);
+        if (m_contextObject.IsEmpty())
+        {
+            m_contextObject = Napi::Persistent(Context::CreateInstance(info.Env(), info.This()).As<Napi::Object>());
+        }
+        return m_contextObject.Value();
     }
 
     Napi::Value NativeCanvas::GetWidth(const Napi::CallbackInfo&)
@@ -242,9 +247,8 @@ namespace Babylon::Polyfills
     {
         auto impl{std::make_shared<Canvas::Impl>(env)};
 
-        Internal::NativeCanvas::CreateInstance(env);
-        Internal::NativeCanvasImage::CreateInstance(env);
-
+        Internal::NativeCanvas::Initialize(env);
+        Internal::NativeCanvasImage::Initialize(env);
         Internal::Context::Initialize(env);
 
         return {impl};

--- a/Polyfills/Canvas/Source/Canvas.h
+++ b/Polyfills/Canvas/Source/Canvas.h
@@ -54,7 +54,7 @@ namespace Babylon::Polyfills::Internal
     class NativeCanvas final : public Napi::ObjectWrap<NativeCanvas>, Polyfills::Canvas::Impl::MonitoredResource
     {
     public:
-        static void CreateInstance(Napi::Env env);
+        static void Initialize(Napi::Env env);
 
         explicit NativeCanvas(const Napi::CallbackInfo& info);
         virtual ~NativeCanvas();
@@ -85,6 +85,8 @@ namespace Babylon::Polyfills::Internal
         void Remove(const Napi::CallbackInfo& info);
         void Dispose(const Napi::CallbackInfo& info);
         void Dispose();
+
+        Napi::ObjectReference m_contextObject{};
 
         uint16_t m_width{1};
         uint16_t m_height{1};

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -86,17 +86,18 @@ namespace Babylon::Polyfills::Internal
         JsRuntime::NativeObject::GetFromJavaScript(env).Set(JS_CONTEXT_CONSTRUCTOR_NAME, func);
     }
 
-    Napi::Value Context::CreateInstance(Napi::Env env, NativeCanvas* canvas)
+    Napi::Value Context::CreateInstance(Napi::Env env, Napi::Value canvas)
     {
         Napi::HandleScope scope{env};
 
         auto func = JsRuntime::NativeObject::GetFromJavaScript(env).Get(JS_CONTEXT_CONSTRUCTOR_NAME).As<Napi::Function>();
-        return func.New({Napi::External<NativeCanvas>::New(env, canvas)});
+        return func.New({canvas});
     }
 
     Context::Context(const Napi::CallbackInfo& info)
         : Napi::ObjectWrap<Context>{info}
-        , m_canvas{info[0].As<Napi::External<NativeCanvas>>().Data()}
+        , m_canvasObject{Napi::Persistent(info[0].As<Napi::Object>())}
+        , m_canvas{NativeCanvas::Unwrap(info[0].As<Napi::Object>())}
         , m_nvg{nvgCreate(1)}
         , m_graphicsContext{m_canvas->GetGraphicsContext()}
         , m_update{m_graphicsContext.GetUpdate("update")}
@@ -669,6 +670,6 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value Context::GetCanvas(const Napi::CallbackInfo& info)
     {
-        throw Napi::Error::New(info.Env(), "not implemented");
+        return m_canvasObject.Value();
     }
 }

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -13,7 +13,7 @@ namespace Babylon::Polyfills::Internal
     {
     public:
         static void Initialize(Napi::Env);
-        static Napi::Value CreateInstance(Napi::Env env, NativeCanvas* canvas);
+        static Napi::Value CreateInstance(Napi::Env env, Napi::Value canvas);
 
         explicit Context(const Napi::CallbackInfo& info);
         virtual ~Context();
@@ -75,8 +75,9 @@ namespace Babylon::Polyfills::Internal
         void SetDirty();
         void DeferredFlushFrame();
 
-        NativeCanvas* m_canvas;
-        NVGcontext* m_nvg;
+        Napi::ObjectReference m_canvasObject{};
+        NativeCanvas* m_canvas{};
+        NVGcontext* m_nvg{};
 
         std::string m_font{};
         std::string m_fillStyle{};

--- a/Polyfills/Canvas/Source/Image.cpp
+++ b/Polyfills/Canvas/Source/Image.cpp
@@ -17,7 +17,7 @@ namespace Babylon::Polyfills::Internal
 {
     static constexpr auto JS_IMAGE_CONSTRUCTOR_NAME = "Image";
 
-    void NativeCanvasImage::CreateInstance(Napi::Env env)
+    void NativeCanvasImage::Initialize(Napi::Env env)
     {
         Napi::HandleScope scope{env};
 

--- a/Polyfills/Canvas/Source/Image.h
+++ b/Polyfills/Canvas/Source/Image.h
@@ -15,7 +15,7 @@ namespace Babylon::Polyfills::Internal
     class NativeCanvasImage final : public Napi::ObjectWrap<NativeCanvasImage>
     {
     public:
-        static void CreateInstance(Napi::Env env);
+        static void Initialize(Napi::Env env);
 
         explicit NativeCanvasImage(const Napi::CallbackInfo& info);
         virtual ~NativeCanvasImage();


### PR DESCRIPTION
Replaces https://github.com/BabylonJS/BabylonNative/pull/1488

- Fix wrongly named `CreateInstance` with `Initialize`
- Canvas/Context unit test
- Implement `GetCanvas`
- Fix parameters and objectReference between Canvas and Context
- Keep and return the object reference created for `getContext`