### PR TITLE
fix(cmake): Use CMAKE_BINARY_DIR for installation path

### DIFF
--- a/Install/Install.cmake
+++ b/Install/Install.cmake
@@ -1,7 +1,7 @@
 include(GNUInstallDirs)
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX "./install/" CACHE PATH "..." FORCE)
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "..." FORCE)
 endif()
 
 function(install_targets)


### PR DESCRIPTION
Replace relative path with CMAKE_BINARY_DIR in Install.cmake to ensure consistent installation behavior across different platforms and support out-of-source builds. This change follows CMake best practices by keeping generated files within the build directory.