### PR TITLE
Fix instancing data layout for all graphics backends.

### DIFF
--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -5,22 +5,13 @@
             "title": "Gaussian Splatting Compressed ply SH",
             "playgroundId": "#U8O4EP#1",
             "renderCount": 15,
-            "referenceImage": "gsplat-compressedply-sh.png",
-            "excludedGraphicsApis": [ "OpenGL" ],
-            "comments": {
-                "OpenGL": "Test doesn't render correctly"
-            }
+            "referenceImage": "gsplat-compressedply-sh.png"
         },
         {
             "title": "Gaussian Splatting Update Data",
             "playgroundId": "#Q0LBM8#2",
             "renderCount": 15,
-            "excludedGraphicsApis": [ "OpenGL", "Metal" ],
-            "referenceImage": "gsplat-update-data.png",
-            "comments": {
-                "OpenGL": "Test doesn't render correctly",
-                "Metal": "Crashes"
-            }
+            "referenceImage": "gsplat-update-data.png"
         },
         {
             "title": "Native Canvas",
@@ -56,10 +47,10 @@
             "playgroundId": "#QFIGLW#9",
             "renderCount": 10,
             "errorRatio": 6,
-            "excludedGraphicsApis": [ "OpenGL" ],
             "referenceImage": "gltfExtensionExtMeshGpuInstancingTest.png",
+            "excludedGraphicsApis": [ "OpenGL" ],
             "comments": {
-                "OpenGL": "Test works with OpenGL but it so slow that CI times out"
+                 "OpenGL": "Test works with OpenGL but it so slow that CI times out"
             }
         },
         {

--- a/Plugins/NativeEngine/Source/VertexBuffer.cpp
+++ b/Plugins/NativeEngine/Source/VertexBuffer.cpp
@@ -145,12 +145,10 @@ namespace Babylon
         uint8_t* data{instanceDataBuffer.data};
         uint32_t offset{};
 
-        // Reverse because bgfx is also reversed: https://github.com/bkaradzic/bgfx/blob/4581f14cd481bad1e0d6292f0dd0a6e298c2ee18/src/renderer_d3d11.cpp#L2701
-#if D3D11 || D3D12
+        // Reverse because bgfx maps instance data in reverse attrib order:
+        // D3D11: TEXCOORD7 = i_data0, TEXCOORD6 = i_data1, etc.
+        // OpenGL also expects this layout since bgfx abstracts the mapping.
         for (auto iter = instances.rbegin(); iter != instances.rend(); ++iter)
-#else
-        for (auto iter = instances.cbegin(); iter != instances.cend(); ++iter)
-#endif
         {
             const auto& element{iter->second};
             const auto* source{element.Buffer->m_bytes.data()};

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
@@ -548,7 +548,11 @@ namespace Babylon::ShaderCompilerTraversers
                         !strcmp(name, "world1") ||
                         !strcmp(name, "world2") ||
                         !strcmp(name, "world3") ||
-                        !strcmp(name, "instanceColor"));
+                        !strcmp(name, "instanceColor") ||
+                        !strcmp(name, "splatIndex0") ||
+                        !strcmp(name, "splatIndex1") ||
+                        !strcmp(name, "splatIndex2") ||
+                        !strcmp(name, "splatIndex3"));
             }
 
             unsigned int m_genericAttributesRunningCount{0};
@@ -598,6 +602,18 @@ namespace Babylon::ShaderCompilerTraversers
                 auto intermediate{program.getIntermediate(EShLangVertex)};
                 VertexVaryingInTraverserOpenGL traverser{};
                 intermediate->getTreeRoot()->traverse(&traverser);
+
+                // Pre-count instance attributes so i_data names can be assigned in reverse.
+                // bgfx maps i_data0 to the last attribute (TEXCOORD7), so instance names
+                // must be assigned in reverse order, matching the Metal traverser.
+                for (const auto& [name, symbol] : traverser.m_varyingNameToSymbol)
+                {
+                    if (IsInstance(name.c_str()))
+                    {
+                        traverser.m_instanceAttributeCount++;
+                    }
+                }
+
                 VertexVaryingInTraverser::Traverse(intermediate, ids, replacementToOriginalName, traverser);
             }
 
@@ -611,14 +627,16 @@ namespace Babylon::ShaderCompilerTraversers
                 m_genericAttributesRunningCount++;
                 if (IsInstance(name))
                 {
-                    return {static_cast<unsigned int>(m_genericAttributesRunningCount - 1), s_attribInstanceName[m_instanceAttributeIndex++]};
+                    // Reverse: bgfx maps i_data0 to the highest semantic (TEXCOORD7),
+                    // so the first instance attribute gets the highest i_data index.
+                    return {static_cast<unsigned int>(m_genericAttributesRunningCount - 1), s_attribInstanceName[--m_instanceAttributeCount]};
                 }
                 if (m_genericAttributesRunningCount >= static_cast<unsigned int>(bgfx::Attrib::Count))
                     throw std::runtime_error("Cannot support more than 18 vertex attributes.");
 
                 return {static_cast<unsigned int>(m_genericAttributesRunningCount - 1), s_attribName[static_cast<unsigned int>(m_genericAttributesRunningCount - 1)]};
             }
-            unsigned int m_instanceAttributeIndex{0};
+            unsigned int m_instanceAttributeCount{0};
         };
 
         class VertexVaryingInTraverserMetal final : private VertexVaryingInTraverser


### PR DESCRIPTION
VertexBuffer: Always pack instance data in reverse attribute order. bgfx maps i_data0 to the highest semantic (TEXCOORD7) in all backends, so reverse iteration is correct universally, not just D3D11/D3D12.
 
ShaderCompilerTraversers: Fix OpenGL traverser to assign i_data names in reverse order (--m_instanceAttributeCount), matching the Metal traverser. Previously it used forward order (m_instanceAttributeIndex++) which produced wrong attribute-to-slot mapping when combined with reverse instance buffer packing.
 
ShaderCompilerTraversers: Add splatIndex0-3 to IsInstance() so Gaussian Splatting attributes are recognized as instance data on OpenGL and Metal.
 
config.json: Re-enable Gaussian Splatting tests on OpenGL and Metal now that instancing is fixed for those backends.