### PR TITLE
Update playgroundId for Native Canvas entry

### DIFF
--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -15,7 +15,7 @@
         },
         {
             "title": "Native Canvas",
-            "playgroundId": "#TKVFSA#7",
+            "playgroundId": "#TKVFSA#8",
             "referenceImage": "native-canvas.png"
         },
         {


### PR DESCRIPTION
the old playground #TKVFSA#7 used `new` where it was not needed (i.e. not a construct-able class):

```
let heartPath = new engine.createCanvasPath2D("M390,30 A 20, 20 0, 0, 1 430, 30 A 20, 20 0, 0, 1 470, 30 Q 470, 60 430, 90 Q 390, 60 390, 30 z");
        
```
This is an accepted syntax in es3/es5 but not in any future version of es.