### PR TITLE
Use D3D11 in CI when sanitizers are enabled

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,18 +62,17 @@ jobs:
 
   - template: .github/jobs/win32.yml
     parameters:
+      name: Win32_x64_D3D11_Sanitizers
+      vmImage: "windows-latest"
+      platform: x64
+      enableSanitizers: true
+
+  - template: .github/jobs/win32.yml
+    parameters:
       name: Win32_x64_D3D12
       vmImage: "windows-latest"
       platform: x64
       graphics_api: D3D12
-
-  - template: .github/jobs/win32.yml
-    parameters:
-      name: Win32_x64_D3D12_Sanitizers
-      vmImage: "windows-latest"
-      platform: x64
-      graphics_api: D3D12
-      enableSanitizers: true
 
   # UWP
   - template: .github/jobs/uwp.yml


### PR DESCRIPTION
The CI for D3D12 is slow compared to D3D11. Enabling sanitizers makes it even slower. Using D3D11 makes it better.
