### PR TITLE
NativeEngine: accept R8 and RG32F in raw texture upload path.

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -254,12 +254,14 @@ namespace Babylon
         bimg::ImageContainer* PrepareImage(bx::AllocatorI& allocator, bimg::ImageContainer* image, bool invertY, bool srgb, bool generateMips)
         {
             assert(
+                image->m_format == bimg::TextureFormat::R8 ||
                 image->m_format == bimg::TextureFormat::R16 ||
                 image->m_format == bimg::TextureFormat::RGB8 ||
                 image->m_format == bimg::TextureFormat::RGBA8 ||
                 image->m_format == bimg::TextureFormat::RGBA16 ||
                 image->m_format == bimg::TextureFormat::RGBA16F ||
                 image->m_format == bimg::TextureFormat::RG16F ||
+                image->m_format == bimg::TextureFormat::RG32F ||
                 image->m_format == bimg::TextureFormat::RGBA32F ||
                 image->m_format == bimg::TextureFormat::RGBA32U);
 


### PR DESCRIPTION
## What

Adds `R8` and `RG32F` to the small format whitelist asserted by `PrepareImage` in `Plugins/NativeEngine/Source/NativeEngine.cpp`. Both formats are already supported by `bimg` and `bgfx`; the gap was only in BN's adapter assert.

```diff
             assert(
+                image->m_format == bimg::TextureFormat::R8 ||
                 image->m_format == bimg::TextureFormat::R16 ||
                 image->m_format == bimg::TextureFormat::RGB8 ||
                 image->m_format == bimg::TextureFormat::RGBA8 ||
                 image->m_format == bimg::TextureFormat::RGBA16 ||
                 image->m_format == bimg::TextureFormat::RGBA16F ||
                 image->m_format == bimg::TextureFormat::RG16F ||
+                image->m_format == bimg::TextureFormat::RG32F ||
                 image->m_format == bimg::TextureFormat::RGBA32F ||
                 image->m_format == bimg::TextureFormat::RGBA32U);
```

## Why

`NativeEngine::LoadRawTexture` (the binding for Babylon.js `engine.createRawTexture(...)`) forwards the JS-supplied texture format to `PrepareImage`, which had a hard-coded whitelist of 8 formats. Two formats that Babylon.js requests in normal usage fall outside that list and cause SIGABRT on the assert:

| Format | Where it shows up |
|---|---|
| `R8` | `createRawTexture` for single-channel byte data (texture updates) |
| `RG32F` | GPU particle internal state textures (262 elements * 8 bytes) |

`RG16F` was already on the list - the 32-bit twin had simply been overlooked.

## How verified

Local Win32 V8 D3D11 Debug build, headless Playground runner, 8 currently-excluded tests known to hit this assert:

| idx | title | before | after |
|----:|---|---|---|
| 336 | Test updateTextureData | SIGABRT (R8) | runs (hits separate JS issue, not in scope) |
| 652 | Particles - Billboard Y | SIGABRT (RG32F) | runs (pixel-diff fail) |
| 682 | GPU Particles - Change - Size | SIGABRT (RG32F) | runs (pixel-diff fail) |
| 684 | GPU Particles - Change - Speed | SIGABRT (RG32F) | runs (pixel-diff fail) |
| 685 | GPU Particles - Change - Speed Limit | SIGABRT (RG32F) | runs (pixel-diff fail) |
| 686 | GPU Particles - Change - Angular Speed | SIGABRT (RG32F) | runs (pixel-diff fail) |
| 687 | GPU Particles - Change - Drag | SIGABRT (RG32F) | runs (pixel-diff fail) |
| 688 | GPU Particles - Change - Size Range | SIGABRT (RG32F) | runs (pixel-diff fail) |

Each failing call was confirmed by a temporary `fprintf` placed in `LoadRawTexture` (build, capture, revert).

## Scope

- This PR only fixes the assert. The 8 tests still fail and remain excluded - whether they should be re-enabled is a separate question, since they fail pixel-diff (and idx 336 surfaces an unrelated JS issue) after the assert is removed.
- For these tests `mips=false` and `srgb=false`, so the mipmap-generation and SRGB-conversion branches in `PrepareImage` don't need format-aware extensions for this fix. If a future caller requests mips on `R8` / `RG32F`, the existing mip branch will need analogous handling.
- `FlipImage` is format-agnostic (it computes rowPitch from total-size / height), so `invertY` is safe for the new formats.

## Risk

Very low. Two enum values added to a disjunction. No code path that previously rejected these formats now accepts data that bgfx would refuse to ingest - the underlying renderer already advertises both formats.
