### PR TITLE
ReadTexture: Avoid double-free

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1759,7 +1759,7 @@ namespace Babylon
         else
         {
             bgfx::TextureHandle sourceTextureHandle{texture->Handle()};
-            auto tempTexture{false};
+            auto tempTexture = std::make_shared<bool>(false);
 
             // If the image needs to be cropped (not starting at 0, or less than full width/height (accounting for requested mip level)),
             // or if the texture was not created with the BGFX_TEXTURE_READ_BACK flag, then blit it to a temp texture.
@@ -1770,7 +1770,7 @@ namespace Babylon
                 encoder->blit(static_cast<uint16_t>(bgfx::getCaps()->limits.maxViews - 1), blitTextureHandle, /*dstMip*/ 0, /*dstX*/ 0, /*dstY*/ 0, /*dstZ*/ 0, sourceTextureHandle, mipLevel, x, y, /*srcZ*/ 0, width, height, /*depth*/ 0);
 
                 sourceTextureHandle = blitTextureHandle;
-                tempTexture = true;
+                *tempTexture = true;
 
                 // The requested mip level was blitted, so the source texture now has just one mip, so reset the mip level to 0.
                 mipLevel = 0;
@@ -1814,10 +1814,10 @@ namespace Babylon
 
                     // Dispose of the texture handle before resolving the promise.
                     // TODO: Handle properly handle stale handles after BGFX shutdown
-                    if (tempTexture && !m_cancellationSource->cancelled())
+                    if (*tempTexture && !m_cancellationSource->cancelled())
                     {
                         bgfx::destroy(sourceTextureHandle);
-                        tempTexture = false;
+                        *tempTexture = false;
                     }
 
                     deferred.Resolve(bufferRef.Value());
@@ -1825,7 +1825,7 @@ namespace Babylon
                 .then(m_runtimeScheduler, arcana::cancellation::none(), [this, env, deferred, tempTexture, sourceTextureHandle](const arcana::expected<void, std::exception_ptr>& result) {
                     // Dispose of the texture handle if not yet disposed.
                     // TODO: Handle properly handle stale handles after BGFX shutdown
-                    if (tempTexture && !m_cancellationSource->cancelled())
+                    if (*tempTexture && !m_cancellationSource->cancelled())
                     {
                         bgfx::destroy(sourceTextureHandle);
                     }


### PR DESCRIPTION
Both lambda captures get a copy of `tempTexture`, so if the first lambda sets `tempTexture = false`, the second lambda will still have `tempTexture = true` and try to destroy an already-destroyed handle.