### PR TITLE
Canvas Path2D roundRect

### DIFF
--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -238,6 +238,11 @@ CreateBoxAsync(scene).then(function () {
                 diamondPath.lineTo(350, 200); // Close back to the starting point
                 context.fill(diamondPath);
 
+                // Path 2D round rect
+                context.strokeStyle = "red";
+                let roundRectPath = new engine.createCanvasPath2D();
+                roundRectPath.roundRect(300, 150, 45, 70, [10, 35]);
+                context.stroke(roundRectPath);
 
                 // Draw clipped round rect
                 // TODO: this is currently broken, clipping area does not have round corners

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -500,6 +500,12 @@ namespace Babylon::Polyfills::Internal
                         args.roundRect.width, args.roundRect.height,
                         args.roundRect.radii);
                     break;
+                case P2D_ROUNDRECTVARYING:
+                    nvgRoundedRectVarying(*m_nvg, args.roundRectVarying.x, args.roundRectVarying.y,
+                        args.roundRectVarying.width, args.roundRectVarying.height,
+                        args.roundRectVarying.topLeft, args.roundRectVarying.topRight,
+                        args.roundRectVarying.bottomRight, args.roundRectVarying.bottomLeft);
+                    break;
                 case P2D_TRANSFORM:
                     nvgTransform(*m_nvg,
                         args.transform.a, args.transform.b, args.transform.c,

--- a/Polyfills/Canvas/Source/Path2D.cpp
+++ b/Polyfills/Canvas/Source/Path2D.cpp
@@ -283,10 +283,57 @@ namespace Babylon::Polyfills::Internal
         const auto y = static_cast<float>(info[1].As<Napi::Number>().DoubleValue());
         const auto width = static_cast<float>(info[2].As<Napi::Number>().DoubleValue());
         const auto height = static_cast<float>(info[3].As<Napi::Number>().DoubleValue());
-        const auto radii = static_cast<float>(info[4].As<Napi::Number>().DoubleValue()); // TODO: support list of numbers
+        const auto radii = info[4];
 
-        Path2DCommandArgs args = {};
-        args.roundRect = {x, y, width, height, radii};
-        AppendCommand(P2D_ROUNDRECT, args);
+        if (radii.IsNumber())
+        {
+            const auto radius = radii.As<Napi::Number>().FloatValue();
+            Path2DCommandArgs args = {};
+            args.roundRect = {x, y, width, height, radius};
+            AppendCommand(P2D_ROUNDRECT, args);
+        }
+        else
+        {
+            const auto radiiArray = radii.As<Napi::Array>();
+            const auto radiiArrayLength = radiiArray.Length();
+            if (radiiArrayLength == 1)
+            {
+                const auto radius = radiiArray[0u].As<Napi::Number>().FloatValue();
+                Path2DCommandArgs args = {};
+                args.roundRect = {x, y, width, height, radius};
+                AppendCommand(P2D_ROUNDRECT, args);
+            }
+            else if (radiiArrayLength == 2)
+            {
+                const auto topLeftBottomRight = radiiArray[0u].As<Napi::Number>().FloatValue();
+                const auto topRightBottomLeft = radiiArray[1].As<Napi::Number>().FloatValue();
+                Path2DCommandArgs args = {};
+                args.roundRectVarying = {x, y, width, height, topLeftBottomRight, topRightBottomLeft, topLeftBottomRight, topRightBottomLeft};
+                AppendCommand(P2D_ROUNDRECTVARYING, args);
+            }
+            else if (radiiArrayLength == 3)
+            {
+                const auto topLeft = radiiArray[0u].As<Napi::Number>().FloatValue();
+                const auto topRightBottomLeft = radiiArray[1].As<Napi::Number>().FloatValue();
+                const auto bottomRight = radiiArray[2].As<Napi::Number>().FloatValue();
+                Path2DCommandArgs args = {};
+                args.roundRectVarying = {x, y, width, height, topLeft, topRightBottomLeft, bottomRight, topRightBottomLeft};
+                AppendCommand(P2D_ROUNDRECTVARYING, args);
+            }
+            else if (radiiArrayLength == 4)
+            {
+                const auto topLeft = radiiArray[0u].As<Napi::Number>().FloatValue();
+                const auto topRight = radiiArray[1].As<Napi::Number>().FloatValue();
+                const auto bottomRight = radiiArray[2].As<Napi::Number>().FloatValue();
+                const auto bottomLeft = radiiArray[3].As<Napi::Number>().FloatValue();
+                Path2DCommandArgs args = {};
+                args.roundRectVarying = {x, y, width, height, topLeft, topRight, bottomRight, bottomLeft};
+                AppendCommand(P2D_ROUNDRECTVARYING, args);
+            }
+            else
+            {
+                throw Napi::Error::New(info.Env(), "Invalid number of parameters for radii");
+            }
+        }
     }
 }

--- a/Polyfills/Canvas/Source/Path2D.h
+++ b/Polyfills/Canvas/Source/Path2D.h
@@ -16,7 +16,8 @@ enum Path2DCommandTypes
     P2D_ELLIPSE = 7,
     P2D_RECT = 8,
     P2D_ROUNDRECT = 9,
-    P2D_TRANSFORM = 10,
+    P2D_ROUNDRECTVARYING = 10,
+    P2D_TRANSFORM = 11,
 };
 
 struct Path2DClose {}; // TODO: don't bother if no args?
@@ -29,6 +30,7 @@ struct Path2DArcTo { float x1; float y1; float x2; float y2; float radius; };
 struct Path2DEllipse { float x; float y; float radiusX; float radiusY; float rotation; float startAngle; float endAngle; bool counterclockwise; };
 struct Path2DRect { float x; float y; float width; float height; };
 struct Path2DRoundRect { float x; float y; float width; float height; float radii; };
+struct Path2DRoundRectVarying { float x; float y; float width; float height; float topLeft; float topRight; float bottomRight; float bottomLeft; };
 struct Path2DTransform { float a; float b; float c; float d; float e; float f; };
 
 union Path2DCommandArgs
@@ -43,6 +45,7 @@ union Path2DCommandArgs
     Path2DEllipse ellipse;
     Path2DRect rect;
     Path2DRoundRect roundRect;
+    Path2DRoundRectVarying roundRectVarying;
     Path2DTransform transform;
 };
 
@@ -79,6 +82,7 @@ namespace Babylon::Polyfills::Internal
         void Ellipse(const Napi::CallbackInfo&);
         void Rect(const Napi::CallbackInfo&);
         void RoundRect(const Napi::CallbackInfo&);
+        void RoundRectVarying(const Napi::CallbackInfo&);
 
         void AppendCommand(Path2DCommandTypes type, Path2DCommandArgs args);
 


### PR DESCRIPTION
MDN: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect
Implements CSS-style radius array argument

![image](https://github.com/user-attachments/assets/48ae0d13-fc96-4681-999a-3280f56268e5)
