### PR TITLE
Bump JsRuntimeHost and arcana.cpp to latest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ FetchContent_Declare(AndroidExtensions
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(arcana.cpp
     GIT_REPOSITORY https://github.com/microsoft/arcana.cpp.git
-    GIT_TAG 53e5b05eaf53154b60dff8ffb45e52a417cf5020
+    GIT_TAG b9bf9d85fce37d5fc9dbfc4a4dc5e1531bee215a
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(arcore-android-sdk
     GIT_REPOSITORY https://github.com/google-ar/arcore-android-sdk.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include(FetchContent)
 
 FetchContent_Declare(AndroidExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/AndroidExtensions.git
-    GIT_TAG 2d5af72259cc73e5f249d3c99bee2010be9cb042
+    GIT_TAG 2e85a8d43b89246c460112c9e5546ad54b6e87b4
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(arcana.cpp
     GIT_REPOSITORY https://github.com/microsoft/arcana.cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ FetchContent_Declare(ios-cmake
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(JsRuntimeHost
     GIT_REPOSITORY https://github.com/BabylonJS/JsRuntimeHost.git
-    GIT_TAG 598f004457cf7a340a9acbe7138fcc3196b80674)
+    GIT_TAG 901208a93157f77a835508a6f097cf30ac028220)
 FetchContent_Declare(libwebp
     GIT_REPOSITORY https://github.com/webmproject/libwebp.git
     GIT_TAG 57e324e2eb99be46df46d77b65705e34a7ae616c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ FetchContent_Declare(ios-cmake
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(JsRuntimeHost
     GIT_REPOSITORY https://github.com/BabylonJS/JsRuntimeHost.git
-    GIT_TAG 901208a93157f77a835508a6f097cf30ac028220)
+    GIT_TAG 808601482588b7f806d91231288310b94766dc84)
 FetchContent_Declare(libwebp
     GIT_REPOSITORY https://github.com/webmproject/libwebp.git
     GIT_TAG 57e324e2eb99be46df46d77b65705e34a7ae616c


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

Bump JsRuntimeHost, arcana.cpp, and AndroidExtensions to latest.

## JsRuntimeHost (8086014)
- **#147**: Fix WorkQueue destructor deadlock (cancel + no-op wake)
- **#149**: Merge WorkQueue into AppRuntime (eliminates split-lifetime issues)
- **#150**: Fix WebSocket test flake + update UrlLib/AndroidExtensions for consistent onClose-after-onError
- **#151**: Clean up deadlock regression test (one-shot hook, expanded comments)
- **#152**: Fix performance test flake (remove upper-bound setTimeout assertion)
- **#154**: Hide arcana behind pimpl pattern in AppRuntime (arcana headers no longer exposed publicly)
- **#155**: Update package-lock.json

## arcana.cpp (b9bf9d8)
Includes test hooks for the deadlock regression test (`ARCANA_TEST_HOOKS` / `arcana::test_hooks::blocking_concurrent_queue`).

## AndroidExtensions (2e85a8d)
Removes the redundant `errorCallback` from `onClose` in the Java WebSocket wrapper (AndroidExtensions#16). Matches the version JsRuntimeHost depends on via UrlLib.
