### PR TITLE
Improve CMake logging output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ FetchContent_Declare(bgfx.cmake
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(CMakeExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/CMakeExtensions.git
-    GIT_TAG ea28b7689530bfdc4905806f27ecf7e8ed4b5419
+    GIT_TAG 892b0b70d908c37adeb5d8719fd8b0212a8fa17d
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(glslang
     GIT_REPOSITORY https://github.com/BabylonJS/glslang.git
@@ -97,6 +97,9 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Suppress "Performing Test ..." output from check_c_compiler_flag() and similar macros.
+set(CMAKE_REQUIRED_QUIET TRUE)
 
 # --------------------------------------------------
 # Options


### PR DESCRIPTION
- Suppresses libwebp noisy `Performing Test` logging
- Add message indent when fetching content

Sample output:
```
1>-- Selecting Windows SDK version 10.0.26100.0 to target Windows 10.0.26200.
1>-- Fetching arcana.cpp
1>-- Fetching arcana.cpp - done
1>-- Fetching base-n
1>-- Fetching base-n - done
1>-- Fetching bgfx.cmake
1>-- Fetching bgfx.cmake - done
1>-- Fetching glslang
1>-- Fetching glslang - done
1>-- Fetching googletest
1>-- Fetching googletest - done
1>-- Fetching JsRuntimeHost
1>--   Fetching UrlLib
1>--   Fetching UrlLib - done
1>--   Selected Chakra
1>-- Fetching JsRuntimeHost - done
1>-- Fetching SPIRV-Cross
1>--   SPIRV-Cross: Finding Git version for SPIRV-Cross.
1>--   SPIRV-Cross: Git hash: 6277baf6
1>-- Fetching SPIRV-Cross - done
1>-- Fetching libwebp
1>-- Fetching libwebp - done
1>-- Fetching DirectXTK
1>--   Using Shader Model 4.0/9.1 for shaders.
1>--   Building for Windows 7.
1>-- Fetching DirectXTK - done
1>-- Installing npm modules (.../BabylonNative/Apps)
1>-- Installing npm modules (.../BabylonNative/Apps) - done
1>-- Configuring done (38.7s)
1>-- Generating done (0.7s)
```