### PR TITLE
fix: don't allow loading same font more than once

### DIFF
--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -119,6 +119,7 @@ namespace Babylon::Polyfills::Internal
 
         for (auto& font : NativeCanvas::fontsInfos)
         {
+            // TODO: update nvgCreateFontMem safely when old font buffer invalidated
             m_fonts[font.first] = nvgCreateFontMem(*m_nvg, font.first.c_str(), font.second.data(), static_cast<int>(font.second.size()), 0);
         }
     }


### PR DESCRIPTION
@ryantrem found that when we load in a replacement font buffer..
the old buffer passed to nvgCreateFontMem is freed and can get corrupted

To solve this, we've made LoadTTFAsync effectively synchronous and don't allow loading in a duplicate font. We can consider future work to support safely updating existing fonts