### PR TITLE
Fix OGL internal texture format

### DIFF
--- a/Plugins/NativeCamera/Source/Android/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Android/CameraDevice.cpp
@@ -17,6 +17,7 @@
 #include <arcana/macros.h>
 #include <memory>
 #include "CameraWrappers.h"
+#include <sstream>
 
 using namespace android;
 using namespace android::global;


### PR DESCRIPTION
- Add checks for opengl calls + assert
- destroy previous texture and framebuffer when getting new dimensions
- change texture internal format from GL_RGBA to GL_RGBA8: source of crash when trying to read back.