### PR TITLE
Prototype: sccache via GitHub Actions cache backend (Linux + macOS Ninja)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -20,6 +20,7 @@ on:
 env:
   UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
   ASAN_OPTIONS: abort_on_error=1
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   build:
@@ -31,6 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Install packages
         run: |
@@ -40,6 +43,8 @@ jobs:
       - name: Build X11
         run: |
           cmake -G Ninja -B build/Linux \
+            -D CMAKE_C_COMPILER_LAUNCHER=sccache \
+            -D CMAKE_CXX_COMPILER_LAUNCHER=sccache \
             -D JAVASCRIPTCORE_LIBRARY=/usr/lib/x86_64-linux-gnu/libjavascriptcoregtk-4.1.so \
             -D NAPI_JAVASCRIPT_ENGINE=${{ inputs.js-engine }} \
             -D CMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -48,6 +53,10 @@ jobs:
             -D BABYLON_DEBUG_TRACE=ON \
             -D ENABLE_SANITIZERS=${{ inputs.enable-sanitizers && 'ON' || 'OFF' }} .
           ninja -C build/Linux
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
 
       - name: Enable Core Dump
         run: sudo sysctl -w kernel.core_pattern=core.%p

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -23,6 +23,7 @@ on:
 env:
   UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
   ASAN_OPTIONS: abort_on_error=1
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   build:
@@ -35,9 +36,14 @@ jobs:
       - name: Select Xcode ${{ inputs.xcode-version }}
         run: sudo xcode-select --switch /Applications/Xcode_${{ inputs.xcode-version }}.app/Contents/Developer
 
+      - name: Run sccache-cache
+        if: ${{ inputs.generator != 'Xcode' }}
+        uses: mozilla-actions/sccache-action@v0.0.10
+
       - name: Generate macOS solution
         run: |
           cmake -G "${{ inputs.generator }}" -B build/macOS \
+            ${{ inputs.generator != 'Xcode' && '-D CMAKE_C_COMPILER_LAUNCHER=sccache -D CMAKE_CXX_COMPILER_LAUNCHER=sccache -D CMAKE_OBJC_COMPILER_LAUNCHER=sccache -D CMAKE_OBJCXX_COMPILER_LAUNCHER=sccache' || '' }} \
             -D BABYLON_DEBUG_TRACE=ON \
             -D ENABLE_SANITIZERS=${{ inputs.enable-sanitizers && 'ON' || 'OFF' }} \
             -D BABYLON_NATIVE_TESTS_USE_NOOP_METAL_DEVICE=ON
@@ -50,6 +56,10 @@ jobs:
 
       - name: Build ModuleLoadTest macOS
         run: cmake --build build/macOS --target ModuleLoadTest --config RelWithDebInfo
+
+      - name: sccache stats
+        if: ${{ always() && inputs.generator != 'Xcode' }}
+        run: sccache --show-stats
 
       - name: Enable Core Dump
         run: sudo sysctl -w kern.corefile=%N.core.%P


### PR DESCRIPTION
## Context

Prototype for accelerating CI compile time using **sccache** with the GitHub Actions cache as the backend. Motivated by sanitizer / fresh-runner build times where most of the wall clock is recompiling unchanged dependency code (bgfx, bx, bimg, glslang, SPIRV-Cross, libwebp, JsRuntimeHost, etc.).

## What this does

- Adds [`mozilla-actions/sccache-action@v0.0.10`](https://github.com/mozilla-actions/sccache-action) to two reusable workflows.
- Sets `SCCACHE_GHA_ENABLED=true` so sccache uses the per-repo GitHub Actions cache (10 GB) as its storage backend — no external infra required.
- Wires CMake to use sccache as the compiler launcher via `-D CMAKE_{C,CXX}_COMPILER_LAUNCHER=sccache` (and `OBJC`/`OBJCXX` on macOS).
- Adds a `sccache --show-stats` step (with `if: always()`) so each run reports cache hits / misses / size for empirical evaluation.

## Scope

Intentionally narrow for the prototype:

| Workflow | Matrix entry | Generator | Covered? |
| --- | --- | --- | --- |
| build-linux.yml | All (`Ubuntu_Clang_JSC`, `Ubuntu_GCC_JSC`, sanitizers) | Ninja | ✅ |
| build-macos.yml | `MacOS_Ninja` only | Ninja Multi-Config | ✅ |
| build-macos.yml | `MacOS`, `MacOS_Sanitizers`, `MacOS_Xcode26` | Xcode | ❌ skipped |
| build-win32.yml | All | `Visual Studio 17 2022` | ❌ skipped |
| build-android.yml, build-ios.yml, build-uwp.yml, etc. | — | various | ❌ skipped |

The macOS Xcode and Win32 entries are skipped because **`CMAKE_<LANG>_COMPILER_LAUNCHER` is implemented for the Makefile and Ninja generators only — not for the Xcode or Visual Studio generators**. Adding sccache there would require switching their generator (a separate, larger change) so it's deferred.

The macOS step is gated with `if: inputs.generator != 'Xcode'` so `MacOS_Ninja` picks it up while the Xcode-generator entries continue to skip it cleanly.

## What sccache will and won't help

**Will help:** BN source, bgfx, bx, bimg, glslang, SPIRV-Cross, libwebp, JsRuntimeHost, arcana, plugin sources — anything FetchContent-built or compiled from source by BN.

**Won't help:**

- JavaScriptCore on Linux/macOS — system libraries, not compiled by us.
- V8 on Win32 — NuGet prebuilt, not compiled by us.
- Configure-time (FetchContent download/extract), link time, test runtime, npm/NuGet downloads.

So expected wall-clock gains are bounded by the compile share of total job time. For sanitizer builds that share is high.

## How to evaluate

After this lands as draft, look at the new "sccache stats" step output in each Linux + `MacOS_Ninja` job:

- First run: cache cold, 0 % hits — expected.
- Subsequent runs (force-push, retrigger, rebases): hit % climbs as the cache warms.
- Compare wall time of the build step before/after the cache warms.

If results are good, follow-up PRs can:
1. Switch macOS sanitizer + default to Ninja so they can use sccache.
2. Switch Win32 to Ninja under MSVC dev environment so it can use sccache (also requires `cmake_policy(SET CMP0141 NEW)` for `/Z7` debug-info to make sanitizer objects cacheable).
3. Wire Android / iOS / UWP if signal looks worth it.

## Caveats

- 10 GB per-repo GHA cache. With Linux × multiple matrix entries + macOS Ninja, the cache may grow large enough to evict other CI caches. If that becomes a problem, options include narrowing scope, raising compression, or moving to an explicit S3/Azure backend.
- GHA cache is branch-scoped with default-branch fallback. PR runs may have lower hit rates than `master` runs. That's normal — the master cache warms over time and PRs benefit from it.
- Action is pinned by tag (`@v0.0.10`). For stronger supply-chain hygiene we could pin to a commit SHA in a follow-up.

[Created by Copilot on behalf of @bghgary]
