### PR TITLE
CopyTexture command

### DIFF
--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -8,11 +8,11 @@
       "name": "BabylonNative",
       "version": "0.0.1",
       "dependencies": {
-        "babylonjs": "^8.0.0",
-        "babylonjs-gltf2interface": "^8.0.0",
-        "babylonjs-gui": "^8.0.0",
-        "babylonjs-loaders": "^8.0.0",
-        "babylonjs-materials": "^8.0.0",
+        "babylonjs": "^8.3.1",
+        "babylonjs-gltf2interface": "^8.3.1",
+        "babylonjs-gui": "^8.3.1",
+        "babylonjs-loaders": "^8.3.1",
+        "babylonjs-materials": "^8.3.1",
         "chai": "^4.3.4",
         "jsc-android": "^241213.1.0",
         "mocha": "^9.2.2",
@@ -87,44 +87,39 @@
       }
     },
     "node_modules/babylonjs": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-8.0.0.tgz",
-      "integrity": "sha512-jCXdPH9ruqSIwFZoQo3qT+cmfTeNtl3Y8/rjCNaWNvnnRZdDKN+BgbKEZTB3GQlmEoQXLJMwKNNL/LQgxnxmLw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0"
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-8.3.1.tgz",
+      "integrity": "sha512-vrBJpt6AMcyXltN6t5UhnusTyWB2gugxEHPs0c6ef6sdLFZHRI9BE9njyppAItl3sgI0gKW5R1CALH0NFEdtrQ==",
+      "hasInstallScript": true
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-8.0.0.tgz",
-      "integrity": "sha512-BenZ6S2L0ftHqOz0ow9SSfPlAppmILmvwlJcwh6bZ9PzU+vFExsjpUSnE4zGfGKvx9VH98eD4AGwoXhExPrNjQ==",
-      "license": "Apache-2.0"
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-8.3.1.tgz",
+      "integrity": "sha512-ymnDfjRpQEoxmsiSQZKLAn2QFRSMz3HBJTZXmlIqghPeGA1H1vioeUq7/BM0eRaZAC0TdhtznainfOmdcg8DMQ=="
     },
     "node_modules/babylonjs-gui": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-8.0.0.tgz",
-      "integrity": "sha512-Bhb9cWZFAXvzPhBZLayF73pAcWQInPugR57+mZ3pKgBPABntJEnwaEF/ahb6xr0irUgmko9gWJVtBrw+J5u+QQ==",
-      "license": "Apache-2.0",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-8.3.1.tgz",
+      "integrity": "sha512-7XwlqKqdjiZLC/X1wYRusp0GwbqRRueypZF6HYsP/UpXfP0bVEU+KC8pOHFijqTROiIPJ1BWeQFIQQhp7Ba2wQ==",
       "dependencies": {
-        "babylonjs": "^8.0.0"
+        "babylonjs": "^8.3.1"
       }
     },
     "node_modules/babylonjs-loaders": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-8.0.0.tgz",
-      "integrity": "sha512-LL4vRbuvZzYuflW+Zm6WI+0bxfaGX1lwNZ8JJ2+CYWTaiWmN7LxQII+geVG8kB8jCoIX9ptVI1FJ06xSqzcPpw==",
-      "license": "Apache-2.0",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-8.3.1.tgz",
+      "integrity": "sha512-18PXsv7dr2nehs0yvRukDMYHg7+DTailjW/vp3D+QYqJROI1cBSrWl9nOjSu8L34FbCJCDCBQpxwEAsSaxx5Ow==",
       "dependencies": {
-        "babylonjs": "^8.0.0",
-        "babylonjs-gltf2interface": "^8.0.0"
+        "babylonjs": "^8.3.1",
+        "babylonjs-gltf2interface": "^8.3.1"
       }
     },
     "node_modules/babylonjs-materials": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-8.0.0.tgz",
-      "integrity": "sha512-Gi0e5hOx82i78xCE3Xxso7h3ocjhq8/8MHhkX1qdh7LkuB3Ec0ZZIRbeX56TSEG1IK21y/pBExCBv1YPIqZwRA==",
-      "license": "Apache-2.0",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-8.3.1.tgz",
+      "integrity": "sha512-Jj+t9hHCqlgdz+g89vGOyx0NH/D1Ub2YIvhOVoPwBm1HZ8QlU1T6z0r9mv2YiiNyp6mSYXB7iqMPiBSJN6N7zg==",
       "dependencies": {
-        "babylonjs": "^8.0.0"
+        "babylonjs": "^8.3.1"
       }
     },
     "node_modules/balanced-match": {

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -6,11 +6,11 @@
     "getNightly": "node scripts/getNightly.js"
   },
   "dependencies": {
-    "babylonjs": "^8.0.0",
-    "babylonjs-gltf2interface": "^8.0.0",
-    "babylonjs-gui": "^8.0.0",
-    "babylonjs-loaders": "^8.0.0",
-    "babylonjs-materials": "^8.0.0",
+    "babylonjs": "^8.3.1",
+    "babylonjs-gltf2interface": "^8.3.1",
+    "babylonjs-gui": "^8.3.1",
+    "babylonjs-loaders": "^8.3.1",
+    "babylonjs-materials": "^8.3.1",
     "chai": "^4.3.4",
     "jsc-android": "^241213.1.0",
     "mocha": "^9.2.2",

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1429,7 +1429,7 @@ namespace Babylon
 
     void NativeEngine::CopyTexture(NativeDataStream::Reader& data)
     {
-        auto encoder = GetUpdateToken().GetEncoder();
+        bgfx::Encoder* encoder = GetUpdateToken().GetEncoder();
 
         const auto textureSource = data.ReadPointer<Graphics::Texture>();
         const auto textureDestination = data.ReadPointer<Graphics::Texture>();

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -418,7 +418,7 @@ namespace Babylon
             JS_CLASS_NAME,
             {
                 // This must match the version in nativeEngine.ts
-                StaticValue("PROTOCOL_VERSION", Napi::Number::From(env, 9)),
+                StaticValue("PROTOCOL_VERSION", Napi::Number::From(env, 8)),
 
                 StaticValue("CAPS_LIMITS_MAX_TEXTURE_SIZE", Napi::Number::From(env, limits.maxTextureSize)),
                 StaticValue("CAPS_LIMITS_MAX_TEXTURE_LAYERS", Napi::Number::From(env, limits.maxTextureLayers)),

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -418,7 +418,7 @@ namespace Babylon
             JS_CLASS_NAME,
             {
                 // This must match the version in nativeEngine.ts
-                StaticValue("PROTOCOL_VERSION", Napi::Number::From(env, 8)),
+                StaticValue("PROTOCOL_VERSION", Napi::Number::From(env, 9)),
 
                 StaticValue("CAPS_LIMITS_MAX_TEXTURE_SIZE", Napi::Number::From(env, limits.maxTextureSize)),
                 StaticValue("CAPS_LIMITS_MAX_TEXTURE_LAYERS", Napi::Number::From(env, limits.maxTextureLayers)),

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -184,7 +184,7 @@ namespace Babylon
         Napi::Value CreateTexture(const Napi::CallbackInfo& info);
         void InitializeTexture(const Napi::CallbackInfo& info);
         void LoadTexture(const Napi::CallbackInfo& info);
-        void CopyTexture(const Napi::CallbackInfo& info);
+        void CopyTexture(NativeDataStream::Reader& data);
         void LoadRawTexture(const Napi::CallbackInfo& info);
         void LoadRawTexture2DArray(const Napi::CallbackInfo& info);
         void LoadCubeTexture(const Napi::CallbackInfo& info);

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -78,7 +78,11 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value NativeCanvas::GetContext(const Napi::CallbackInfo& info)
     {
-        return Context::CreateInstance(info.Env(), this);
+        if (m_contextObject.IsEmpty())
+        {
+            m_contextObject = Napi::Persistent(Context::CreateInstance(info.Env(), info.This()).As<Napi::Object>());
+        }
+        return m_contextObject.Value();
     }
 
     Napi::Value NativeCanvas::GetWidth(const Napi::CallbackInfo&)
@@ -111,7 +115,7 @@ namespace Babylon::Polyfills::Internal
         }
     }
 
-    bool NativeCanvas::UpdateRenderTarget()
+    void NativeCanvas::UpdateRenderTarget()
     {
         if (m_dirty)
         {
@@ -142,10 +146,7 @@ namespace Babylon::Polyfills::Internal
             {
                 m_texture.reset();
             }
-
-            return true;
         }
-        return false;
     }
 
     Napi::Value NativeCanvas::GetCanvasTexture(const Napi::CallbackInfo& info)

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -78,7 +78,7 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value NativeCanvas::GetContext(const Napi::CallbackInfo& info)
     {
-        const auto thisObj = info.This().ToObject();
+        auto thisObj = info.This().ToObject();
         const auto contextPropertyName = Napi::Value::From(Env(), "_context");
 
         auto context = thisObj.Get(contextPropertyName);

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -78,11 +78,17 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value NativeCanvas::GetContext(const Napi::CallbackInfo& info)
     {
-        if (m_contextObject.IsEmpty())
+        const auto thisObj = info.This().ToObject();
+        const auto contextPropertyName = Napi::Value::From(Env(), "_context");
+
+        auto context = thisObj.Get(contextPropertyName);
+        if (context.IsUndefined())
         {
-            m_contextObject = Napi::Persistent(Context::CreateInstance(info.Env(), info.This()).As<Napi::Object>());
+            context = Context::CreateInstance(info.Env(), info.This());
+            thisObj.Set(contextPropertyName, context);
         }
-        return m_contextObject.Value();
+
+        return context;
     }
 
     Napi::Value NativeCanvas::GetWidth(const Napi::CallbackInfo&)

--- a/Polyfills/Canvas/Source/Canvas.h
+++ b/Polyfills/Canvas/Source/Canvas.h
@@ -64,8 +64,7 @@ namespace Babylon::Polyfills::Internal
 
         static inline std::map<std::string, std::vector<uint8_t>> fontsInfos;
 
-        // returns true if frameBuffer size has changed
-        bool UpdateRenderTarget();
+        void UpdateRenderTarget();
         Babylon::Graphics::FrameBuffer& GetFrameBuffer() { return *m_frameBuffer; }
 
         Graphics::DeviceContext& GetGraphicsContext()
@@ -85,6 +84,8 @@ namespace Babylon::Polyfills::Internal
         void Remove(const Napi::CallbackInfo& info);
         void Dispose(const Napi::CallbackInfo& info);
         void Dispose();
+
+        Napi::ObjectReference m_contextObject{};
 
         uint16_t m_width{1};
         uint16_t m_height{1};

--- a/Polyfills/Canvas/Source/Canvas.h
+++ b/Polyfills/Canvas/Source/Canvas.h
@@ -85,8 +85,6 @@ namespace Babylon::Polyfills::Internal
         void Dispose(const Napi::CallbackInfo& info);
         void Dispose();
 
-        Napi::ObjectReference m_contextObject{};
-
         uint16_t m_width{1};
         uint16_t m_height{1};
 

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -70,6 +70,7 @@ namespace Babylon::Polyfills::Internal
                 InstanceMethod("createLinearGradient", &Context::CreateLinearGradient),
                 InstanceMethod("setTransform", &Context::SetTransform),
                 InstanceMethod("dispose", &Context::Dispose),
+                InstanceMethod("flush", &Context::Flush),
                 InstanceAccessor("lineJoin", &Context::GetLineJoin, &Context::SetLineJoin),
                 InstanceAccessor("miterLimit", &Context::GetMiterLimit, &Context::SetMiterLimit),
                 InstanceAccessor("font", &Context::GetFont, &Context::SetFont),
@@ -81,22 +82,21 @@ namespace Babylon::Polyfills::Internal
                 InstanceAccessor("shadowOffsetX", &Context::GetShadowOffsetX, &Context::SetShadowOffsetX),
                 InstanceAccessor("shadowOffsetY", &Context::GetShadowOffsetY, &Context::SetShadowOffsetY),
                 InstanceAccessor("lineWidth", &Context::GetLineWidth, &Context::SetLineWidth),
-                InstanceAccessor("canvas", &Context::GetCanvas, nullptr),
             });
         JsRuntime::NativeObject::GetFromJavaScript(env).Set(JS_CONTEXT_CONSTRUCTOR_NAME, func);
     }
 
-    Napi::Value Context::CreateInstance(Napi::Env env, NativeCanvas* canvas)
+    Napi::Value Context::CreateInstance(Napi::Env env, Napi::Value canvas)
     {
         Napi::HandleScope scope{env};
 
         auto func = JsRuntime::NativeObject::GetFromJavaScript(env).Get(JS_CONTEXT_CONSTRUCTOR_NAME).As<Napi::Function>();
-        return func.New({Napi::External<NativeCanvas>::New(env, canvas)});
+        return func.New({canvas});
     }
 
     Context::Context(const Napi::CallbackInfo& info)
         : Napi::ObjectWrap<Context>{info}
-        , m_canvas{info[0].As<Napi::External<NativeCanvas>>().Data()}
+        , m_canvas{NativeCanvas::Unwrap(info[0].As<Napi::Object>())}
         , m_nvg{nvgCreate(1)}
         , m_graphicsContext{m_canvas->GetGraphicsContext()}
         , m_update{m_graphicsContext.GetUpdate("update")}
@@ -104,6 +104,10 @@ namespace Babylon::Polyfills::Internal
         , m_runtimeScheduler{Babylon::JsRuntime::GetFromJavaScript(info.Env())}
         , Polyfills::Canvas::Impl::MonitoredResource{Polyfills::Canvas::Impl::GetFromJavaScript(info.Env())}
     {
+        // TODO: commented code doesn't compile with napi-jsi. Using non read-only property for now
+        //info.This().ToObject().DefineProperty(Napi::PropertyDescriptor::Value("canvas", info[0], napi_enumerable));
+        info.This().ToObject().Set("canvas", info[0]);
+
         for (auto& font : NativeCanvas::fontsInfos)
         {
             m_fonts[font.first] = nvgCreateFontMem(m_nvg, font.first.c_str(), font.second.data(), static_cast<int>(font.second.size()), 0);
@@ -158,7 +162,6 @@ namespace Babylon::Polyfills::Internal
         const auto color = StringToColor(info.Env(), m_fillStyle);
         nvgFillColor(m_nvg, color);
         nvgFill(m_nvg);
-        SetDirty();
     }
 
     Napi::Value Context::GetFillStyle(const Napi::CallbackInfo&)
@@ -171,7 +174,6 @@ namespace Babylon::Polyfills::Internal
         m_fillStyle = value.As<Napi::String>().Utf8Value();
         const auto color = StringToColor(info.Env(), m_fillStyle);
         nvgFillColor(m_nvg, color);
-        SetDirty();
     }
 
     Napi::Value Context::GetStrokeStyle(const Napi::CallbackInfo&)
@@ -184,7 +186,6 @@ namespace Babylon::Polyfills::Internal
         m_strokeStyle = value.As<Napi::String>().Utf8Value();
         auto color = StringToColor(info.Env(), m_strokeStyle);
         nvgStrokeColor(m_nvg, color);
-        SetDirty();
     }
 
     Napi::Value Context::GetLineWidth(const Napi::CallbackInfo&)
@@ -196,25 +197,21 @@ namespace Babylon::Polyfills::Internal
     {
         m_lineWidth = value.As<Napi::Number>().FloatValue();
         nvgStrokeWidth(m_nvg, m_lineWidth);
-        SetDirty();
     }
 
     void Context::Fill(const Napi::CallbackInfo&)
     {
         nvgFill(m_nvg);
-        SetDirty();
     }
 
     void Context::Save(const Napi::CallbackInfo&)
     {
         nvgSave(m_nvg);
-        SetDirty();
     }
 
     void Context::Restore(const Napi::CallbackInfo&)
     {
         nvgRestore(m_nvg);
-        SetDirty();
         m_isClipped = false;
     }
 
@@ -243,7 +240,6 @@ namespace Babylon::Polyfills::Internal
         nvgFillColor(m_nvg, TRANSPARENT_BLACK);
         nvgFill(m_nvg);
         nvgRestore(m_nvg);
-        SetDirty();
     }
 
     void Context::Translate(const Napi::CallbackInfo& info)
@@ -251,14 +247,12 @@ namespace Babylon::Polyfills::Internal
         const auto x = info[0].As<Napi::Number>().FloatValue();
         const auto y = info[1].As<Napi::Number>().FloatValue();
         nvgTranslate(m_nvg, x, y);
-        SetDirty();
     }
 
     void Context::Rotate(const Napi::CallbackInfo& info)
     {
         const auto angle = info[0].As<Napi::Number>().FloatValue();
         nvgRotate(m_nvg, angle);
-        SetDirty();
     }
 
     void Context::Scale(const Napi::CallbackInfo& info)
@@ -266,19 +260,16 @@ namespace Babylon::Polyfills::Internal
         const auto x = info[0].As<Napi::Number>().FloatValue();
         const auto y = info[1].As<Napi::Number>().FloatValue();
         nvgScale(m_nvg, x, y);
-        SetDirty();
     }
 
     void Context::BeginPath(const Napi::CallbackInfo&)
     {
         nvgBeginPath(m_nvg);
-        SetDirty();
     }
 
     void Context::ClosePath(const Napi::CallbackInfo&)
     {
         nvgClosePath(m_nvg);
-        SetDirty();
     }
 
     void Context::Rect(const Napi::CallbackInfo& info)
@@ -290,7 +281,6 @@ namespace Babylon::Polyfills::Internal
 
         nvgRect(m_nvg, left, top, width, height);
         m_rectangleClipping = {left, top, width, height};
-        SetDirty();
     }
 
     void Context::Clip(const Napi::CallbackInfo& /*info*/)
@@ -314,13 +304,11 @@ namespace Babylon::Polyfills::Internal
 
         nvgRect(m_nvg, left, top, width, height);
         nvgStroke(m_nvg);
-        SetDirty();
     }
 
     void Context::Stroke(const Napi::CallbackInfo&)
     {
         nvgStroke(m_nvg);
-        SetDirty();
     }
 
     void Context::MoveTo(const Napi::CallbackInfo& info)
@@ -329,7 +317,6 @@ namespace Babylon::Polyfills::Internal
         const auto y = info[1].As<Napi::Number>().FloatValue();
 
         nvgMoveTo(m_nvg, x, y);
-        SetDirty();
     }
 
     void Context::LineTo(const Napi::CallbackInfo& info)
@@ -338,7 +325,6 @@ namespace Babylon::Polyfills::Internal
         const auto y = info[1].As<Napi::Number>().FloatValue();
 
         nvgLineTo(m_nvg, x, y);
-        SetDirty();
     }
 
     void Context::QuadraticCurveTo(const Napi::CallbackInfo& info)
@@ -349,7 +335,6 @@ namespace Babylon::Polyfills::Internal
         const auto y = info[3].As<Napi::Number>().FloatValue();
 
         nvgBezierTo(m_nvg, cx, cy, cx, cy, x, y);
-        SetDirty();
     }
 
     Napi::Value Context::MeasureText(const Napi::CallbackInfo& info)
@@ -376,51 +361,24 @@ namespace Babylon::Polyfills::Internal
             }
 
             nvgText(m_nvg, x, y, text.c_str(), nullptr);
-            SetDirty();
         }
     }
 
-    void Context::SetDirty()
+    void Context::Flush(const Napi::CallbackInfo&)
     {
-        if (!m_dirty)
-        {
-            m_dirty = true;
-            DeferredFlushFrame();
-        }
-    }
+        m_canvas->UpdateRenderTarget();
 
-    void Context::DeferredFlushFrame()
-    {
-        // on some systems (Ubuntu), the framebuffer contains garbage.
-        // Unlike other systems where it's cleared.
-        bool needClear = m_canvas->UpdateRenderTarget();
+        Graphics::FrameBuffer& frameBuffer = m_canvas->GetFrameBuffer();
+        bgfx::Encoder* encoder = m_update.GetUpdateToken().GetEncoder();
+        frameBuffer.Bind(*encoder);
+        frameBuffer.SetViewPort(*encoder, 0.f, 0.f, 1.f, 1.f);
+        const auto width = m_canvas->GetWidth();
+        const auto height = m_canvas->GetHeight();
 
-        arcana::make_task(m_update.Scheduler(), *m_cancellationSource, [this, needClear, cancellationSource{m_cancellationSource}]() {
-            return arcana::make_task(m_runtimeScheduler, *m_cancellationSource, [this, needClear, updateToken{m_update.GetUpdateToken()}, cancellationSource{m_cancellationSource}]() {
-                // JS Thread
-                Graphics::FrameBuffer& frameBuffer = m_canvas->GetFrameBuffer();
-                bgfx::Encoder* encoder = m_update.GetUpdateToken().GetEncoder();
-                frameBuffer.Bind(*encoder);
-                if (needClear)
-                {
-                    frameBuffer.Clear(*encoder, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH | BGFX_CLEAR_STENCIL, 0, 1.f, 0);
-                }
-                frameBuffer.SetViewPort(*encoder, 0.f, 0.f, 1.f, 1.f);
-                const auto width = m_canvas->GetWidth();
-                const auto height = m_canvas->GetHeight();
-
-                nvgBeginFrame(m_nvg, float(width), float(height), 1.0f);
-                nvgSetFrameBufferAndEncoder(m_nvg, frameBuffer, encoder);
-                nvgEndFrame(m_nvg);
-                frameBuffer.Unbind(*encoder);
-                m_dirty = false;
-            }).then(arcana::inline_scheduler, *m_cancellationSource, [this, cancellationSource{m_cancellationSource}](const arcana::expected<void, std::exception_ptr>& result) {
-                if (!cancellationSource->cancelled() && result.has_error())
-                {
-                    Napi::Error::New(Env(), result.error()).ThrowAsJavaScriptException();
-                }
-            });
-        });
+        nvgBeginFrame(m_nvg, float(width), float(height), 1.0f);
+        nvgSetFrameBufferAndEncoder(m_nvg, frameBuffer, encoder);
+        nvgEndFrame(m_nvg);
+        frameBuffer.Unbind(*encoder);
     }
 
     void Context::PutImageData(const Napi::CallbackInfo&)
@@ -437,7 +395,6 @@ namespace Babylon::Polyfills::Internal
         const auto endAngle = static_cast<float>(info[4].As<Napi::Number>().DoubleValue());
         const NVGwinding winding = (info.Length() == 6 && info[5].As<Napi::Boolean>()) ? NVGwinding::NVG_CCW : NVGwinding::NVG_CW;
         nvgArc(m_nvg, x, y, radius, startAngle, endAngle, winding);
-        SetDirty();
     }
 
     void Context::DrawImage(const Napi::CallbackInfo& info)
@@ -474,7 +431,6 @@ namespace Babylon::Polyfills::Internal
             nvgRect(m_nvg, dx, dy, width, height);
             nvgFillPaint(m_nvg, imagePaint);
             nvgFill(m_nvg);
-            SetDirty();
         }
         else if (info.Length() == 5)
         {
@@ -493,7 +449,6 @@ namespace Babylon::Polyfills::Internal
             nvgRect(m_nvg, dx, dy, dWidth, dHeight);
             nvgFillPaint(m_nvg, imagePaint);
             nvgFill(m_nvg);
-            SetDirty();
         }
         else if (info.Length() == 9)
         {
@@ -518,7 +473,6 @@ namespace Babylon::Polyfills::Internal
             nvgRect(m_nvg, dx, dy, dWidth, dHeight);
             nvgFillPaint(m_nvg, imagePaint);
             nvgFill(m_nvg);
-            SetDirty();
         }
         else
         {
@@ -663,11 +617,6 @@ namespace Babylon::Polyfills::Internal
     }
 
     void Context::SetShadowOffsetY(const Napi::CallbackInfo& info, const Napi::Value& value)
-    {
-        throw Napi::Error::New(info.Env(), "not implemented");
-    }
-
-    Napi::Value Context::GetCanvas(const Napi::CallbackInfo& info)
     {
         throw Napi::Error::New(info.Env(), "not implemented");
     }

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -88,8 +88,6 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value Context::CreateInstance(Napi::Env env, Napi::Value canvas)
     {
-        Napi::HandleScope scope{env};
-
         auto func = JsRuntime::NativeObject::GetFromJavaScript(env).Get(JS_CONTEXT_CONSTRUCTOR_NAME).As<Napi::Function>();
         return func.New({canvas});
     }

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -369,7 +369,9 @@ namespace Babylon::Polyfills::Internal
         m_canvas->UpdateRenderTarget();
 
         Graphics::FrameBuffer& frameBuffer = m_canvas->GetFrameBuffer();
-        bgfx::Encoder* encoder = m_update.GetUpdateToken().GetEncoder();
+
+        auto updateToken{m_update.GetUpdateToken()};
+        bgfx::Encoder* encoder = updateToken.GetEncoder();
         frameBuffer.Bind(*encoder);
         frameBuffer.SetViewPort(*encoder, 0.f, 0.f, 1.f, 1.f);
         const auto width = m_canvas->GetWidth();

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -287,9 +287,9 @@ namespace Babylon::Polyfills::Internal
     {
         m_isClipped = true;
 
-        //By default m_rectangleClipping is not set, in this case we use the default render target width and height.
-        auto w = m_rectangleClipping.width != 0 ? m_rectangleClipping.width : m_canvas->GetFrameBuffer().Width();
-        auto h = m_rectangleClipping.height != 0 ? m_rectangleClipping.height : m_canvas->GetFrameBuffer().Height();
+        //By default m_rectangleClipping is not set, in this case we use the canvas width and height.
+        auto w = m_rectangleClipping.width != 0 ? m_rectangleClipping.width : m_canvas->GetWidth();
+        auto h = m_rectangleClipping.height != 0 ? m_rectangleClipping.height : m_canvas->GetHeight();
 
         // expand clipping 1pix in each direction because nanovg AA gets cut a bit short.
         nvgScissor(m_nvg, m_rectangleClipping.left - 1, m_rectangleClipping.top - 1, w + 1, h + 1);

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -13,7 +13,7 @@ namespace Babylon::Polyfills::Internal
     {
     public:
         static void Initialize(Napi::Env);
-        static Napi::Value CreateInstance(Napi::Env env, NativeCanvas* canvas);
+        static Napi::Value CreateInstance(Napi::Env env, Napi::Value canvas);
 
         explicit Context(const Napi::CallbackInfo& info);
         virtual ~Context();
@@ -72,8 +72,7 @@ namespace Babylon::Polyfills::Internal
         Napi::Value GetCanvas(const Napi::CallbackInfo&);
         void Dispose(const Napi::CallbackInfo&);
         void Dispose();
-        void SetDirty();
-        void DeferredFlushFrame();
+        void Flush(const Napi::CallbackInfo&);
 
         NativeCanvas* m_canvas;
         NVGcontext* m_nvg;
@@ -90,7 +89,6 @@ namespace Babylon::Polyfills::Internal
         Graphics::DeviceContext& m_graphicsContext;
         Graphics::Update m_update;
 
-        bool m_dirty{};
         bool m_isClipped{false};
 
         struct RectangleClipping


### PR DESCRIPTION
BJS PR ( ~~https://github.com/BabylonJS/Babylon.js/pull/16497~~ https://github.com/BabylonJS/Babylon.js/pull/16502 )needs to be merged before and a new NPM needs to be generated. 

Copy texture is now a queued command (see BJS PR), protocol changed.

Before: 

- canvas rendering was done with a task, in sync with frame rendering. 

Now:

- canvas rendering is done when when copying texture. Browser HTML Canvas rendering happens when rendering commands are issued. With Native, nanovg keeps its own queue that needs to be actually done before the copy. This is done with the `flush` command.
- Because of this 'flush when needed', no need to keep a dirty flag in the context.
- In order to always get the same context with `Canvas.getContext` some code from `CanvasTest` branch has been integrated in this PR

### Test

add this to experience.js. Quad gets black when texture is disposed.

```

    var ground = BABYLON.MeshBuilder.CreateGround("ground1", { width: 0.5, height: 0.5, subdivisions: 2 }, scene);
    ground.rotation.x = -Math.PI * 0.5;
    ground.rotation.y = Math.PI;

    var texSize = 512;
    var dynamicTexture = new BABYLON.DynamicTexture("dynamic texture", texSize, scene);
    dynamicTexture.clear();
    var context = dynamicTexture.getContext();


    var materialGround = new BABYLON.StandardMaterial("Mat", scene);
    materialGround.diffuseTexture = dynamicTexture;
    ground.material = materialGround;
    materialGround.backFaceCulling = false;

    context.save();
    context.fillStyle = "DarkRed";
    context.fillRect(0, 0, texSize, texSize);
    context.restore();

    dynamicTexture.update();
    setTimeout(() => {
        console.log("update-dispose");
        dynamicTexture.update();
        dynamicTexture.dispose();
    }, 5000);
```
### Testing Issues 

- [x] `Dynamic Texture context clip` :  race condition. shape is rendered when using a breakpoint
~~- [ ] `GLTF Extension KHR_materials_volume with attenuation` : rendering is a bit different but it doesn't seem to be related to Canvas/copytexture. To confirm~~ wrong material.js
- [x] `GLTF Material Alpha Mask`: inconsistent result. Might be related to race condition mentioned above.