### PR TITLE
Fix install cmake to include ShaderTool

### DIFF
--- a/Install/Install.cmake
+++ b/Install/Install.cmake
@@ -20,6 +20,7 @@ endfunction()
 function(install_bin)
     foreach(target IN LISTS ARGN)
         install(FILES "$<TARGET_FILE:${target}>" DESTINATION bin)
+        install(FILES "$<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_PREFIX:${target}>$<TARGET_FILE_BASE_NAME:${target}>.pdb" DESTINATION bin OPTIONAL)
     endforeach()
 endfunction()
 


### PR DESCRIPTION
This pull request refactors the installation logic in the `Install.cmake` file to improve clarity and modularity. The main change is replacing the generic `install_targets` and `install_include_for_targets` functions with more specific functions: `install_lib`, `install_bin`, and `install_include`. This makes it clearer what kind of installation each target requires and allows for more granular control, such as installing binaries separately.

Key changes include:

**Refactoring and Function Renaming:**
* Replaced the `install_targets` function with `install_lib`, which is now used for installing library targets throughout the file. (`Install/Install.cmake`) [[1]](diffhunk://#diff-193748a9afd3150777ac1af1a6e8418012c458595bceace59fe48595a20d3ee3L7-R7) [[2]](diffhunk://#diff-193748a9afd3150777ac1af1a6e8418012c458595bceace59fe48595a20d3ee3L36-R112) [[3]](diffhunk://#diff-193748a9afd3150777ac1af1a6e8418012c458595bceace59fe48595a20d3ee3L121-R238)
* Replaced the `install_include_for_targets` function with `install_include`, standardizing how include directories are installed for targets. (`Install/Install.cmake`) [[1]](diffhunk://#diff-193748a9afd3150777ac1af1a6e8418012c458595bceace59fe48595a20d3ee3L20-R26) [[2]](diffhunk://#diff-193748a9afd3150777ac1af1a6e8418012c458595bceace59fe48595a20d3ee3L36-R112) [[3]](diffhunk://#diff-193748a9afd3150777ac1af1a6e8418012c458595bceace59fe48595a20d3ee3L121-R238)
* Introduced a new `install_bin` function to handle binary installations, used for the `ShaderTool` target. (`Install/Install.cmake`) [[1]](diffhunk://#diff-193748a9afd3150777ac1af1a6e8418012c458595bceace59fe48595a20d3ee3L20-R26) [[2]](diffhunk://#diff-193748a9afd3150777ac1af1a6e8418012c458595bceace59fe48595a20d3ee3L121-R238)

**Consistent Application Across Targets:**
* Updated all target installation calls to use the new `install_lib`, `install_include`, and `install_bin` functions for core libraries, plugins, polyfills, and other modules. (`Install/Install.cmake`) [[1]](diffhunk://#diff-193748a9afd3150777ac1af1a6e8418012c458595bceace59fe48595a20d3ee3L36-R112) [[2]](diffhunk://#diff-193748a9afd3150777ac1af1a6e8418012c458595bceace59fe48595a20d3ee3L121-R238)

These changes make the CMake installation process more explicit and maintainable, reducing ambiguity and potential errors in future updates.