### PR TITLE
Update bgfx.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ FetchContent_Declare(base-n
     GIT_TAG 7573e77c0b9b0e8a5fb63d96dbde212c921993b4)
 FetchContent_Declare(bgfx.cmake
     GIT_REPOSITORY https://github.com/BabylonJS/bgfx.cmake.git
-    GIT_TAG fdf3ed4a62acabd7025d0a843f6d8a9aff5e3612)
+    GIT_TAG 5593175b7099af16da3df6e9bb33b9d4e5788556)
 FetchContent_Declare(CMakeExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/CMakeExtensions.git
     GIT_TAG ea28b7689530bfdc4905806f27ecf7e8ed4b5419)


### PR DESCRIPTION
Updated bgfx.cmake, removing minz from bimg_decode. This should avoid symbol duplication issues on projects that use compiler flags such as clang's ```-all_load``` and ```-no_deduplicate```. 