### PR TITLE
Re-enable GUI Near Menu test on D3D11 (idx 177)

### DIFF
--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -1145,8 +1145,8 @@
             "title": "GUI Near Menu",
             "playgroundId": "#2YZFA0#302",
             "renderCount": 60,
-            "excludeFromAutomaticTesting": true,
-            "reason": "Test crashes on Win32 V8 D3D11 / hangs on OpenGL",
+            "excludedGraphicsApis": ["OpenGL"],
+            "reason": "OpenGL: BGFX FATAL shader compile error in GUI fragment shader ('=' : cannot convert from 'highp float' to 'bool'). Re-enabled on D3D11 post BabylonJS/BabylonNative#1695 (original 'V8 D3D11 crash' no longer reproduces under Chakra; original 'hangs on OpenGL' is now this clean shader-compile failure surfaced by the BabylonJS/BabylonNative#1688 BgfxCallback).",
             "referenceImage": "guiNearMenu.png"
         },
         {


### PR DESCRIPTION
## Summary

Re-enables `validation_native.js` test idx 177 `GUI Near Menu` (`#2YZFA0#302`) on D3D11 and adds an OpenGL-only exclusion for the residual fragment-shader-compile crash.

## What changed

The original exclusion reason was:

> "Test crashes on Win32 V8 D3D11 / hangs on OpenGL"

Both halves of that statement are now stale:

1. **Win32 D3D11 (Chakra Release x64)**: the test now runs to completion with **783 px diff** (well under the 2.5% `errorRatio` threshold) and validates. The original `Win32 V8 D3D11` `ACCESS_VIOLATION` was specific to the V8 cascade and is no longer reproducible on Chakra. Other V8-cascade victims in `config.json` keep their own exclusion reasons.
2. **OpenGL** (Windows ANGLE + Linux native OpenGL): the test no longer "hangs". With the console hook landed in #1688 and the bgfx FATAL routed through `BgfxCallback`, the previous silent hang is now a clean shader-compile failure:

   ```
   BGFX FATAL 0x00000001: Failed to compile shader.
   ERROR: 0:266: '=' : cannot convert from 'highp float' to 'bool'
   ERROR: 0:267: '=' : cannot convert from 'highp float' to 'bool'
   ERROR: 0:389: '=' : cannot convert from 'highp float' to 'bool'
   ```

   This is the same family of GLSL implicit-precision-conversion bug already affecting idx 293/296/299 (`mediump float` -> `int` in the PrePassRenderer fragment shader); here the conversion is `highp float` -> `bool` in a GUI fragment shader. Tracked separately for the OpenGL backend; for now the test is gated with `excludedGraphicsApis: ["OpenGL"]`.

## Verification

```powershell
# D3D11 (Chakra) sweep covering idx 177:
.\Playground.exe --headless --test-index=150-200 app:///Scripts/validation_native.js
# -> ran=2 passed=2 failed=0 skipped=49, exit 0
# -> "Test 'GUI Near Menu' validated" with 783 px diff

# Windows ANGLE / OpenGL sweep covering idx 177:
.\Playground.exe --headless --test-index=150-200 app:///Scripts/validation_native.js  (OpenGLWindowsDevOnly build)
# -> ran=1 passed=1 failed=0 skipped=50, exit 0
# -> "Skipping 'GUI Near Menu' -- excludedGraphicsApis: OpenGL"
```

## Notes

- This is a config-only change (one entry in `Apps/Playground/Scripts/config.json`); the binary build is unaffected.
- The `excludedGraphicsApis` mechanism added in #1695 is reused here to keep the test running on every backend where it works while gating it on backends where it doesn't.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
