### PR TITLE
ModuleLoadTest: drop dbghelp.dll from expected Win32 boot modules

### DIFF
--- a/Apps/ModuleLoadTest/Source/App.Win32.cpp
+++ b/Apps/ModuleLoadTest/Source/App.Win32.cpp
@@ -67,9 +67,6 @@ namespace ModuleLoadTest
             "d3d12core.dll",
             "d3d12sdklayers.dll",
             "d3dscache.dll",
-            // TODO: bgfx loads dbghelp.dll at boot (callstack/crash helper). Drop this
-            // entry once bgfx stops pulling it in.
-            "dbghelp.dll",
             "dcomp.dll",
             "devobj.dll",
             "directxdatabasehelper.dll",


### PR DESCRIPTION
## Context

bx commit `3ea49f9` ("Lazy load debug help once it's needed to resolve callstack", #383) moved the `dlopen("dbghelp.dll")` call out of the file-scope static's constructor into a lazy `init()` invoked on the first `writeCallstack` call.

That commit is in the bx submodule of BabylonJS/bgfx.cmake `e5f3f31`, which is BabylonNative's current `GIT_TAG` pin (root `CMakeLists.txt`). So a fresh BN build no longer pulls `dbghelp.dll` into the process on startup.

## Change

Drop `dbghelp.dll` from `GetExpectedBootModules()` in `Apps/ModuleLoadTest/Source/App.Win32.cpp`, plus the TODO comment that flagged it as bgfx-blocked. Resolves @bkaradzic-microsoft's review comment on #1666 (L70).

## Verification

Local RelWithDebInfo build + run (Win11 x64, D3D11 + Chakra):

- Reconfigured CMake (deleted stale `_deps/bgfx.cmake-src` to force re-fetch at the pinned SHA).
- Built `ModuleLoadTest` RelWithDebInfo.
- Ran the test; verdict `PASS`. `dbghelp.dll` is NOT in the boot delta. (`imagehlp.dll` still is -- different DLL, image loader.)

[Created by Copilot on behalf of @bghgary]