### PR TITLE
ci: pin jwlawson/actions-setup-cmake to v2.2

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jwlawson/actions-setup-cmake@v2
+      - uses: jwlawson/actions-setup-cmake@v2.2
         with:
           cmake-version: ${{ env.CMAKE_VERSION }}
 

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jwlawson/actions-setup-cmake@v2
+      - uses: jwlawson/actions-setup-cmake@v2.2
         with:
           cmake-version: ${{ env.CMAKE_VERSION }}
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jwlawson/actions-setup-cmake@v2
+      - uses: jwlawson/actions-setup-cmake@v2.2
         with:
           cmake-version: ${{ env.CMAKE_VERSION }}
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jwlawson/actions-setup-cmake@v2
+      - uses: jwlawson/actions-setup-cmake@v2.2
         with:
           cmake-version: ${{ env.CMAKE_VERSION }}
 

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jwlawson/actions-setup-cmake@v2
+      - uses: jwlawson/actions-setup-cmake@v2.2
         with:
           cmake-version: ${{ env.CMAKE_VERSION }}
 

--- a/.github/workflows/build-win32-shader.yml
+++ b/.github/workflows/build-win32-shader.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jwlawson/actions-setup-cmake@v2
+      - uses: jwlawson/actions-setup-cmake@v2.2
         with:
           cmake-version: ${{ env.CMAKE_VERSION }}
 

--- a/.github/workflows/build-win32.yml
+++ b/.github/workflows/build-win32.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jwlawson/actions-setup-cmake@v2
+      - uses: jwlawson/actions-setup-cmake@v2.2
         with:
           cmake-version: ${{ env.CMAKE_VERSION }}
 

--- a/.github/workflows/test-install-ios.yml
+++ b/.github/workflows/test-install-ios.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jwlawson/actions-setup-cmake@v2
+      - uses: jwlawson/actions-setup-cmake@v2.2
         with:
           cmake-version: ${{ env.CMAKE_VERSION }}
 

--- a/.github/workflows/test-install-linux.yml
+++ b/.github/workflows/test-install-linux.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jwlawson/actions-setup-cmake@v2
+      - uses: jwlawson/actions-setup-cmake@v2.2
         with:
           cmake-version: ${{ env.CMAKE_VERSION }}
 

--- a/.github/workflows/test-install-macos.yml
+++ b/.github/workflows/test-install-macos.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jwlawson/actions-setup-cmake@v2
+      - uses: jwlawson/actions-setup-cmake@v2.2
         with:
           cmake-version: ${{ env.CMAKE_VERSION }}
 

--- a/.github/workflows/test-install-win32.yml
+++ b/.github/workflows/test-install-win32.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jwlawson/actions-setup-cmake@v2
+      - uses: jwlawson/actions-setup-cmake@v2.2
         with:
           cmake-version: ${{ env.CMAKE_VERSION }}
 


### PR DESCRIPTION
## Summary

Pins `jwlawson/actions-setup-cmake` from the floating `@v2` tag to `@v2.2` across all CI workflows.

## Files changed (11)

- `.github/workflows/build-android.yml`
- `.github/workflows/build-ios.yml`
- `.github/workflows/build-linux.yml`
- `.github/workflows/build-macos.yml`
- `.github/workflows/build-uwp.yml`
- `.github/workflows/build-win32.yml`
- `.github/workflows/build-win32-shader.yml`
- `.github/workflows/test-install-ios.yml`
- `.github/workflows/test-install-linux.yml`
- `.github/workflows/test-install-macos.yml`
- `.github/workflows/test-install-win32.yml`

Each is a one-line change: `jwlawson/actions-setup-cmake@v2` → `jwlawson/actions-setup-cmake@v2.2`.
