### PR TITLE
Bump Babylon.js from 9.0.0 to 9.3.4

### DIFF
--- a/Apps/PrecompiledShaderTest/JavaScript/package-lock.json
+++ b/Apps/PrecompiledShaderTest/JavaScript/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/cli": "^7.28.3",
                 "@babel/core": "^7.28.3",
                 "@babel/preset-env": "^7.28.3",
-                "@babylonjs/core": "^9.3.3",
+                "@babylonjs/core": "^9.3.4",
                 "@types/node": "^24.7.1",
                 "rimraf": "^6.0.1",
                 "terser-webpack-plugin": "^5.3.10",
@@ -1571,9 +1571,9 @@
             }
         },
         "node_modules/@babylonjs/core": {
-            "version": "9.3.3",
-            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-9.3.3.tgz",
-            "integrity": "sha512-7/H736aO2NRi9/ocOWKUpzwt0rrL9fWmDIeLvM0F9g2cGURLLO26ZwqzoJmA19UvBAgrud8XgVZdZ6TaFl0OFQ==",
+            "version": "9.3.4",
+            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-9.3.4.tgz",
+            "integrity": "sha512-ZwaIfw9o9kpvloErFaV28QEyofubZu67gFKzxSOcbZwqqitIF8p7xbvt6QHAnIhczEKVYLYilzqyKIlNqYcaqw==",
             "dev": true,
             "license": "Apache-2.0"
         },

--- a/Apps/PrecompiledShaderTest/JavaScript/package-lock.json
+++ b/Apps/PrecompiledShaderTest/JavaScript/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/cli": "^7.28.3",
                 "@babel/core": "^7.28.3",
                 "@babel/preset-env": "^7.28.3",
-                "@babylonjs/core": "^9.0.0",
+                "@babylonjs/core": "^9.3.2",
                 "@types/node": "^24.7.1",
                 "rimraf": "^6.0.1",
                 "terser-webpack-plugin": "^5.3.10",
@@ -1571,9 +1571,9 @@
             }
         },
         "node_modules/@babylonjs/core": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-9.0.0.tgz",
-            "integrity": "sha512-Y4xbHFUw28X4EC5C7NOSzPCOaenxZQgztCB1QZ64y0C85FjZaq5DfWd6gy+EUYklbigmcMIFzCpLj78Wc8EwVw==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-9.3.2.tgz",
+            "integrity": "sha512-u3JYayM3LwPi7vlak74mpQIdBZWV5ISEYq+E1Lps2hlQuE6Y5CHYge2f6jH/KjbKNXWaJUQqx5JwRxbRtXE//w==",
             "dev": true,
             "license": "Apache-2.0"
         },

--- a/Apps/PrecompiledShaderTest/JavaScript/package-lock.json
+++ b/Apps/PrecompiledShaderTest/JavaScript/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/cli": "^7.28.3",
                 "@babel/core": "^7.28.3",
                 "@babel/preset-env": "^7.28.3",
-                "@babylonjs/core": "^9.3.2",
+                "@babylonjs/core": "^9.3.3",
                 "@types/node": "^24.7.1",
                 "rimraf": "^6.0.1",
                 "terser-webpack-plugin": "^5.3.10",
@@ -1571,9 +1571,9 @@
             }
         },
         "node_modules/@babylonjs/core": {
-            "version": "9.3.2",
-            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-9.3.2.tgz",
-            "integrity": "sha512-u3JYayM3LwPi7vlak74mpQIdBZWV5ISEYq+E1Lps2hlQuE6Y5CHYge2f6jH/KjbKNXWaJUQqx5JwRxbRtXE//w==",
+            "version": "9.3.3",
+            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-9.3.3.tgz",
+            "integrity": "sha512-7/H736aO2NRi9/ocOWKUpzwt0rrL9fWmDIeLvM0F9g2cGURLLO26ZwqzoJmA19UvBAgrud8XgVZdZ6TaFl0OFQ==",
             "dev": true,
             "license": "Apache-2.0"
         },

--- a/Apps/PrecompiledShaderTest/JavaScript/package.json
+++ b/Apps/PrecompiledShaderTest/JavaScript/package.json
@@ -11,18 +11,17 @@
         "prepare:shaders": "tsx ./tools/prepareShaders.ts"
     },
     "license": "MIT",
-    "dependencies": {},
     "devDependencies": {
         "@babel/cli": "^7.28.3",
         "@babel/core": "^7.28.3",
         "@babel/preset-env": "^7.28.3",
-        "@babylonjs/core": "^9.0.0",
+        "@babylonjs/core": "^9.3.2",
         "@types/node": "^24.7.1",
         "rimraf": "^6.0.1",
+        "terser-webpack-plugin": "^5.3.10",
         "ts-loader": "^9.5.4",
         "tsx": "^4.20.6",
         "typescript": "^5.5.4",
-        "terser-webpack-plugin": "^5.3.10",
         "webpack": "^5.101.3",
         "webpack-cli": "^6.0.1"
     },

--- a/Apps/PrecompiledShaderTest/JavaScript/package.json
+++ b/Apps/PrecompiledShaderTest/JavaScript/package.json
@@ -15,7 +15,7 @@
         "@babel/cli": "^7.28.3",
         "@babel/core": "^7.28.3",
         "@babel/preset-env": "^7.28.3",
-        "@babylonjs/core": "^9.3.2",
+        "@babylonjs/core": "^9.3.3",
         "@types/node": "^24.7.1",
         "rimraf": "^6.0.1",
         "terser-webpack-plugin": "^5.3.10",

--- a/Apps/PrecompiledShaderTest/JavaScript/package.json
+++ b/Apps/PrecompiledShaderTest/JavaScript/package.json
@@ -15,7 +15,7 @@
         "@babel/cli": "^7.28.3",
         "@babel/core": "^7.28.3",
         "@babel/preset-env": "^7.28.3",
-        "@babylonjs/core": "^9.3.3",
+        "@babylonjs/core": "^9.3.4",
         "@types/node": "^24.7.1",
         "rimraf": "^6.0.1",
         "terser-webpack-plugin": "^5.3.10",

--- a/Apps/UnitTests/JavaScript/package.json
+++ b/Apps/UnitTests/JavaScript/package.json
@@ -7,8 +7,8 @@
     "watch": "webpack -watch"
   },
   "dependencies": {
-    "babylonjs": "^9.0.0",
-    "babylonjs-materials": "^9.0.0",
+    "babylonjs": "^9.3.2",
+    "babylonjs-materials": "^9.3.2",
     "chai": "^5.2.0",
     "jsc-android": "^241213.1.0",
     "mocha": "^11.1.0",
@@ -27,8 +27,8 @@
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
     "@babel/runtime": "^7.28.2",
-    "@babylonjs/core": "^9.0.0",
-    "@babylonjs/materials": "^9.0.0",
+    "@babylonjs/core": "^9.3.2",
+    "@babylonjs/materials": "^9.3.2",
     "babel-loader": "^10.0.0",
     "buffer": "^6.0.3",
     "core-js": "^3.45.0",

--- a/Apps/UnitTests/JavaScript/package.json
+++ b/Apps/UnitTests/JavaScript/package.json
@@ -7,8 +7,8 @@
     "watch": "webpack -watch"
   },
   "dependencies": {
-    "babylonjs": "^9.3.3",
-    "babylonjs-materials": "^9.3.3",
+    "babylonjs": "^9.3.4",
+    "babylonjs-materials": "^9.3.4",
     "chai": "^5.2.0",
     "jsc-android": "^241213.1.0",
     "mocha": "^11.1.0",
@@ -27,8 +27,8 @@
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
     "@babel/runtime": "^7.28.2",
-    "@babylonjs/core": "^9.3.3",
-    "@babylonjs/materials": "^9.3.3",
+    "@babylonjs/core": "^9.3.4",
+    "@babylonjs/materials": "^9.3.4",
     "babel-loader": "^10.0.0",
     "buffer": "^6.0.3",
     "core-js": "^3.45.0",

--- a/Apps/UnitTests/JavaScript/package.json
+++ b/Apps/UnitTests/JavaScript/package.json
@@ -7,8 +7,8 @@
     "watch": "webpack -watch"
   },
   "dependencies": {
-    "babylonjs": "^9.3.2",
-    "babylonjs-materials": "^9.3.2",
+    "babylonjs": "^9.3.3",
+    "babylonjs-materials": "^9.3.3",
     "chai": "^5.2.0",
     "jsc-android": "^241213.1.0",
     "mocha": "^11.1.0",
@@ -27,8 +27,8 @@
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
     "@babel/runtime": "^7.28.2",
-    "@babylonjs/core": "^9.3.2",
-    "@babylonjs/materials": "^9.3.2",
+    "@babylonjs/core": "^9.3.3",
+    "@babylonjs/materials": "^9.3.3",
     "babel-loader": "^10.0.0",
     "buffer": "^6.0.3",
     "core-js": "^3.45.0",

--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -11,12 +11,12 @@
         "UnitTests/JavaScript"
       ],
       "dependencies": {
-        "babylonjs": "^9.0.0",
-        "babylonjs-gltf2interface": "^9.0.0",
-        "babylonjs-gui": "^9.0.0",
-        "babylonjs-loaders": "^9.0.0",
-        "babylonjs-materials": "^9.0.0",
-        "babylonjs-serializers": "^9.0.0",
+        "babylonjs": "^9.3.2",
+        "babylonjs-gltf2interface": "^9.3.2",
+        "babylonjs-gui": "^9.3.2",
+        "babylonjs-loaders": "^9.3.2",
+        "babylonjs-materials": "^9.3.2",
+        "babylonjs-serializers": "^9.3.2",
         "jsc-android": "^241213.1.0",
         "v8-android": "^7.8.2"
       }
@@ -1921,6 +1921,23 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babylonjs/core": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-9.3.2.tgz",
+      "integrity": "sha512-u3JYayM3LwPi7vlak74mpQIdBZWV5ISEYq+E1Lps2hlQuE6Y5CHYge2f6jH/KjbKNXWaJUQqx5JwRxbRtXE//w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@babylonjs/materials": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-9.3.2.tgz",
+      "integrity": "sha512-/lwvghxePYJbbnkKA6rTNADM+XEo86YUFeP5e9aFDyKhrQdltzkJdXn6Ckt9l2+3ND1qMJwJeJ7xpdytR05mhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@babylonjs/core": "^9.0.0"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
@@ -2578,54 +2595,54 @@
       }
     },
     "node_modules/babylonjs": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-9.0.0.tgz",
-      "integrity": "sha512-NlHOf9R6GwHMoYZ+9uT0VxzhFwjoMqc9HT0o/TpEAymZZKZOa15IS2be8QTBpgHCOq0T3t3gwWq9ecpw3IQlIw==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-9.3.2.tgz",
+      "integrity": "sha512-dKHt2Qaeae1tnHGm/2yoy8uVznE6MknmXsFl0rLgS3xp8/D69X30hkLJAdF8ZXxeSj/oVWWZ3rmU83qzhCopBw==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.0.0.tgz",
-      "integrity": "sha512-k2B6B39stVxJcATNqPGJp19732pQouZPGiMsa1uke3812ZPd2M3h2Xm+QHpRo9n8wPMFC2tPUVu+dSka0skR1w==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.3.2.tgz",
+      "integrity": "sha512-IKmATyMioyMISWYJ4HULilV6FUZ6pBL8CJPJ/qPBkR133bzg3TrIcjJJpqMMcE5tITBoz19LvwgUK38p8v0CSg==",
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-gui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-9.0.0.tgz",
-      "integrity": "sha512-kBZUHZpJmB/pgs95RXVMGQJjHYC1hEPyE/9emjjGvQAGHARCUTsyJdN4lVY+VoeazM/3oy3vXMZCysAwg0eDew==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-9.3.2.tgz",
+      "integrity": "sha512-oIZ8dK6gbAEFTNiS+AU0TX3UQnJ5abqp9+HYrYJeV4ShpPOJeDEBZcmAVzNVb4IW9lzXlan1CfHKWoApS5XzJg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.0.0"
+        "babylonjs": "9.3.2"
       }
     },
     "node_modules/babylonjs-loaders": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-9.0.0.tgz",
-      "integrity": "sha512-hrbXvHi8gvdOcqdMk9Zyx9A7WQ7SJ+Svt4s1IP5bUVLabWIrqo8oBHWpV4Ybw5spK48SE8EjvRPe4xwK0IbNEA==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-9.3.2.tgz",
+      "integrity": "sha512-urFYgqiSjEqgtITApEONJWkVWAHTzdUZmYYiCc+xJqBV7hbzML2aQ6huSSnfGyB6W0Ggex402ocL4k67G+1KWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.0.0",
-        "babylonjs-gltf2interface": "9.0.0"
+        "babylonjs": "9.3.2",
+        "babylonjs-gltf2interface": "9.3.2"
       }
     },
     "node_modules/babylonjs-materials": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-9.0.0.tgz",
-      "integrity": "sha512-4Ua2xfM3Oe7xE5CnZiEyyRWdwBajPOgV5dNlJkLBn5MZUCUU8mptHClYGTnIhDnCIMZg1FWNpqgC3StD3k7XQQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-9.3.2.tgz",
+      "integrity": "sha512-sCzO9ma7h9QZvFUsPhq6jPkeLOItWOtUOosbXHfRGZZAlrKoqf2+iN0akptadi5zv/T7iMDj8q+fLNA5qPPmQg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.0.0"
+        "babylonjs": "9.3.2"
       }
     },
     "node_modules/babylonjs-serializers": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.0.0.tgz",
-      "integrity": "sha512-YoDDmVLwtapsbeg+UZ3SCF/vv/qMioNJhNbIKrR4WzwD7IDYNsbBKHDcUEvnmj1B8K4Z2LgUVUv2yawjsrCNqQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.3.2.tgz",
+      "integrity": "sha512-SCnice8+1XR7TTqrnn3GO8ZLDv9h6CsMN6VCv/qCkXtDdF1IS336hBsxojIVqgta6Kb+b8AXNI0WS/Z/wDmGNA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.0.0",
-        "babylonjs-gltf2interface": "9.0.0"
+        "babylonjs": "9.3.2",
+        "babylonjs-gltf2interface": "9.3.2"
       }
     },
     "node_modules/balanced-match": {
@@ -5594,8 +5611,8 @@
       "name": "UnitTests",
       "version": "0.0.1",
       "dependencies": {
-        "babylonjs": "^9.0.0",
-        "babylonjs-materials": "^9.0.0",
+        "babylonjs": "^9.3.2",
+        "babylonjs-materials": "^9.3.2",
         "chai": "^5.2.0",
         "jsc-android": "^241213.1.0",
         "mocha": "^11.1.0",
@@ -5614,8 +5631,8 @@
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",
         "@babel/runtime": "^7.28.2",
-        "@babylonjs/core": "^9.0.0",
-        "@babylonjs/materials": "^9.0.0",
+        "@babylonjs/core": "^9.3.2",
+        "@babylonjs/materials": "^9.3.2",
         "babel-loader": "^10.0.0",
         "buffer": "^6.0.3",
         "core-js": "^3.45.0",
@@ -5625,23 +5642,6 @@
         "util": "^0.12.5",
         "webpack": "^5.101.0",
         "webpack-cli": "^6.0.1"
-      }
-    },
-    "UnitTests/JavaScript/node_modules/@babylonjs/core": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-9.0.0.tgz",
-      "integrity": "sha512-Y4xbHFUw28X4EC5C7NOSzPCOaenxZQgztCB1QZ64y0C85FjZaq5DfWd6gy+EUYklbigmcMIFzCpLj78Wc8EwVw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "UnitTests/JavaScript/node_modules/@babylonjs/materials": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-9.0.0.tgz",
-      "integrity": "sha512-wATGzT/IQZ9/h9VhjgrZt8W59ZWXZ/mEZdCP2zHdopz3fqKP3gpJlbGt8UpAQUQF6XFKJrGuzVe7Vesrg36vyw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@babylonjs/core": "^9.0.0"
       }
     }
   }

--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -11,12 +11,12 @@
         "UnitTests/JavaScript"
       ],
       "dependencies": {
-        "babylonjs": "^9.3.3",
-        "babylonjs-gltf2interface": "^9.3.3",
-        "babylonjs-gui": "^9.3.3",
-        "babylonjs-loaders": "^9.3.3",
-        "babylonjs-materials": "^9.3.3",
-        "babylonjs-serializers": "^9.3.3",
+        "babylonjs": "^9.3.4",
+        "babylonjs-gltf2interface": "^9.3.4",
+        "babylonjs-gui": "^9.3.4",
+        "babylonjs-loaders": "^9.3.4",
+        "babylonjs-materials": "^9.3.4",
+        "babylonjs-serializers": "^9.3.4",
         "jsc-android": "^241213.1.0",
         "v8-android": "^7.8.2"
       }
@@ -1922,16 +1922,16 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-9.3.3.tgz",
-      "integrity": "sha512-7/H736aO2NRi9/ocOWKUpzwt0rrL9fWmDIeLvM0F9g2cGURLLO26ZwqzoJmA19UvBAgrud8XgVZdZ6TaFl0OFQ==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-9.3.4.tgz",
+      "integrity": "sha512-ZwaIfw9o9kpvloErFaV28QEyofubZu67gFKzxSOcbZwqqitIF8p7xbvt6QHAnIhczEKVYLYilzqyKIlNqYcaqw==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@babylonjs/materials": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-9.3.3.tgz",
-      "integrity": "sha512-QyW0Sgn0E0jBsbcgXmGtpeWUNLTvQRAE8Ax+bzqjOZ6rgaAN/X8EWdMywqJrVxc/YglixaQC2IZo9ShzIa+tgA==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-9.3.4.tgz",
+      "integrity": "sha512-9nakZasS28K4y0m9EgdOiGDKlcCCVknwjKJ7u+CtmcNGuVD9kg4qa2BCLillgApircn86CuygaiJF3ht3K2GfA==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -2595,54 +2595,54 @@
       }
     },
     "node_modules/babylonjs": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-9.3.3.tgz",
-      "integrity": "sha512-DubXimIGJtle2wC5H0U+usqHPPeyIh7N6fVBPl4k9evdJ95jVisbIaE+jfocYOnno6zBtBH5Qd2LOKRA17F/6Q==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-9.3.4.tgz",
+      "integrity": "sha512-ylxaBWHuv7XLkwWSKQjEoRty0dFg+IOemil/i76jaY49kg/nSw0ym/dBPt9QW3s5YPU+BpNP+1Luwm9d/FGeNQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.3.3.tgz",
-      "integrity": "sha512-v4x7AX7ugx6auVitzHzYnQTsznlsDzIefXBSZLC9t4LjH0jgghzm+nUSG2lQGokwt591NUh6Rvlmv/RFFI1bpA==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.3.4.tgz",
+      "integrity": "sha512-Eqs/j1hF8bOhFBwnS9DjhNOdCC27Ax2Z9JauoDu1tiHdKmhG2zgyIsWwY+hP0KjtdFxMIg9CAyuB/JDBFapzbQ==",
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-gui": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-9.3.3.tgz",
-      "integrity": "sha512-h+Kg5NzcBugHZcA8UAY2VpXNqZfq6dukSXUxCiglmjjLMyDfpr1jraCnwY+OYGGb7/upRJVxkQga6B13E6q3Ww==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-9.3.4.tgz",
+      "integrity": "sha512-gedtM/bjhoE37/Is/tukAwxXvdwGfA94sFXvTlMYtlGarg7yL2i0Q4ipQLHaK/KL7IsdXmbWBwzwlOQeEvE0Xw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.3.3"
+        "babylonjs": "9.3.4"
       }
     },
     "node_modules/babylonjs-loaders": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-9.3.3.tgz",
-      "integrity": "sha512-lJbhaUIsBMKUpVB8EBHhQe61NbMa1yTBOMsZCAiB1gLMwITBslw1iBvME9d5ufxHdk/w0FvFUU0AmKwSbOl2PA==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-9.3.4.tgz",
+      "integrity": "sha512-oaE7+TQDbZx1jITOBEUPMkwpoD90s1bYbKne65oBE9yr2zDE/03gTNS1ZmpvSnLDG/UZ7Ix1+yScLhhP9ZhU7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.3.3",
-        "babylonjs-gltf2interface": "9.3.3"
+        "babylonjs": "9.3.4",
+        "babylonjs-gltf2interface": "9.3.4"
       }
     },
     "node_modules/babylonjs-materials": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-9.3.3.tgz",
-      "integrity": "sha512-XCDI4lj0+sW2DFF2/pB2YHmA6+rSBH2I2/gUrP4aNrahuKruqRgJn7QLOfr0ibsm+cGkqR9ycCcf2VHYcaFdJA==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-9.3.4.tgz",
+      "integrity": "sha512-QFy6L2o6PQuNDheAvs0Dh1awxlguNt4ZV4aLA8giVHC/8r7wziADZ1EIA04xL/v7QhFkOqtIRIag0weBHGY3Iw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.3.3"
+        "babylonjs": "9.3.4"
       }
     },
     "node_modules/babylonjs-serializers": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.3.3.tgz",
-      "integrity": "sha512-qbCggcOSoSMx4/aTPpWn0X8tEX26mPK773aGDeAvR2BbmhgRGQk/dyeVgM5EVHlrqlGawTspLwXwty0Tm2MtlQ==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.3.4.tgz",
+      "integrity": "sha512-j0Tci1EZxBtol8+A3taQkx2Jnn0/QWUegnUEDKPfhYH5WMLQUAUAg7fyk0HZrBj+nEkt59+D5faP5fg9T0wUfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.3.3",
-        "babylonjs-gltf2interface": "9.3.3"
+        "babylonjs": "9.3.4",
+        "babylonjs-gltf2interface": "9.3.4"
       }
     },
     "node_modules/balanced-match": {
@@ -5611,8 +5611,8 @@
       "name": "UnitTests",
       "version": "0.0.1",
       "dependencies": {
-        "babylonjs": "^9.3.3",
-        "babylonjs-materials": "^9.3.3",
+        "babylonjs": "^9.3.4",
+        "babylonjs-materials": "^9.3.4",
         "chai": "^5.2.0",
         "jsc-android": "^241213.1.0",
         "mocha": "^11.1.0",
@@ -5631,8 +5631,8 @@
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",
         "@babel/runtime": "^7.28.2",
-        "@babylonjs/core": "^9.3.3",
-        "@babylonjs/materials": "^9.3.3",
+        "@babylonjs/core": "^9.3.4",
+        "@babylonjs/materials": "^9.3.4",
         "babel-loader": "^10.0.0",
         "buffer": "^6.0.3",
         "core-js": "^3.45.0",

--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -11,12 +11,12 @@
         "UnitTests/JavaScript"
       ],
       "dependencies": {
-        "babylonjs": "^9.3.2",
-        "babylonjs-gltf2interface": "^9.3.2",
-        "babylonjs-gui": "^9.3.2",
-        "babylonjs-loaders": "^9.3.2",
-        "babylonjs-materials": "^9.3.2",
-        "babylonjs-serializers": "^9.3.2",
+        "babylonjs": "^9.3.3",
+        "babylonjs-gltf2interface": "^9.3.3",
+        "babylonjs-gui": "^9.3.3",
+        "babylonjs-loaders": "^9.3.3",
+        "babylonjs-materials": "^9.3.3",
+        "babylonjs-serializers": "^9.3.3",
         "jsc-android": "^241213.1.0",
         "v8-android": "^7.8.2"
       }
@@ -1922,16 +1922,16 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-9.3.2.tgz",
-      "integrity": "sha512-u3JYayM3LwPi7vlak74mpQIdBZWV5ISEYq+E1Lps2hlQuE6Y5CHYge2f6jH/KjbKNXWaJUQqx5JwRxbRtXE//w==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-9.3.3.tgz",
+      "integrity": "sha512-7/H736aO2NRi9/ocOWKUpzwt0rrL9fWmDIeLvM0F9g2cGURLLO26ZwqzoJmA19UvBAgrud8XgVZdZ6TaFl0OFQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@babylonjs/materials": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-9.3.2.tgz",
-      "integrity": "sha512-/lwvghxePYJbbnkKA6rTNADM+XEo86YUFeP5e9aFDyKhrQdltzkJdXn6Ckt9l2+3ND1qMJwJeJ7xpdytR05mhA==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-9.3.3.tgz",
+      "integrity": "sha512-QyW0Sgn0E0jBsbcgXmGtpeWUNLTvQRAE8Ax+bzqjOZ6rgaAN/X8EWdMywqJrVxc/YglixaQC2IZo9ShzIa+tgA==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -2595,54 +2595,54 @@
       }
     },
     "node_modules/babylonjs": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-9.3.2.tgz",
-      "integrity": "sha512-dKHt2Qaeae1tnHGm/2yoy8uVznE6MknmXsFl0rLgS3xp8/D69X30hkLJAdF8ZXxeSj/oVWWZ3rmU83qzhCopBw==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-9.3.3.tgz",
+      "integrity": "sha512-DubXimIGJtle2wC5H0U+usqHPPeyIh7N6fVBPl4k9evdJ95jVisbIaE+jfocYOnno6zBtBH5Qd2LOKRA17F/6Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.3.2.tgz",
-      "integrity": "sha512-IKmATyMioyMISWYJ4HULilV6FUZ6pBL8CJPJ/qPBkR133bzg3TrIcjJJpqMMcE5tITBoz19LvwgUK38p8v0CSg==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.3.3.tgz",
+      "integrity": "sha512-v4x7AX7ugx6auVitzHzYnQTsznlsDzIefXBSZLC9t4LjH0jgghzm+nUSG2lQGokwt591NUh6Rvlmv/RFFI1bpA==",
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-gui": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-9.3.2.tgz",
-      "integrity": "sha512-oIZ8dK6gbAEFTNiS+AU0TX3UQnJ5abqp9+HYrYJeV4ShpPOJeDEBZcmAVzNVb4IW9lzXlan1CfHKWoApS5XzJg==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-9.3.3.tgz",
+      "integrity": "sha512-h+Kg5NzcBugHZcA8UAY2VpXNqZfq6dukSXUxCiglmjjLMyDfpr1jraCnwY+OYGGb7/upRJVxkQga6B13E6q3Ww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.3.2"
+        "babylonjs": "9.3.3"
       }
     },
     "node_modules/babylonjs-loaders": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-9.3.2.tgz",
-      "integrity": "sha512-urFYgqiSjEqgtITApEONJWkVWAHTzdUZmYYiCc+xJqBV7hbzML2aQ6huSSnfGyB6W0Ggex402ocL4k67G+1KWA==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-9.3.3.tgz",
+      "integrity": "sha512-lJbhaUIsBMKUpVB8EBHhQe61NbMa1yTBOMsZCAiB1gLMwITBslw1iBvME9d5ufxHdk/w0FvFUU0AmKwSbOl2PA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.3.2",
-        "babylonjs-gltf2interface": "9.3.2"
+        "babylonjs": "9.3.3",
+        "babylonjs-gltf2interface": "9.3.3"
       }
     },
     "node_modules/babylonjs-materials": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-9.3.2.tgz",
-      "integrity": "sha512-sCzO9ma7h9QZvFUsPhq6jPkeLOItWOtUOosbXHfRGZZAlrKoqf2+iN0akptadi5zv/T7iMDj8q+fLNA5qPPmQg==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-9.3.3.tgz",
+      "integrity": "sha512-XCDI4lj0+sW2DFF2/pB2YHmA6+rSBH2I2/gUrP4aNrahuKruqRgJn7QLOfr0ibsm+cGkqR9ycCcf2VHYcaFdJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.3.2"
+        "babylonjs": "9.3.3"
       }
     },
     "node_modules/babylonjs-serializers": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.3.2.tgz",
-      "integrity": "sha512-SCnice8+1XR7TTqrnn3GO8ZLDv9h6CsMN6VCv/qCkXtDdF1IS336hBsxojIVqgta6Kb+b8AXNI0WS/Z/wDmGNA==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.3.3.tgz",
+      "integrity": "sha512-qbCggcOSoSMx4/aTPpWn0X8tEX26mPK773aGDeAvR2BbmhgRGQk/dyeVgM5EVHlrqlGawTspLwXwty0Tm2MtlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.3.2",
-        "babylonjs-gltf2interface": "9.3.2"
+        "babylonjs": "9.3.3",
+        "babylonjs-gltf2interface": "9.3.3"
       }
     },
     "node_modules/balanced-match": {
@@ -5611,8 +5611,8 @@
       "name": "UnitTests",
       "version": "0.0.1",
       "dependencies": {
-        "babylonjs": "^9.3.2",
-        "babylonjs-materials": "^9.3.2",
+        "babylonjs": "^9.3.3",
+        "babylonjs-materials": "^9.3.3",
         "chai": "^5.2.0",
         "jsc-android": "^241213.1.0",
         "mocha": "^11.1.0",
@@ -5631,8 +5631,8 @@
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",
         "@babel/runtime": "^7.28.2",
-        "@babylonjs/core": "^9.3.2",
-        "@babylonjs/materials": "^9.3.2",
+        "@babylonjs/core": "^9.3.3",
+        "@babylonjs/materials": "^9.3.3",
         "babel-loader": "^10.0.0",
         "buffer": "^6.0.3",
         "core-js": "^3.45.0",

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -9,12 +9,12 @@
     "getNightly": "node scripts/getNightly.js"
   },
   "dependencies": {
-    "babylonjs": "^9.3.2",
-    "babylonjs-gltf2interface": "^9.3.2",
-    "babylonjs-gui": "^9.3.2",
-    "babylonjs-loaders": "^9.3.2",
-    "babylonjs-materials": "^9.3.2",
-    "babylonjs-serializers": "^9.3.2",
+    "babylonjs": "^9.3.3",
+    "babylonjs-gltf2interface": "^9.3.3",
+    "babylonjs-gui": "^9.3.3",
+    "babylonjs-loaders": "^9.3.3",
+    "babylonjs-materials": "^9.3.3",
+    "babylonjs-serializers": "^9.3.3",
     "jsc-android": "^241213.1.0",
     "v8-android": "^7.8.2"
   }

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -9,12 +9,12 @@
     "getNightly": "node scripts/getNightly.js"
   },
   "dependencies": {
-    "babylonjs": "^9.3.3",
-    "babylonjs-gltf2interface": "^9.3.3",
-    "babylonjs-gui": "^9.3.3",
-    "babylonjs-loaders": "^9.3.3",
-    "babylonjs-materials": "^9.3.3",
-    "babylonjs-serializers": "^9.3.3",
+    "babylonjs": "^9.3.4",
+    "babylonjs-gltf2interface": "^9.3.4",
+    "babylonjs-gui": "^9.3.4",
+    "babylonjs-loaders": "^9.3.4",
+    "babylonjs-materials": "^9.3.4",
+    "babylonjs-serializers": "^9.3.4",
     "jsc-android": "^241213.1.0",
     "v8-android": "^7.8.2"
   }

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -9,12 +9,12 @@
     "getNightly": "node scripts/getNightly.js"
   },
   "dependencies": {
-    "babylonjs": "^9.0.0",
-    "babylonjs-gltf2interface": "^9.0.0",
-    "babylonjs-gui": "^9.0.0",
-    "babylonjs-loaders": "^9.0.0",
-    "babylonjs-materials": "^9.0.0",
-    "babylonjs-serializers": "^9.0.0",
+    "babylonjs": "^9.3.2",
+    "babylonjs-gltf2interface": "^9.3.2",
+    "babylonjs-gui": "^9.3.2",
+    "babylonjs-loaders": "^9.3.2",
+    "babylonjs-materials": "^9.3.2",
+    "babylonjs-serializers": "^9.3.2",
     "jsc-android": "^241213.1.0",
     "v8-android": "^7.8.2"
   }


### PR DESCRIPTION
## Summary

Bump Babylon.js from `9.0.0` to `9.3.4` across all `package.json` / `package-lock.json` files under `Apps/`.

## Motivation

Recent CI runs (e.g. on #1666) show `Win32_x64_D3D11` intermittently failing on the `Light Projection Texture` UnitTests case:

```
[Log] Running Light Projection Texture
[Log] First pixel off at 182856: Value: (51, 51, 53) - Expected: (46, 22, 16)
[Log] Pixel difference: 170840 pixels.
[Log] failed
##[error]Process completed with exit code -1.
```

Two upstream readiness bugs combine to produce this flake, and both need to land to remove it:

- **BabylonJS/Babylon.js#18255** — "Fix material readiness to gate on light texture readiness." Shipped in Babylon.js 9.3.2.
- **BabylonJS/Babylon.js#18355** — heightmap `CreateGroundFromHeightMap` readiness (the async image load was not gated by `addPendingData`/`removePendingData`, so `scene.isReady()` could return true before the heightmap was uploaded). Shipped in Babylon.js 9.3.4.

Earlier 9.3.2 / 9.3.3 bumps on this branch picked up #18255 but the flake persisted because the heightmap race (#18355) was still present. Bumping to `^9.3.4` picks up both.

## Changes

- `Apps/package.json` + lockfile: bump `babylonjs`, `babylonjs-gltf2interface`, `babylonjs-gui`, `babylonjs-loaders`, `babylonjs-materials`, `babylonjs-serializers` to `^9.3.4`.
- `Apps/UnitTests/JavaScript/package.json`: bump `babylonjs`, `babylonjs-materials`, `@babylonjs/core`, `@babylonjs/materials` to `^9.3.4`.
- `Apps/PrecompiledShaderTest/JavaScript/package.json` + lockfile: bump `@babylonjs/core` to `^9.3.4`.

No code changes — dependency bump only.

## Verification

CI on this PR is expected to go green on `Win32_x64_D3D11 Light Projection Texture` where it was previously flaky. Validated out-of-band on #1668 (monkey-patched 9.3.3 → 9.3.4 behavior) running LPT ×20 × 6 configs = 120/120 on Ubuntu_GCC_JSC.

---

[Created by Copilot on behalf of @bghgary]
