### PR TITLE
fix(cmake): Use CMAKE_SOURCE_DIR for installation path

### DIFF
--- a/Install/Install.cmake
+++ b/Install/Install.cmake
@@ -1,7 +1,7 @@
 include(GNUInstallDirs)
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX "./install/" CACHE PATH "..." FORCE)
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/install" CACHE PATH "Installation directory" FORCE)
 endif()
 
 function(install_targets)


### PR DESCRIPTION
Replace relative path with CMAKE_SOURCE_DIR in Install.cmake to ensure consistent installation behavior across different platforms, especially on macOS where relative paths in CMAKE_INSTALL_PREFIX can be problematic.