### PR TITLE
Fall back to main screen scale for an unparented MTKView

### DIFF
--- a/Core/Graphics/Source/DeviceImpl_iOS.mm
+++ b/Core/Graphics/Source/DeviceImpl_iOS.mm
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <Babylon/Graphics/Platform.h>
 #include "DeviceImpl.h"
 
@@ -14,6 +15,14 @@ namespace Babylon::Graphics
 
     float DeviceImpl::GetDevicePixelRatio(WindowT window)
     {
-        return window.contentScaleFactor;
+        // contentScaleFactor can return infinity if the view is not yet parented
+        // to a window hierarchy (and thus has no associated screen).
+        // Fallback to the scale from the main screen.
+        float scale = window.contentScaleFactor;
+        if (std::isinf(scale) || scale <= 0)
+        {
+            scale = UIScreen.mainScreen.scale;
+        }
+        return scale;
     }
 }


### PR DESCRIPTION
When an MTKView is unparented and therefore not on a screen, it returns infinity for the scale. In this case, fall back to the main screen scale. When an MTKView changes from one display to another, the consumer would have to call UpdateWindow anyway with the current API.