### PR TITLE
fix: pool framebuffer stencil, release issues

### DIFF
--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -159,23 +159,16 @@ namespace Babylon::Polyfills::Internal
             std::array<bgfx::Attachment, textures.size()> attachments{};
             for (size_t idx = 0; idx < attachments.size(); ++idx)
             {
-                std::array<bgfx::TextureHandle, 1> textures{
-                   bgfx::createTexture2D(m_width, m_height, false, 1, bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT) };
+                attachments[idx].init(textures[idx]);
+            }
+            auto handle = bgfx::createFrameBuffer(static_cast<uint8_t>(attachments.size()), attachments.data(), true);
+            assert(handle.idx != bgfx::kInvalidHandle);
+            m_frameBuffer = std::make_unique<Graphics::FrameBuffer>(m_graphicsContext, handle, m_width, m_height, false, false, false);
+            m_dirty = false;
 
-                std::array<bgfx::Attachment, textures.size()> attachments{};
-                for (size_t idx = 0; idx < attachments.size(); ++idx)
-                {
-                    attachments[idx].init(textures[idx]);
-                }
-                auto handle = bgfx::createFrameBuffer(static_cast<uint8_t>(attachments.size()), attachments.data(), true);
-                assert(handle.idx != bgfx::kInvalidHandle);
-                m_frameBuffer = std::make_unique<Graphics::FrameBuffer>(m_graphicsContext, handle, m_width, m_height, false, false, false);
-                m_dirty = false;
-
-                if (m_texture)
-                {
-                    m_texture.reset();
-                }
+            if (m_texture)
+            {
+                m_texture.reset();
             }
 
             m_frameBufferPool.Clear();

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -639,7 +639,7 @@ namespace Babylon::Polyfills::Internal
                 };
                 std::function<void(Babylon::Graphics::FrameBuffer*)> release = [this, encoder](Babylon::Graphics::FrameBuffer* frameBuffer) -> void {
                     // clear framebuffer when released
-                    frameBuffer->Clear(*encoder, BGFX_CLEAR_COLOR, 0, 0, 0);
+                    frameBuffer->Clear(*encoder, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH | BGFX_CLEAR_STENCIL, 0, 1.f, 0);
                     this->m_canvas->m_frameBufferPool.Release(frameBuffer);
                     frameBuffer->Unbind(*encoder);
                 };

--- a/Polyfills/Canvas/Source/FrameBufferPool.cpp
+++ b/Polyfills/Canvas/Source/FrameBufferPool.cpp
@@ -41,8 +41,9 @@ namespace Babylon::Polyfills
             const bgfx::Memory* mem = bgfx::makeRef(image->m_data, image->m_size, releaseFn, image);
             bx::memSet(image->m_data, 0, image->m_size);
 
-            std::array<bgfx::TextureHandle, 1> textures{
-                bgfx::createTexture2D(width, height, false, 1, bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT, mem)};
+            std::array<bgfx::TextureHandle, 2> textures{
+                bgfx::createTexture2D(width, height, false, 1, bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT, mem),
+                bgfx::createTexture2D(width, height, false, 1, bgfx::TextureFormat::D24S8, BGFX_TEXTURE_RT)};
 
             std::array<bgfx::Attachment, textures.size()> attachments{};
             for (size_t idx = 0; idx < attachments.size(); ++idx)

--- a/Polyfills/Canvas/Source/FrameBufferPool.cpp
+++ b/Polyfills/Canvas/Source/FrameBufferPool.cpp
@@ -65,6 +65,7 @@ namespace Babylon::Polyfills
             if (buffer.frameBuffer)
             {
                 buffer.frameBuffer->Dispose();
+                delete buffer.frameBuffer;
             }
         }
         m_available = 0;
@@ -99,6 +100,7 @@ namespace Babylon::Polyfills
             if (buffer.frameBuffer == frameBuffer)
             {
                 buffer.isAvailable = true;
+                m_available++;
                 return;
             }
         }

--- a/Polyfills/Canvas/Source/nanovg/nanovg_babylon.cpp
+++ b/Polyfills/Canvas/Source/nanovg/nanovg_babylon.cpp
@@ -722,7 +722,19 @@ namespace
                 if (2 < paths[i].fillCount)
                 {
                     gl->encoder->setState(0);
-                    gl->encoder->setStencil(0);
+                    gl->encoder->setStencil(0
+                        | BGFX_STENCIL_TEST_ALWAYS
+                        | BGFX_STENCIL_FUNC_RMASK(0xff)
+                        | BGFX_STENCIL_OP_FAIL_S_KEEP
+                        | BGFX_STENCIL_OP_FAIL_Z_KEEP
+                        | BGFX_STENCIL_OP_PASS_Z_INCR
+                        , 0
+                        | BGFX_STENCIL_TEST_ALWAYS
+                        | BGFX_STENCIL_FUNC_RMASK(0xff)
+                        | BGFX_STENCIL_OP_FAIL_S_KEEP
+                        | BGFX_STENCIL_OP_FAIL_Z_KEEP
+                        | BGFX_STENCIL_OP_PASS_Z_DECR
+                        );
                     gl->encoder->setVertexBuffer(0, &gl->tvb);
                     gl->encoder->setTexture(0, gl->s_tex, gl->th);
                     gl->encoder->setTexture(1, gl->s_tex2, gl->th2);
@@ -742,7 +754,13 @@ namespace
                     gl->encoder->setState(gl->state
                         | BGFX_STATE_PT_TRISTRIP
                         );
-                    gl->encoder->setStencil(0);
+                    gl->encoder->setStencil(0
+                        | BGFX_STENCIL_TEST_EQUAL
+                        | BGFX_STENCIL_FUNC_RMASK(0xff)
+                        | BGFX_STENCIL_OP_FAIL_S_KEEP
+                        | BGFX_STENCIL_OP_FAIL_Z_KEEP
+                        | BGFX_STENCIL_OP_PASS_Z_KEEP
+                        );
                     gl->encoder->setVertexBuffer(0, &gl->tvb, paths[i].strokeOffset, paths[i].strokeCount);
                     gl->encoder->setTexture(0, gl->s_tex, gl->th);
                     gl->encoder->setTexture(1, gl->s_tex2, gl->th2);
@@ -755,7 +773,13 @@ namespace
             gl->encoder->setVertexBuffer(0, &gl->tvb, call->vertexOffset, call->vertexCount);
             gl->encoder->setTexture(0, gl->s_tex, gl->th);
             gl->encoder->setTexture(1, gl->s_tex2, gl->th2);
-            gl->encoder->setStencil(0);
+            gl->encoder->setStencil(0
+                    | BGFX_STENCIL_TEST_NOTEQUAL
+                    | BGFX_STENCIL_FUNC_RMASK(0xff)
+                    | BGFX_STENCIL_OP_FAIL_S_ZERO
+                    | BGFX_STENCIL_OP_FAIL_Z_ZERO
+                    | BGFX_STENCIL_OP_PASS_Z_ZERO
+                    );
             outBuffer->Submit(*gl->encoder, prog, BGFX_DISCARD_ALL);
         };
         std::function filterPass = [gl, call](bgfx::ProgramHandle prog, Babylon::Graphics::FrameBuffer *inBuffer, Babylon::Graphics::FrameBuffer *outBuffer) {

--- a/Polyfills/Canvas/Source/nanovg/nanovg_babylon.cpp
+++ b/Polyfills/Canvas/Source/nanovg/nanovg_babylon.cpp
@@ -722,19 +722,7 @@ namespace
                 if (2 < paths[i].fillCount)
                 {
                     gl->encoder->setState(0);
-                    gl->encoder->setStencil(0
-                        | BGFX_STENCIL_TEST_ALWAYS
-                        | BGFX_STENCIL_FUNC_RMASK(0xff)
-                        | BGFX_STENCIL_OP_FAIL_S_KEEP
-                        | BGFX_STENCIL_OP_FAIL_Z_KEEP
-                        | BGFX_STENCIL_OP_PASS_Z_INCR
-                        , 0
-                        | BGFX_STENCIL_TEST_ALWAYS
-                        | BGFX_STENCIL_FUNC_RMASK(0xff)
-                        | BGFX_STENCIL_OP_FAIL_S_KEEP
-                        | BGFX_STENCIL_OP_FAIL_Z_KEEP
-                        | BGFX_STENCIL_OP_PASS_Z_DECR
-                        );
+                    gl->encoder->setStencil(0);
                     gl->encoder->setVertexBuffer(0, &gl->tvb);
                     gl->encoder->setTexture(0, gl->s_tex, gl->th);
                     gl->encoder->setTexture(1, gl->s_tex2, gl->th2);
@@ -754,13 +742,7 @@ namespace
                     gl->encoder->setState(gl->state
                         | BGFX_STATE_PT_TRISTRIP
                         );
-                    gl->encoder->setStencil(0
-                        | BGFX_STENCIL_TEST_EQUAL
-                        | BGFX_STENCIL_FUNC_RMASK(0xff)
-                        | BGFX_STENCIL_OP_FAIL_S_KEEP
-                        | BGFX_STENCIL_OP_FAIL_Z_KEEP
-                        | BGFX_STENCIL_OP_PASS_Z_KEEP
-                        );
+                    gl->encoder->setStencil(0);
                     gl->encoder->setVertexBuffer(0, &gl->tvb, paths[i].strokeOffset, paths[i].strokeCount);
                     gl->encoder->setTexture(0, gl->s_tex, gl->th);
                     gl->encoder->setTexture(1, gl->s_tex2, gl->th2);
@@ -773,13 +755,7 @@ namespace
             gl->encoder->setVertexBuffer(0, &gl->tvb, call->vertexOffset, call->vertexCount);
             gl->encoder->setTexture(0, gl->s_tex, gl->th);
             gl->encoder->setTexture(1, gl->s_tex2, gl->th2);
-            gl->encoder->setStencil(0
-                    | BGFX_STENCIL_TEST_NOTEQUAL
-                    | BGFX_STENCIL_FUNC_RMASK(0xff)
-                    | BGFX_STENCIL_OP_FAIL_S_ZERO
-                    | BGFX_STENCIL_OP_FAIL_Z_ZERO
-                    | BGFX_STENCIL_OP_PASS_Z_ZERO
-                    );
+            gl->encoder->setStencil(0);
             outBuffer->Submit(*gl->encoder, prog, BGFX_DISCARD_ALL);
         };
         std::function filterPass = [gl, call](bgfx::ProgramHandle prog, Babylon::Graphics::FrameBuffer *inBuffer, Babylon::Graphics::FrameBuffer *outBuffer) {


### PR DESCRIPTION
Fixes:
- Depth stencil missing. Not optional in nanovg
- Unnecessary texture creation. This was caused by a bad merge resolution ([link](https://github.com/BabylonJS/BabylonNative/pull/1489/commits/50697ff3e4937cf8a2932fc67d95b5b7eddf9684))
- Missing `m_available` increment when framebuffer released caused infinite framebuffer creation

The various warnings about missing stencil bugger and failed to allocate framebuffer are now gone.