### PR TITLE
Fixed race condition when passing data to bgfx. Issue #1398

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -398,8 +398,7 @@ namespace Babylon
                             }
 
                             bgfx::ReleaseFn releaseFn{};
-                            if (side == 5
-                            &&  mip == image->m_numMips - 1)
+                            if (mip == image->m_numMips - 1)
                             {
                                 releaseFn = [](void*, void* userData) {
                                     bimg::imageFree(static_cast<bimg::ImageContainer*>(userData));


### PR DESCRIPTION
Change makes `image` pointer not being touched after passing data to bgfx.

Alternative solution is to use `bgfx::copy` instead of `bgfx::makeRef`.