### PR TITLE
Harden Playground tests against transient network errors

### DIFF
--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -157,20 +157,24 @@
             const snippetUrl = "https://snippet.babylonjs.com";
             const pgRoot = "https://playground.babylonjs.com";
 
-            const retryTime = 500;
-            const maxRetry = 5;
+            const initialRetryTime = 500;
+            const maxRetry = 8;
             let retry = 0;
 
             const onError = function () {
                 retry++;
                 if (retry < maxRetry) {
+                    // Exponential backoff capped at 30s. The snippet service can be briefly
+                    // unavailable (5xx, 429, gateway timeout); 8 attempts over ~60s gives the
+                    // upstream room to recover before we fail the whole run.
+                    const delay = Math.min(initialRetryTime * Math.pow(2, retry - 1), 30000);
                     setTimeout(function () {
                         loadPG();
-                    }, retryTime);
+                    }, delay);
                 }
                 else {
                     // Fail the test, something wrong happen
-                    console.log("Running the playground failed.");
+                    console.log("Running the playground failed after " + maxRetry + " attempts.");
                     done(false);
                 }
             }
@@ -179,8 +183,16 @@
                 const xmlHttp = new XMLHttpRequest();
                 xmlHttp.addEventListener("readystatechange", function () {
                     if (xmlHttp.readyState === 4) {
+                        xmlHttp.onreadystatechange = null;
+                        // Treat any non-200 (5xx, 429, empty body, etc.) as retryable rather
+                        // than feeding the response body to JSON.parse and surfacing it as a
+                        // SyntaxError.
+                        if (xmlHttp.status !== 200) {
+                            console.error("Snippet fetch returned status " + xmlHttp.status + " for " + test.playgroundId);
+                            onError();
+                            return;
+                        }
                         try {
-                            xmlHttp.onreadystatechange = null;
                             const snippet = JSON.parse(xmlHttp.responseText);
                             let code = JSON.parse(snippet.jsonPayload).code.toString();
 

--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -183,7 +183,6 @@
                 const xmlHttp = new XMLHttpRequest();
                 xmlHttp.addEventListener("readystatechange", function () {
                     if (xmlHttp.readyState === 4) {
-                        xmlHttp.onreadystatechange = null;
                         // Treat any non-200 (5xx, 429, empty body, etc.) as retryable rather
                         // than feeding the response body to JSON.parse and surfacing it as a
                         // SyntaxError.

--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -83,6 +83,27 @@
     const engine = new BABYLON.NativeEngine();
     engine.getCaps().parallelShaderCompile = undefined;
 
+    // Broaden Babylon's default retry strategy for the test framework: in addition to
+    // network drops (status 0, the default trigger), also retry transient HTTP errors
+    // (5xx) and rate limits (429). Applies to every BABYLON.Tools.LoadFile request
+    // including the snippet fetches in loadPG below and the texture/asset loads
+    // initiated from inside each playground's createScene().
+    BABYLON.Tools.DefaultRetryStrategy = function (url, request, retryIndex) {
+        const maxRetries = 5;
+        if (retryIndex >= maxRetries) {
+            return -1;
+        }
+        if (url.indexOf("file:") !== -1) {
+            return -1;
+        }
+        if (request.status === 0 ||
+            request.status === 429 ||
+            (request.status >= 500 && request.status < 600)) {
+            return Math.pow(2, retryIndex) * 500;
+        }
+        return -1;
+    };
+
     engine.getRenderingCanvas = function () {
         return window;
     }
@@ -284,42 +305,13 @@
             const snippetUrl = "https://snippet.babylonjs.com";
             const pgRoot = "https://playground.babylonjs.com";
 
-            const initialRetryTime = 500;
-            const maxRetry = 8;
-            let retry = 0;
-
-            const onError = function () {
-                retry++;
-                if (retry < maxRetry) {
-                    // Exponential backoff capped at 30s. The snippet service can be briefly
-                    // unavailable (5xx, 429, gateway timeout); 8 attempts over ~60s gives the
-                    // upstream room to recover before we fail the whole run.
-                    const delay = Math.min(initialRetryTime * Math.pow(2, retry - 1), 30000);
-                    setTimeout(function () {
-                        loadPG();
-                    }, delay);
-                }
-                else {
-                    // Fail the test, something wrong happen
-                    console.log("Running the playground failed.");
-                    failTest(done);
-                }
-            }
-
             const loadPG = function () {
-                const xmlHttp = new XMLHttpRequest();
-                xmlHttp.addEventListener("readystatechange", function () {
-                    if (xmlHttp.readyState === 4) {
-                        // Treat any non-200 (5xx, 429, empty body, etc.) as retryable rather
-                        // than feeding the response body to JSON.parse and surfacing it as a
-                        // SyntaxError.
-                        if (xmlHttp.status !== 200) {
-                            console.error("Snippet fetch returned status " + xmlHttp.status + " for " + test.playgroundId);
-                            onError();
-                            return;
-                        }
+                const url = snippetUrl + test.playgroundId.replace(/#/g, "/");
+                BABYLON.Tools.LoadFile(
+                    url,
+                    function (responseText) {
                         try {
-                            const snippet = JSON.parse(xmlHttp.responseText);
+                            const snippet = JSON.parse(responseText);
                             let code = JSON.parse(snippet.jsonPayload).code.toString();
 
                             // Check if this is a v2 manifest and extract the entry file's code
@@ -361,26 +353,30 @@
                                     processCurrentScene(test, referenceImage, done, compareFunction);
                                 }).catch(function (e) {
                                     console.error(e);
-                                    onError();
-                                })
+                                    failTest(done);
+                                });
                             } else {
                                 // Handle if createScene returns a scene
                                 processCurrentScene(test, referenceImage, done, compareFunction);
                             }
-
                         }
                         catch (e) {
-                            console.error(e);
-                            onError();
+                            console.error("Failed to evaluate playground snippet " + test.playgroundId + ": " + e);
+                            failTest(done);
                         }
+                    },
+                    undefined,  // onProgress
+                    undefined,  // database
+                    false,      // useArrayBuffer (snippet response is JSON text)
+                    function (request, exception) {
+                        const status = request ? (request.status + " " + request.statusText) : "no response";
+                        console.error("Failed to load playground snippet " + test.playgroundId + " after retries: " + status);
+                        if (exception) {
+                            console.error(exception);
+                        }
+                        failTest(done);
                     }
-                }, false);
-                xmlHttp.onerror = function () {
-                    console.error("Network error during test load.");
-                    onError();
-                }
-                xmlHttp.open("GET", snippetUrl + test.playgroundId.replace(/#/g, "/"));
-                xmlHttp.send();
+                );
             }
             loadPG();
         } else {


### PR DESCRIPTION
## Context

Two transient-CDN failures observed in CI:

1. **Snippet fetch**: `Win32_x64_D3D11 / build` intermittently fails with 5× `SyntaxError: JSON.parse Error: Unexpected input at position:0`, when the snippet service returns 5xx/429/empty body and `loadPG()`'s hand-rolled XHR parses the response without checking `xmlHttp.status`.

2. **Asset fetch**: `EXR Loader` visualization test flaked once on `Win32_x64_V8_D3D11` (run 25930475253) with a ~110k-pixel diff. The artifact is Babylon's `EngineStore.FallbackTexture` checkerboard, substituted because `green-door.exr` fetch returned an error. Babylon's `FileToolsOptions.DefaultRetryStrategy` only retries on `request.status === 0`, so HTTP 5xx/429 → no retry → fallback.

## Approach

Two changes in `Apps/Playground/Scripts/validation_native.js`:

1. **Replace the hand-rolled XHR + retry in `loadPG()` with `BABYLON.Tools.LoadFile()`.** Reuses the upstream `retryLoop` in `FileTools.LoadFile`; no more custom retry state.

2. **Broaden `BABYLON.Tools.DefaultRetryStrategy` for the test framework** to also retry `429` and `5xx`, not just `status === 0`. Up to 5 attempts, `500 * 2^N` backoff. One-time global mutation; doesn't affect non-test BabylonNative apps.

The single strategy override covers snippet fetches (`loadPG`), reference-image fetches (`runTest`), and every asset URL loaded from inside a playground's `createScene()` body — closing the EXR Loader flake surface without per-call changes.

[Created by Copilot on behalf of @bghgary]
