### PR TITLE
Canvas roundRect DOMPoint argument

### DIFF
--- a/Apps/Playground/Scripts/experience.js
+++ b/Apps/Playground/Scripts/experience.js
@@ -241,7 +241,7 @@ CreateBoxAsync(scene).then(function () {
                 // Path 2D round rect
                 context.strokeStyle = "red";
                 let roundRectPath = new engine.createCanvasPath2D();
-                roundRectPath.roundRect(300, 150, 45, 70, [10, 35]);
+                roundRectPath.roundRect(300, 150, 45, 70, { x: 30, y: 15 });
                 context.stroke(roundRectPath);
 
                 // Draw clipped round rect

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -421,6 +421,7 @@ namespace Babylon::Polyfills::Internal
             }
         }
         // DOMPoint
+        // TODO: move duplicate Path2D & Context args parsing into a utils.cpp
         else if (radii.IsObject())
         {
             const auto dompoint = radii.As<Napi::Object>();

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -382,7 +382,7 @@ namespace Babylon::Polyfills::Internal
             const auto radius = radii.As<Napi::Number>().FloatValue();
             nvgRoundedRect(*m_nvg, x, y, width, height, radius);
         }
-        else
+        else if (radii.IsArray())
         {
             const auto radiiArray = radii.As<Napi::Array>();
             const auto radiiArrayLength = radiiArray.Length();
@@ -419,6 +419,18 @@ namespace Babylon::Polyfills::Internal
             {
                 throw Napi::Error::New(info.Env(), "Invalid number of parameters for radii");
             }
+        }
+        // DOMPoint
+        else if (radii.IsObject())
+        {
+            const auto dompoint = radii.As<Napi::Object>();
+            const auto dpx = dompoint.Get("x").As<Napi::Number>().FloatValue();
+            const auto dpy = dompoint.Get("y").As<Napi::Number>().FloatValue();
+            nvgRoundedRectElliptic(*m_nvg, x, y, width, height, dpx, dpy, dpx, dpy, dpx, dpy, dpx, dpy);
+        }
+        else
+        {
+            throw Napi::Error::New(info.Env(), "Invalid radii parameter");
         }
 
         m_rectangleClipping = {x, y, width, height};
@@ -506,6 +518,14 @@ namespace Babylon::Polyfills::Internal
                         args.roundRectVarying.width, args.roundRectVarying.height,
                         args.roundRectVarying.topLeft, args.roundRectVarying.topRight,
                         args.roundRectVarying.bottomRight, args.roundRectVarying.bottomLeft);
+                    break;
+                case P2D_ROUNDRECTELLIPTIC:
+                    nvgRoundedRectElliptic(*m_nvg, args.roundRectElliptic.x, args.roundRectElliptic.y,
+                        args.roundRectElliptic.width, args.roundRectElliptic.height,
+                        args.roundRectElliptic.topLeftX, args.roundRectElliptic.topLeftY,
+                        args.roundRectElliptic.topRightX, args.roundRectElliptic.topRightY,
+                        args.roundRectElliptic.bottomRightX, args.roundRectElliptic.bottomRightY,
+                        args.roundRectElliptic.bottomLeftX, args.roundRectElliptic.bottomLeftY);
                     break;
                 case P2D_TRANSFORM:
                     nvgTransform(*m_nvg,

--- a/Polyfills/Canvas/Source/Path2D.cpp
+++ b/Polyfills/Canvas/Source/Path2D.cpp
@@ -336,6 +336,7 @@ namespace Babylon::Polyfills::Internal
             }
         }
         // DOMPoint
+        // TODO: move duplicate Path2D & Context args parsing into a utils.cpp
         else if (radii.IsObject())
         {
             const auto dompoint = radii.As<Napi::Object>();

--- a/Polyfills/Canvas/Source/Path2D.cpp
+++ b/Polyfills/Canvas/Source/Path2D.cpp
@@ -292,7 +292,7 @@ namespace Babylon::Polyfills::Internal
             args.roundRect = {x, y, width, height, radius};
             AppendCommand(P2D_ROUNDRECT, args);
         }
-        else
+        else if (radii.IsArray())
         {
             const auto radiiArray = radii.As<Napi::Array>();
             const auto radiiArrayLength = radiiArray.Length();
@@ -334,6 +334,20 @@ namespace Babylon::Polyfills::Internal
             {
                 throw Napi::Error::New(info.Env(), "Invalid number of parameters for radii");
             }
+        }
+        // DOMPoint
+        else if (radii.IsObject())
+        {
+            const auto dompoint = radii.As<Napi::Object>();
+            const auto radiusX = dompoint.Get("x").As<Napi::Number>().FloatValue();
+            const auto radiusY = dompoint.Get("y").As<Napi::Number>().FloatValue();
+            Path2DCommandArgs args = {};
+            args.roundRectElliptic = {x, y, width, height, radiusX, radiusY, radiusX, radiusY, radiusX, radiusY, radiusX, radiusY};
+            AppendCommand(P2D_ROUNDRECTELLIPTIC, args);
+        }
+        else
+        {
+            throw Napi::Error::New(info.Env(), "Invalid radii parameter");
         }
     }
 }

--- a/Polyfills/Canvas/Source/Path2D.h
+++ b/Polyfills/Canvas/Source/Path2D.h
@@ -17,7 +17,8 @@ enum Path2DCommandTypes
     P2D_RECT = 8,
     P2D_ROUNDRECT = 9,
     P2D_ROUNDRECTVARYING = 10,
-    P2D_TRANSFORM = 11,
+    P2D_ROUNDRECTELLIPTIC = 11,
+    P2D_TRANSFORM = 12,
 };
 
 struct Path2DClose {}; // TODO: don't bother if no args?
@@ -31,6 +32,7 @@ struct Path2DEllipse { float x; float y; float radiusX; float radiusY; float rot
 struct Path2DRect { float x; float y; float width; float height; };
 struct Path2DRoundRect { float x; float y; float width; float height; float radii; };
 struct Path2DRoundRectVarying { float x; float y; float width; float height; float topLeft; float topRight; float bottomRight; float bottomLeft; };
+struct Path2DRoundRectElliptic { float x; float y; float width; float height; float topLeftX; float topLeftY; float topRightX; float topRightY; float bottomRightX; float bottomRightY; float bottomLeftX; float bottomLeftY; };
 struct Path2DTransform { float a; float b; float c; float d; float e; float f; };
 
 union Path2DCommandArgs
@@ -46,6 +48,7 @@ union Path2DCommandArgs
     Path2DRect rect;
     Path2DRoundRect roundRect;
     Path2DRoundRectVarying roundRectVarying;
+    Path2DRoundRectElliptic roundRectElliptic;
     Path2DTransform transform;
 };
 

--- a/Polyfills/Canvas/Source/nanovg/nanovg.cpp
+++ b/Polyfills/Canvas/Source/nanovg/nanovg.cpp
@@ -2138,21 +2138,29 @@ void nvgRect(NVGcontext* ctx, float x, float y, float w, float h)
 
 void nvgRoundedRect(NVGcontext* ctx, float x, float y, float w, float h, float r)
 {
-	nvgRoundedRectVarying(ctx, x, y, w, h, r, r, r, r);
+	nvgRoundedRectElliptic(ctx, x, y, w, h, r, r, r, r, r, r, r, r);
 }
 
 void nvgRoundedRectVarying(NVGcontext* ctx, float x, float y, float w, float h, float radTopLeft, float radTopRight, float radBottomRight, float radBottomLeft)
 {
-	if(radTopLeft < 0.1f && radTopRight < 0.1f && radBottomRight < 0.1f && radBottomLeft < 0.1f) {
+	nvgRoundedRectElliptic(ctx, x, y, w, h, radTopLeft, radTopLeft, radTopRight, radTopRight, radBottomRight, radBottomRight, radBottomLeft, radBottomLeft);
+}
+
+void nvgRoundedRectElliptic(NVGcontext* ctx, float x, float y, float w, float h, float rxTopLeft, float ryTopLeft, float rxTopRight, float ryTopRight, float rxBottomRight, float ryBottomRight, float rxBottomLeft, float ryBottomLeft)
+{
+	if (rxTopLeft < 0.1f && ryTopLeft < 0.1f && rxTopRight < 0.1f && ryTopRight < 0.1f && rxBottomRight < 0.1f && ryBottomRight < 0.1f && rxBottomLeft < 0.1f && ryBottomLeft < 0.1f)
+	{
 		nvgRect(ctx, x, y, w, h);
 		return;
-	} else {
+	}
+	else
+	{
 		float halfw = nvg__absf(w)*0.5f;
 		float halfh = nvg__absf(h)*0.5f;
-		float rxBL = nvg__minf(radBottomLeft, halfw) * nvg__signf(w), ryBL = nvg__minf(radBottomLeft, halfh) * nvg__signf(h);
-		float rxBR = nvg__minf(radBottomRight, halfw) * nvg__signf(w), ryBR = nvg__minf(radBottomRight, halfh) * nvg__signf(h);
-		float rxTR = nvg__minf(radTopRight, halfw) * nvg__signf(w), ryTR = nvg__minf(radTopRight, halfh) * nvg__signf(h);
-		float rxTL = nvg__minf(radTopLeft, halfw) * nvg__signf(w), ryTL = nvg__minf(radTopLeft, halfh) * nvg__signf(h);
+		float rxBL = nvg__minf(rxBottomLeft, halfw) * nvg__signf(w), ryBL = nvg__minf(ryBottomLeft, halfh) * nvg__signf(h);
+		float rxBR = nvg__minf(rxBottomRight, halfw) * nvg__signf(w), ryBR = nvg__minf(ryBottomRight, halfh) * nvg__signf(h);
+		float rxTR = nvg__minf(rxTopRight, halfw) * nvg__signf(w), ryTR = nvg__minf(ryTopRight, halfh) * nvg__signf(h);
+		float rxTL = nvg__minf(rxTopLeft, halfw) * nvg__signf(w), ryTL = nvg__minf(ryTopRight, halfh) * nvg__signf(h);
 		float vals[] = {
 			NVG_MOVETO, x, y + ryTL,
 			NVG_LINETO, x, y + h - ryBL,

--- a/Polyfills/Canvas/Source/nanovg/nanovg.h
+++ b/Polyfills/Canvas/Source/nanovg/nanovg.h
@@ -493,6 +493,9 @@ void nvgRoundedRect(NVGcontext* ctx, float x, float y, float w, float h, float r
 // Creates new rounded rectangle shaped sub-path with varying radii for each corner.
 void nvgRoundedRectVarying(NVGcontext* ctx, float x, float y, float w, float h, float radTopLeft, float radTopRight, float radBottomRight, float radBottomLeft);
 
+// Creates new rounded rectangle shaped sub-path with varying elliptic radii for each corner.
+void nvgRoundedRectElliptic(NVGcontext* ctx, float x, float y, float w, float h, float rxTopLeft, float ryTopLeft, float rxTopRight, float ryTopRight, float rxBottomRight, float ryBottomRight, float rxBottomLeft, float ryBottomLeft);
+
 // Creates new ellipse shaped sub-path.
 void nvgEllipse(NVGcontext* ctx, float cx, float cy, float rx, float ry);
 


### PR DESCRIPTION
MDN: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect
Adds support for single DOMPoint argument in roundRect (Context, Path2D)
Looks like `nvgRoundedRectVarying` already implemented seperate x/y radius, so just needed to add extra args

![image](https://github.com/user-attachments/assets/97ba3152-4d2d-4979-91cd-224200b28492)
