### PR TITLE
Prototype: cache CMake FetchContent populated dir with actions/cache

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -22,6 +22,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Cache FetchContent deps
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.fc-cache
+          key: fc-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: |
+            fc-${{ runner.os }}-
 
       - name: Select Xcode ${{ inputs.xcode-version }}
         run: sudo xcode-select --switch /Applications/Xcode_${{ inputs.xcode-version }}.app/Contents/Developer
@@ -29,6 +36,8 @@ jobs:
       - name: Generate iOS solution
         run: |
           cmake -G Xcode -B build/iOS \
+            -D FETCHCONTENT_BASE_DIR=${{ github.workspace }}/.fc-cache \
+            -D FETCHCONTENT_UPDATES_DISCONNECTED=ON \
             -D IOS=ON \
             -D DEPLOYMENT_TARGET=${{ inputs.deployment-target }} \
             -D BABYLON_DEBUG_TRACE=ON \

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -29,9 +29,9 @@ jobs:
             ${{ github.workspace }}/.fc-cache
             !${{ github.workspace }}/.fc-cache/*-build
             !${{ github.workspace }}/.fc-cache/*-build/**
-          key: fc-ios-${{ hashFiles('**/CMakeLists.txt') }}
+          key: fc-v2-ios-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            fc-ios-
+            fc-v2-ios-
 
       - name: Select Xcode ${{ inputs.xcode-version }}
         run: sudo xcode-select --switch /Applications/Xcode_${{ inputs.xcode-version }}.app/Contents/Developer

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -26,9 +26,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.fc-cache
-          key: fc-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
+          key: fc-ios-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            fc-${{ runner.os }}-
+            fc-ios-
 
       - name: Select Xcode ${{ inputs.xcode-version }}
         run: sudo xcode-select --switch /Applications/Xcode_${{ inputs.xcode-version }}.app/Contents/Developer

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -25,7 +25,10 @@ jobs:
       - name: Cache FetchContent deps
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/.fc-cache
+          path: |
+            ${{ github.workspace }}/.fc-cache
+            !${{ github.workspace }}/.fc-cache/*-build
+            !${{ github.workspace }}/.fc-cache/*-build/**
           key: fc-ios-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
             fc-ios-

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -31,6 +31,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Cache FetchContent deps
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.fc-cache
+          key: fc-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: |
+            fc-${{ runner.os }}-
 
       - name: Install packages
         run: |
@@ -40,6 +47,8 @@ jobs:
       - name: Build X11
         run: |
           cmake -G Ninja -B build/Linux \
+            -D FETCHCONTENT_BASE_DIR=${{ github.workspace }}/.fc-cache \
+            -D FETCHCONTENT_UPDATES_DISCONNECTED=ON \
             -D JAVASCRIPTCORE_LIBRARY=/usr/lib/x86_64-linux-gnu/libjavascriptcoregtk-4.1.so \
             -D NAPI_JAVASCRIPT_ENGINE=${{ inputs.js-engine }} \
             -D CMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -35,9 +35,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.fc-cache
-          key: fc-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
+          key: fc-linux-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            fc-${{ runner.os }}-
+            fc-linux-
 
       - name: Install packages
         run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -38,9 +38,9 @@ jobs:
             ${{ github.workspace }}/.fc-cache
             !${{ github.workspace }}/.fc-cache/*-build
             !${{ github.workspace }}/.fc-cache/*-build/**
-          key: fc-linux-${{ hashFiles('**/CMakeLists.txt') }}
+          key: fc-v2-linux-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            fc-linux-
+            fc-v2-linux-
 
       - name: Install packages
         run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Cache FetchContent deps
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/.fc-cache
+          path: |
+            ${{ github.workspace }}/.fc-cache
+            !${{ github.workspace }}/.fc-cache/*-build
+            !${{ github.workspace }}/.fc-cache/*-build/**
           key: fc-linux-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
             fc-linux-

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -35,9 +35,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.fc-cache
-          key: fc-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
+          key: fc-macos-${{ inputs.generator }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            fc-${{ runner.os }}-
+            fc-macos-${{ inputs.generator }}-
 
       - name: Select Xcode ${{ inputs.xcode-version }}
         run: sudo xcode-select --switch /Applications/Xcode_${{ inputs.xcode-version }}.app/Contents/Developer

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -38,9 +38,9 @@ jobs:
             ${{ github.workspace }}/.fc-cache
             !${{ github.workspace }}/.fc-cache/*-build
             !${{ github.workspace }}/.fc-cache/*-build/**
-          key: fc-macos-${{ inputs.generator }}-${{ hashFiles('**/CMakeLists.txt') }}
+          key: fc-v2-macos-${{ inputs.generator }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            fc-macos-${{ inputs.generator }}-
+            fc-v2-macos-${{ inputs.generator }}-
 
       - name: Select Xcode ${{ inputs.xcode-version }}
         run: sudo xcode-select --switch /Applications/Xcode_${{ inputs.xcode-version }}.app/Contents/Developer

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Cache FetchContent deps
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/.fc-cache
+          path: |
+            ${{ github.workspace }}/.fc-cache
+            !${{ github.workspace }}/.fc-cache/*-build
+            !${{ github.workspace }}/.fc-cache/*-build/**
           key: fc-macos-${{ inputs.generator }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
             fc-macos-${{ inputs.generator }}-

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -31,6 +31,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Cache FetchContent deps
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.fc-cache
+          key: fc-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: |
+            fc-${{ runner.os }}-
 
       - name: Select Xcode ${{ inputs.xcode-version }}
         run: sudo xcode-select --switch /Applications/Xcode_${{ inputs.xcode-version }}.app/Contents/Developer
@@ -38,6 +45,8 @@ jobs:
       - name: Generate macOS solution
         run: |
           cmake -G "${{ inputs.generator }}" -B build/macOS \
+            -D FETCHCONTENT_BASE_DIR=${{ github.workspace }}/.fc-cache \
+            -D FETCHCONTENT_UPDATES_DISCONNECTED=ON \
             -D BABYLON_DEBUG_TRACE=ON \
             -D ENABLE_SANITIZERS=${{ inputs.enable-sanitizers && 'ON' || 'OFF' }} \
             -D BABYLON_NATIVE_TESTS_USE_NOOP_METAL_DEVICE=ON

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -25,9 +25,9 @@ jobs:
             ${{ github.workspace }}/.fc-cache
             !${{ github.workspace }}/.fc-cache/*-build
             !${{ github.workspace }}/.fc-cache/*-build/**
-          key: fc-uwp-${{ inputs.platform }}-${{ hashFiles('**/CMakeLists.txt') }}
+          key: fc-v2-uwp-${{ inputs.platform }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            fc-uwp-${{ inputs.platform }}-
+            fc-v2-uwp-${{ inputs.platform }}-
 
       - name: Set NAPI variables
         id: napi

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -21,7 +21,10 @@ jobs:
       - name: Cache FetchContent deps
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/.fc-cache
+          path: |
+            ${{ github.workspace }}/.fc-cache
+            !${{ github.workspace }}/.fc-cache/*-build
+            !${{ github.workspace }}/.fc-cache/*-build/**
           key: fc-uwp-${{ inputs.platform }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
             fc-uwp-${{ inputs.platform }}-

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.fc-cache
-          key: fc-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
+          key: fc-uwp-${{ inputs.platform }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            fc-${{ runner.os }}-
+            fc-uwp-${{ inputs.platform }}-
 
       - name: Set NAPI variables
         id: napi

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -18,6 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Cache FetchContent deps
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.fc-cache
+          key: fc-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: |
+            fc-${{ runner.os }}-
 
       - name: Set NAPI variables
         id: napi
@@ -36,6 +43,8 @@ jobs:
         run: |
           cmake -G "Visual Studio 17 2022" ^
             -B build/UWP_${{ inputs.platform }}${{ steps.napi.outputs.suffix }} ^
+            -D FETCHCONTENT_BASE_DIR=${{ github.workspace }}/.fc-cache ^
+            -D FETCHCONTENT_UPDATES_DISCONNECTED=ON ^
             -D CMAKE_SYSTEM_NAME=WindowsStore ^
             -D CMAKE_SYSTEM_VERSION=10.0 ^
             ${{ steps.napi.outputs.define }} ^

--- a/.github/workflows/build-win32-shader.yml
+++ b/.github/workflows/build-win32-shader.yml
@@ -19,9 +19,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.fc-cache
-          key: fc-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
+          key: fc-win32shader-${{ inputs.platform }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            fc-${{ runner.os }}-
+            fc-win32shader-${{ inputs.platform }}-
 
       - name: Generate solution
         shell: cmd

--- a/.github/workflows/build-win32-shader.yml
+++ b/.github/workflows/build-win32-shader.yml
@@ -18,7 +18,10 @@ jobs:
       - name: Cache FetchContent deps
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/.fc-cache
+          path: |
+            ${{ github.workspace }}/.fc-cache
+            !${{ github.workspace }}/.fc-cache/*-build
+            !${{ github.workspace }}/.fc-cache/*-build/**
           key: fc-win32shader-${{ inputs.platform }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
             fc-win32shader-${{ inputs.platform }}-

--- a/.github/workflows/build-win32-shader.yml
+++ b/.github/workflows/build-win32-shader.yml
@@ -15,6 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Cache FetchContent deps
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.fc-cache
+          key: fc-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: |
+            fc-${{ runner.os }}-
 
       - name: Generate solution
         shell: cmd
@@ -22,6 +29,8 @@ jobs:
           cmake -G "Visual Studio 17 2022" ^
             -B build/Win32_${{ inputs.platform }}_PrecompiledShaderTest ^
             -A ${{ inputs.platform }} ^
+            -D FETCHCONTENT_BASE_DIR=${{ github.workspace }}/.fc-cache ^
+            -D FETCHCONTENT_UPDATES_DISCONNECTED=ON ^
             -D BX_CONFIG_DEBUG=ON ^
             -D GRAPHICS_API=D3D11 ^
             -D BGFX_CONFIG_MAX_FRAME_BUFFERS=256 ^

--- a/.github/workflows/build-win32-shader.yml
+++ b/.github/workflows/build-win32-shader.yml
@@ -22,9 +22,9 @@ jobs:
             ${{ github.workspace }}/.fc-cache
             !${{ github.workspace }}/.fc-cache/*-build
             !${{ github.workspace }}/.fc-cache/*-build/**
-          key: fc-win32shader-${{ inputs.platform }}-${{ hashFiles('**/CMakeLists.txt') }}
+          key: fc-v2-win32shader-${{ inputs.platform }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            fc-win32shader-${{ inputs.platform }}-
+            fc-v2-win32shader-${{ inputs.platform }}-
 
       - name: Generate solution
         shell: cmd

--- a/.github/workflows/build-win32.yml
+++ b/.github/workflows/build-win32.yml
@@ -33,9 +33,9 @@ jobs:
             ${{ github.workspace }}/.fc-cache
             !${{ github.workspace }}/.fc-cache/*-build
             !${{ github.workspace }}/.fc-cache/*-build/**
-          key: fc-win32-${{ inputs.platform }}-${{ hashFiles('**/CMakeLists.txt') }}
+          key: fc-v2-win32-${{ inputs.platform }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            fc-win32-${{ inputs.platform }}-
+            fc-v2-win32-${{ inputs.platform }}-
 
       - name: Set variables
         id: vars

--- a/.github/workflows/build-win32.yml
+++ b/.github/workflows/build-win32.yml
@@ -29,7 +29,10 @@ jobs:
       - name: Cache FetchContent deps
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/.fc-cache
+          path: |
+            ${{ github.workspace }}/.fc-cache
+            !${{ github.workspace }}/.fc-cache/*-build
+            !${{ github.workspace }}/.fc-cache/*-build/**
           key: fc-win32-${{ inputs.platform }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
             fc-win32-${{ inputs.platform }}-

--- a/.github/workflows/build-win32.yml
+++ b/.github/workflows/build-win32.yml
@@ -30,9 +30,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.fc-cache
-          key: fc-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
+          key: fc-win32-${{ inputs.platform }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            fc-${{ runner.os }}-
+            fc-win32-${{ inputs.platform }}-
 
       - name: Set variables
         id: vars

--- a/.github/workflows/build-win32.yml
+++ b/.github/workflows/build-win32.yml
@@ -26,6 +26,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Cache FetchContent deps
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.fc-cache
+          key: fc-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: |
+            fc-${{ runner.os }}-
 
       - name: Set variables
         id: vars
@@ -51,6 +58,8 @@ jobs:
           cmake -G "Visual Studio 17 2022" ^
             -B build/${{ steps.vars.outputs.solution_name }} ^
             -A ${{ inputs.platform }} ^
+            -D FETCHCONTENT_BASE_DIR=${{ github.workspace }}/.fc-cache ^
+            -D FETCHCONTENT_UPDATES_DISCONNECTED=ON ^
             ${{ steps.vars.outputs.js_define }} ^
             -D BX_CONFIG_DEBUG=ON ^
             -D GRAPHICS_API=${{ inputs.graphics-api }} ^


### PR DESCRIPTION
## Goal

Measure CI configure-step savings from caching CMake's `FetchContent` populated dir via `actions/cache`. Discussion in [internal session]; recap below.

## Why

Configure step today (last green master run `25109347097`):

| Job | Configure step |
|---|---|
| Win32_x64_D3D11 | 142s |
| UWP_x64 | 189s |
| MacOS / build | 158s |
| iOS_iOS180 | 180s |
| Linux/Android (configure inside Build step) | est 60-100s |

A warm-cache CMake configure (no network, deps already on disk) typically runs ~20-40s. Estimated savings:
- **Per-job typical**: ~100-160s on Win32/Mac/iOS/UWP, ~50-80s on Linux/Android.
- **Per-pipeline wall time**: ~2-3 min off the longest job (`Win32_x64_D3D11_Sanitizers` at ~16 min).
- **Aggregate compute per CI run**: ~45-70 min CI minutes saved across the 28-job matrix.
- **Variance**: removes the 30-min UWP timeout flake we recently hit, where configure alone took 16:35 on a contended Windows runner.

## Approach

Each reusable `build-*.yml` workflow:

1. Adds an `actions/cache@v4` step right after `checkout`:
   - `path: ${{ github.workspace }}/.fc-cache`
   - `key: fc-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}`
   - `restore-keys: fc-${{ runner.os }}-` (partial-match fallback)
2. Passes two new flags to the `cmake` configure invocation:
   - `-D FETCHCONTENT_BASE_DIR=${{ github.workspace }}/.fc-cache` — redirects FetchContent's populated dir to the cache location.
   - `-D FETCHCONTENT_UPDATES_DISCONNECTED=ON` — once a dep is in cache, don't `git fetch` to re-validate it.

## Cache key

Per-OS (line endings + file timestamps differ across runners) and hashes every `CMakeLists.txt`. This invalidates the cache on any `GIT_TAG` bump, new `FetchContent_Declare`, or `PATCH_COMMAND` change while leaving it intact across unrelated source-file changes.

## Scope

6 workflows: `build-{linux,macos,ios,uwp,win32,win32-shader}.yml`. **Android skipped** — it goes through gradle which dispatches cmake; needs a separate edit to the gradle build script. Will add as a follow-up if results are good here.

## Validation plan

1. First CI run on this PR: cold cache for every job (no key match yet). Configure timings should be similar to master baseline.
2. Push an empty commit (or have the PR re-trigger via amend-equivalent push) — second run should hit warm cache. Measure delta.
3. Compare warm-cache step timings vs master baseline; report.

## Risks / things to verify

- Cache size per OS (need to stay under GHA's 10 GB total quota per repo).
- `FETCHCONTENT_UPDATES_DISCONNECTED=ON` behavior when a dep is partially populated (e.g., previous run failed mid-fetch). Should work because it only skips remote re-validation; missing deps still get fetched.
- `PATCH_COMMAND` outcomes get cached as part of the source-tree state. If a patch script is changed, the CMakeLists hash should change to invalidate. Verify by intentionally bumping a patch.
- Cross-job cache collision: multiple jobs sharing the same key may all populate from scratch on the first run. Subsequent runs share. Acceptable.

[Created by Copilot on behalf of @bghgary]
