### PR TITLE
fixes: canvas.SetHeight/Width, Path2D, context.fill

### DIFF
--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -113,7 +113,7 @@ namespace Babylon::Polyfills::Internal
 
     void NativeCanvas::SetHeight(const Napi::CallbackInfo&, const Napi::Value& value)
     {
-        auto height = value.As<Napi::Number>().Uint32Value();
+        auto height = static_cast<uint16_t>(value.As<Napi::Number>().Uint32Value());
         if (!height)
         {
             return;
@@ -160,7 +160,7 @@ namespace Babylon::Polyfills::Internal
             return true;
         }
 
-        return needClear || false;
+        return needClear;
     }
 
     Napi::Value NativeCanvas::GetCanvasTexture(const Napi::CallbackInfo& info)

--- a/Polyfills/Canvas/Source/Canvas.h
+++ b/Polyfills/Canvas/Source/Canvas.h
@@ -94,6 +94,7 @@ namespace Babylon::Polyfills::Internal
         std::unique_ptr<Graphics::FrameBuffer> m_frameBuffer;
         std::unique_ptr<Graphics::Texture> m_texture{};
         bool m_dirty{};
+        bool m_clear{};
 
         void FlushGraphicResources() override;
     };

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -247,8 +247,12 @@ namespace Babylon::Polyfills::Internal
 
     void Context::Fill(const Napi::CallbackInfo& info)
     {
+        const NativeCanvasPath2D* path = info.Length() >= 1 && info[0].IsObject()
+            ? NativeCanvasPath2D::Unwrap(info[0].As<Napi::Object>())
+            : nullptr;
+        // TODO: handle fillRule: nonzero, evenodd
+
         // draw Path2D if exists
-        const NativeCanvasPath2D* path = info.Length() == 1 ? NativeCanvasPath2D::Unwrap(info[0].As<Napi::Object>()) : nullptr;
         if (path != nullptr)
         {
             PlayPath2D(path);

--- a/Polyfills/Canvas/Source/Path2D.cpp
+++ b/Polyfills/Canvas/Source/Path2D.cpp
@@ -49,8 +49,19 @@ namespace Babylon::Polyfills::Internal
         : Napi::ObjectWrap<NativeCanvasPath2D>{info}
         , m_commands{std::deque<Path2DCommand>()}
     {
+        const NativeCanvasPath2D* path = info.Length() == 1 && info[0].IsObject()
+            ? NativeCanvasPath2D::Unwrap(info[0].As<Napi::Object>())
+            : nullptr;
         const std::string d = info.Length() == 1 && info[0].IsString() ? info[0].As<Napi::String>().Utf8Value() : "";
-        // auto context{info[0].As<Napi::External<NativeCanvasPath2D>>().Data()}; // TODO: Path2D constructor
+
+        if (path != nullptr)
+        {
+            for (const auto& command : *path)
+            {
+                m_commands.push_back(command);
+            }
+        }
+
         if (!d.empty())
         {
             NSVGparser* parser = nsvg__createParser();


### PR DESCRIPTION
- Supports passing Path2D to Path2D constructor
- Handles >1 args for context.fill
- As [matanui159](https://github.com/BabylonJS/BabylonNative/issues?q=is%3Apr%20is%3Aopen%20author%3Amatanui159), as pointed out, `SetHeight`, `SetWidth` clears canvas on browser even if width/height doesn't change. We re-use framebuffer but clear it in this scenario.