### PR TITLE
Replace ifstream/ofstream with istream/ostream in ShaderCache

### DIFF
--- a/Plugins/ShaderCache/Include/Babylon/Plugins/ShaderCache.h
+++ b/Plugins/ShaderCache/Include/Babylon/Plugins/ShaderCache.h
@@ -19,9 +19,9 @@ namespace Babylon::Plugins::ShaderCache
 
     // Saves the shader cache to an output file stream.
     // Returns the number of entries in the shader cache.
-    uint32_t Save(std::ofstream& stream);
+    uint32_t Save(std::ostream& stream);
 
     // Loads the shader cache from an input file stream.
     // Returns the number of entries in the shader cache.
-    uint32_t Load(std::ifstream& stream);
+    uint32_t Load(std::istream& stream);
 }

--- a/Plugins/ShaderCache/Source/ShaderCache.cpp
+++ b/Plugins/ShaderCache/Source/ShaderCache.cpp
@@ -31,7 +31,7 @@ namespace Babylon::Plugins::ShaderCache
         ShaderCacheImpl::Instance->Clear();
     }
 
-    uint32_t Save(std::ofstream& stream)
+    uint32_t Save(std::ostream& stream)
     {
         if (!ShaderCacheImpl::Instance)
         {
@@ -41,7 +41,7 @@ namespace Babylon::Plugins::ShaderCache
         return ShaderCacheImpl::Instance->Save(stream);
     }
 
-    uint32_t Load(std::ifstream& stream)
+    uint32_t Load(std::istream& stream)
     {
         if (!ShaderCacheImpl::Instance)
         {

--- a/Plugins/ShaderCache/Source/ShaderCacheImpl.cpp
+++ b/Plugins/ShaderCache/Source/ShaderCacheImpl.cpp
@@ -2,14 +2,14 @@
 
 namespace
 {
-    void SaveString(std::ofstream& stream, const std::string& string)
+    void SaveString(std::ostream& stream, const std::string& string)
     {
         uint32_t stringSize{static_cast<uint32_t>(string.size())};
         stream.write(reinterpret_cast<const char*>(&stringSize), sizeof(uint32_t));
         stream.write(reinterpret_cast<const char*>(string.data()), string.size());
     }
 
-    void LoadString(std::ifstream& stream, std::string& string)
+    void LoadString(std::istream& stream, std::string& string)
     {
         uint32_t stringSize;
         stream.read(reinterpret_cast<char*>(&stringSize), sizeof(uint32_t));
@@ -42,7 +42,7 @@ namespace Babylon::Plugins::ShaderCache
         m_cache.clear();
     }
 
-    uint32_t ShaderCacheImpl::Save(std::ofstream& stream)
+    uint32_t ShaderCacheImpl::Save(std::ostream& stream)
     {
         uint32_t cacheVersion{CACHE_VERSION};
         stream.write(reinterpret_cast<const char*>(&cacheVersion), sizeof(uint32_t));
@@ -79,7 +79,7 @@ namespace Babylon::Plugins::ShaderCache
         return cacheSize;
     }
 
-    uint32_t ShaderCacheImpl::Load(std::ifstream& stream)
+    uint32_t ShaderCacheImpl::Load(std::istream& stream)
     {
         uint32_t cacheVersion;
         stream.read(reinterpret_cast<char*>(&cacheVersion), sizeof(uint32_t));

--- a/Plugins/ShaderCache/Source/ShaderCacheImpl.h
+++ b/Plugins/ShaderCache/Source/ShaderCacheImpl.h
@@ -16,8 +16,8 @@ namespace Babylon::Plugins::ShaderCache
     public:
         ShaderCacheImpl() = default;
 
-        uint32_t Save(std::ofstream& stream);
-        uint32_t Load(std::ifstream& stream);
+        uint32_t Save(std::ostream& stream);
+        uint32_t Load(std::istream& stream);
 
         void Clear();
 


### PR DESCRIPTION
This pull request updates the shader cache serialization and deserialization logic to use more generic stream types, improving flexibility and code reuse. The main change is replacing the use of file stream types (`std::ifstream`, `std::ofstream`) with their base stream types (`std::istream`, `std::ostream`) throughout the shader cache API and implementation.

**API and Implementation Stream Type Generalization**

* Changed the signatures of `Save` and `Load` functions in the `Babylon::Plugins::ShaderCache` namespace and `ShaderCacheImpl` class to use `std::ostream` and `std::istream` instead of `std::ofstream` and `std::ifstream`, allowing for more flexible stream handling. [[1]](diffhunk://#diff-8771aa7eb5c30383d56bf6aed3358116aa11b2960aeeacb03952392935d166aeL22-R26) [[2]](diffhunk://#diff-8dca32e357c82ca97c5f77aade195975b03b5f24624080973426e86d247fbf88L19-R20) [[3]](diffhunk://#diff-0b242c35b9c7b46eb4c48d82e14d14935d3801bd68996bed46079df90a92c39dL34-R34) [[4]](diffhunk://#diff-0b242c35b9c7b46eb4c48d82e14d14935d3801bd68996bed46079df90a92c39dL44-R44) [[5]](diffhunk://#diff-f0db11a085d06e6004ec16b71768ec10562caeee70b9060fa86e8d157472c4fbL45-R45) [[6]](diffhunk://#diff-f0db11a085d06e6004ec16b71768ec10562caeee70b9060fa86e8d157472c4fbL82-R82)
* Updated helper functions `SaveString` and `LoadString` to accept `std::ostream` and `std::istream` parameters instead of file streams, supporting the generalized stream usage.