### PR TITLE
Remove obsolete CMake setup action; use runner-preinstalled cmake

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 env:
-  CMAKE_VERSION: '3.31.8'
+  CMAKE_VERSION: '3.31.12'
   NDK_VERSION: '28.2.13676358'
 
 jobs:

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -11,7 +11,6 @@ on:
         type: string
 
 env:
-  CMAKE_VERSION: '3.31.12'
   NDK_VERSION: '28.2.13676358'
 
 jobs:
@@ -20,10 +19,6 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
-
-      - uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
 
 
       - uses: actions/setup-java@v5

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 env:
-  CMAKE_VERSION: '3.31.6'
+  CMAKE_VERSION: '3.31.8'
   NDK_VERSION: '28.2.13676358'
 
 jobs:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -16,7 +16,7 @@ on:
         default: macos-latest
 
 env:
-  CMAKE_VERSION: '3.31.6'
+  CMAKE_VERSION: '3.31.8'
 
 jobs:
   build:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -16,7 +16,7 @@ on:
         default: macos-latest
 
 env:
-  CMAKE_VERSION: '3.31.8'
+  CMAKE_VERSION: '3.31.12'
 
 jobs:
   build:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -15,19 +15,12 @@ on:
         type: string
         default: macos-latest
 
-env:
-  CMAKE_VERSION: '3.31.12'
-
 jobs:
   build:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
-
-      - uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
 
 
       - name: Select Xcode ${{ inputs.xcode-version }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -18,7 +18,7 @@ on:
         default: false
 
 env:
-  CMAKE_VERSION: '3.31.8'
+  CMAKE_VERSION: '3.31.12'
   UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
   ASAN_OPTIONS: abort_on_error=1
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -18,7 +18,6 @@ on:
         default: false
 
 env:
-  CMAKE_VERSION: '3.31.12'
   UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
   ASAN_OPTIONS: abort_on_error=1
 
@@ -31,10 +30,6 @@ jobs:
       CXX: ${{ inputs.cxx }}
     steps:
       - uses: actions/checkout@v5
-
-      - uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
 
 
       - name: Install packages

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -18,7 +18,7 @@ on:
         default: false
 
 env:
-  CMAKE_VERSION: '3.31.6'
+  CMAKE_VERSION: '3.31.8'
   UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
   ASAN_OPTIONS: abort_on_error=1
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -21,7 +21,7 @@ on:
         default: macos-latest
 
 env:
-  CMAKE_VERSION: '3.31.6'
+  CMAKE_VERSION: '3.31.8'
   UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
   ASAN_OPTIONS: abort_on_error=1
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -21,7 +21,7 @@ on:
         default: macos-latest
 
 env:
-  CMAKE_VERSION: '3.31.8'
+  CMAKE_VERSION: '3.31.12'
   UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
   ASAN_OPTIONS: abort_on_error=1
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -21,7 +21,6 @@ on:
         default: macos-latest
 
 env:
-  CMAKE_VERSION: '3.31.12'
   UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
   ASAN_OPTIONS: abort_on_error=1
 
@@ -31,10 +30,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
-
-      - uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
 
 
       - name: Select Xcode ${{ inputs.xcode-version }}

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -12,7 +12,7 @@ on:
         default: direct
 
 env:
-  CMAKE_VERSION: '3.31.8'
+  CMAKE_VERSION: '3.31.12'
 
 jobs:
   build:

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -12,7 +12,7 @@ on:
         default: direct
 
 env:
-  CMAKE_VERSION: '3.31.6'
+  CMAKE_VERSION: '3.31.8'
 
 jobs:
   build:

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -11,19 +11,12 @@ on:
         type: string
         default: direct
 
-env:
-  CMAKE_VERSION: '3.31.12'
-
 jobs:
   build:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
-
-      - uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
 
 
       - name: Set NAPI variables

--- a/.github/workflows/build-win32-shader.yml
+++ b/.github/workflows/build-win32-shader.yml
@@ -9,7 +9,7 @@ on:
         default: x64
 
 env:
-  CMAKE_VERSION: '3.31.8'
+  CMAKE_VERSION: '3.31.12'
 
 jobs:
   build:

--- a/.github/workflows/build-win32-shader.yml
+++ b/.github/workflows/build-win32-shader.yml
@@ -9,7 +9,7 @@ on:
         default: x64
 
 env:
-  CMAKE_VERSION: '3.31.6'
+  CMAKE_VERSION: '3.31.8'
 
 jobs:
   build:

--- a/.github/workflows/build-win32-shader.yml
+++ b/.github/workflows/build-win32-shader.yml
@@ -8,19 +8,12 @@ on:
         type: string
         default: x64
 
-env:
-  CMAKE_VERSION: '3.31.12'
-
 jobs:
   build:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
-
-      - uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
 
 
       - name: Generate solution

--- a/.github/workflows/build-win32.yml
+++ b/.github/workflows/build-win32.yml
@@ -19,19 +19,12 @@ on:
         type: boolean
         default: false
 
-env:
-  CMAKE_VERSION: '3.31.12'
-
 jobs:
   build:
     runs-on: windows-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
-
-      - uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
 
 
       - name: Set variables

--- a/.github/workflows/build-win32.yml
+++ b/.github/workflows/build-win32.yml
@@ -20,7 +20,7 @@ on:
         default: false
 
 env:
-  CMAKE_VERSION: '3.31.8'
+  CMAKE_VERSION: '3.31.12'
 
 jobs:
   build:

--- a/.github/workflows/build-win32.yml
+++ b/.github/workflows/build-win32.yml
@@ -20,7 +20,7 @@ on:
         default: false
 
 env:
-  CMAKE_VERSION: '3.31.6'
+  CMAKE_VERSION: '3.31.8'
 
 jobs:
   build:

--- a/.github/workflows/test-install-ios.yml
+++ b/.github/workflows/test-install-ios.yml
@@ -12,7 +12,7 @@ on:
         default: '16.4'
 
 env:
-  CMAKE_VERSION: '3.31.8'
+  CMAKE_VERSION: '3.31.12'
 
 jobs:
   test-install:

--- a/.github/workflows/test-install-ios.yml
+++ b/.github/workflows/test-install-ios.yml
@@ -12,7 +12,7 @@ on:
         default: '16.4'
 
 env:
-  CMAKE_VERSION: '3.31.6'
+  CMAKE_VERSION: '3.31.8'
 
 jobs:
   test-install:

--- a/.github/workflows/test-install-ios.yml
+++ b/.github/workflows/test-install-ios.yml
@@ -11,19 +11,12 @@ on:
         type: string
         default: '16.4'
 
-env:
-  CMAKE_VERSION: '3.31.12'
-
 jobs:
   test-install:
     runs-on: macos-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
-
-      - uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
 
 
       - name: Select Xcode ${{ inputs.xcode-version }}

--- a/.github/workflows/test-install-linux.yml
+++ b/.github/workflows/test-install-linux.yml
@@ -4,7 +4,7 @@ on:
   workflow_call: {}
 
 env:
-  CMAKE_VERSION: '3.31.6'
+  CMAKE_VERSION: '3.31.8'
 
 jobs:
   test-install:

--- a/.github/workflows/test-install-linux.yml
+++ b/.github/workflows/test-install-linux.yml
@@ -4,7 +4,7 @@ on:
   workflow_call: {}
 
 env:
-  CMAKE_VERSION: '3.31.8'
+  CMAKE_VERSION: '3.31.12'
 
 jobs:
   test-install:

--- a/.github/workflows/test-install-linux.yml
+++ b/.github/workflows/test-install-linux.yml
@@ -3,19 +3,12 @@ name: Test Install Linux
 on:
   workflow_call: {}
 
-env:
-  CMAKE_VERSION: '3.31.12'
-
 jobs:
   test-install:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
-
-      - uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
 
 
       - name: Install packages

--- a/.github/workflows/test-install-macos.yml
+++ b/.github/workflows/test-install-macos.yml
@@ -8,19 +8,12 @@ on:
         type: string
         default: '16.4'
 
-env:
-  CMAKE_VERSION: '3.31.12'
-
 jobs:
   test-install:
     runs-on: macos-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
-
-      - uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
 
 
       - name: Select Xcode ${{ inputs.xcode-version }}

--- a/.github/workflows/test-install-macos.yml
+++ b/.github/workflows/test-install-macos.yml
@@ -9,7 +9,7 @@ on:
         default: '16.4'
 
 env:
-  CMAKE_VERSION: '3.31.6'
+  CMAKE_VERSION: '3.31.8'
 
 jobs:
   test-install:

--- a/.github/workflows/test-install-macos.yml
+++ b/.github/workflows/test-install-macos.yml
@@ -9,7 +9,7 @@ on:
         default: '16.4'
 
 env:
-  CMAKE_VERSION: '3.31.8'
+  CMAKE_VERSION: '3.31.12'
 
 jobs:
   test-install:

--- a/.github/workflows/test-install-win32.yml
+++ b/.github/workflows/test-install-win32.yml
@@ -4,7 +4,7 @@ on:
   workflow_call: {}
 
 env:
-  CMAKE_VERSION: '3.31.6'
+  CMAKE_VERSION: '3.31.8'
 
 jobs:
   test-install:

--- a/.github/workflows/test-install-win32.yml
+++ b/.github/workflows/test-install-win32.yml
@@ -4,7 +4,7 @@ on:
   workflow_call: {}
 
 env:
-  CMAKE_VERSION: '3.31.8'
+  CMAKE_VERSION: '3.31.12'
 
 jobs:
   test-install:

--- a/.github/workflows/test-install-win32.yml
+++ b/.github/workflows/test-install-win32.yml
@@ -3,19 +3,12 @@ name: Test Install Win32
 on:
   workflow_call: {}
 
-env:
-  CMAKE_VERSION: '3.31.12'
-
 jobs:
   test-install:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
-
-      - uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
 
 
       - name: Configure


### PR DESCRIPTION
## Context

CI started failing today on every fresh runner with:

```
##[error]Unable to find version matching 3.31.6
```

from `jwlawson/actions-setup-cmake@v2`. The GitHub release for `v3.31.6` still exists, and so do `3.31.8` and `3.31.12`, but the action's resolver can't find any of them right now. Bumping the pin to other 3.31.x patches did not help.

## Why the pin existed

The original Azure Pipelines `cmake.yml` script (pre-#1661) had this comment:

> `# Force using older cmake See https://gitlab.kitware.com/cmake/cmake/-/issues/22021`

That CMake bug — `MACOSX_PACKAGE_LOCATION` mishandling for `INTERFACE_SOURCES` — was [**fixed in CMake 3.22**](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/6698) (MR!6698). The pin carried over into #1661 as part of the faithful Azure-→-Actions port.

## Why we don't need to pin anymore

- `CMakeLists.txt` requires `cmake_minimum_required(VERSION 3.21)`.
- All current GitHub-hosted runner images (Ubuntu, Windows, macOS) ship CMake ≥ 3.30.
- The original `#22021` bug we were avoiding is fixed in 3.22, well below anything any runner ships today.

## Change

Remove the `jwlawson/actions-setup-cmake@v2` step (and its `CMAKE_VERSION` env var) from all 11 workflow files. The runner-preinstalled CMake satisfies our minimum and avoids the broken action altogether.

[Created by Copilot on behalf of @bghgary]
