### PR TITLE
Silence babel warning on large mocha.js file

### DIFF
--- a/Apps/babel.config.json
+++ b/Apps/babel.config.json
@@ -1,4 +1,5 @@
 {
+  "compact": false,
   "presets": [
     ["@babel/preset-env", {
       "targets": {


### PR DESCRIPTION
Set babel "compact" option to `false` to silence warning on large mocha.js file.

See https://babeljs.io/docs/options#compact. Leaving this option set to the "auto" default causes a warning for mocha.js since it is > 500kb.