### PR TITLE
Make UBSan findings fatal in sanitized builds

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -19,6 +19,8 @@ on:
 
 env:
   CMAKE_VERSION: '3.31.6'
+  UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
+  ASAN_OPTIONS: abort_on_error=1
 
 jobs:
   build:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -22,6 +22,8 @@ on:
 
 env:
   CMAKE_VERSION: '3.31.6'
+  UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
+  ASAN_OPTIONS: abort_on_error=1
 
 jobs:
   build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ FetchContent_Declare(CMakeExtensions
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(glslang
     GIT_REPOSITORY https://github.com/BabylonJS/glslang.git
-    GIT_TAG 39a80699a315cb7f66c4ab3180edd4e2910fab28
+    GIT_TAG 284e4301e5a6b44b279635276588db7cdd942624
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(googletest
     URL "https://github.com/google/googletest/archive/refs/tags/v1.17.0.tar.gz"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,10 @@ if(ENABLE_SANITIZERS)
 
         string(JOIN "," SANITIZER_FLAGS ${SANITIZERS})
 
-        add_compile_options(-fsanitize=${SANITIZER_FLAGS} -fno-omit-frame-pointer)
+        # -fno-sanitize-recover=all makes UBSan findings fatal. Without it, UBSan
+        # only prints a diagnostic to stderr and execution continues, so CI stays
+        # green while latent UB goes unreported.
+        add_compile_options(-fsanitize=${SANITIZER_FLAGS} -fno-omit-frame-pointer -fno-sanitize-recover=all)
         add_link_options(-fsanitize=${SANITIZER_FLAGS})
     elseif(MSVC)
         # MSVC only supports AddressSanitizer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ FetchContent_Declare(base-n
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(bgfx.cmake
     GIT_REPOSITORY https://github.com/BabylonJS/bgfx.cmake.git
-    GIT_TAG c6575c5644e37ccc06b83d59d1d536cf8ec9f265
+    GIT_TAG e5f3f31c1ec8a376dde75f8b20366e2696810ea0
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(CMakeExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/CMakeExtensions.git


### PR DESCRIPTION
## Context

Our sanitized macOS/Linux jobs enable `-fsanitize=address,undefined[,vptr]`, so the UB checks are active — but **UBSan is recoverable by default**. On a hit it prints a diagnostic to stderr and keeps running. The process doesn't abort, the test doesn't fail, CI stays green, and the diagnostic is buried in test output nobody reads.

Adding `-fno-sanitize-recover=all` is what converts each UBSan hit into a `SIGABRT` → test failure. We were missing it.

## Change

Three commits:

1. **Make UBSan findings fatal in sanitized builds.** Add `-fno-sanitize-recover=all` to the Clang sanitizer `add_compile_options` line in `CMakeLists.txt`, and set `UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1:symbolize=1` and `ASAN_OPTIONS=abort_on_error=1` in `build-macos.yml` / `build-linux.yml` as runtime belt-and-suspenders. (MSVC only supports ASan, which already aborts on error.)
2. **Bump glslang to merged PR #5 SHA** — picks up [BabylonJS/glslang#5](https://github.com/BabylonJS/glslang/pull/5) (suppress UBSan enum check on SPIR-V mask bit-combining operators).
3. **Bump bgfx.cmake to merged BabylonJS#115 (UBSan fix)** — picks up [BabylonJS/bgfx.cmake#115](https://github.com/BabylonJS/bgfx.cmake/pull/115), which bumps the bgfx submodule to the cherry-pick of [bkaradzic/bgfx#3688](https://github.com/bkaradzic/bgfx/pull/3688) (default-init the SortKey ints/bools so we don't load undefined values into bitfields) via [BabylonJS/bgfx#60](https://github.com/BabylonJS/bgfx/pull/60).

The dependency bumps in commits 2 and 3 fix every UBSan finding currently being printed (and ignored) by the sanitized jobs on `master`, so this PR should be green on first run.

## Out of scope

- **metal-cpp's intentional "nil-messaging" pattern.** Apple documents sending messages to `nil` as well-defined in Obj-C, but C++ UBSan doesn't know that. Not hit on the current pin; if a future metal-cpp bump trips it, the standard fix is a scoped `-fno-sanitize=null` on metal-cpp only.
- `-fsanitize=nullability` (Apple `_Nonnull` attribute checks, separate from `null`) — worth considering as a follow-up once this lands and the baseline is clean.
- Windows ASan already aborts on error; no change needed there.

[Created by Copilot on behalf of @bghgary]
