### PR TITLE
Snippet rewrite: handle single-quoted texture and scenes paths in validation_native.js

### DIFF
--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -326,9 +326,12 @@
 
                             code = code
                                 .replace(/"\/textures\//g, '"' + pgRoot + "/textures/")
+                                .replace(/'\/textures\//g, "'" + pgRoot + "/textures/")
                                 .replace(/"textures\//g, '"' + pgRoot + "/textures/")
+                                .replace(/'textures\//g, "'" + pgRoot + "/textures/")
                                 .replace(/\/scenes\//g, pgRoot + "/scenes/")
                                 .replace(/"scenes\//g, '"' + pgRoot + "/scenes/")
+                                .replace(/'scenes\//g, "'" + pgRoot + "/scenes/")
                                 .replace(/"\.\.\/\.\.https/g, '"' + "https")
                                 .replace("http://", "https://");
 


### PR DESCRIPTION
The URL rewrite rules in `Apps/Playground/Scripts/validation_native.js` only matched double-quoted texture and scenes paths in playground snippet code. Snippets that use single quotes -- e.g. `BABYLON.Texture('/textures/albedo.png')` -- slipped past the rewrite and hit raw absolute URLs at load time, producing `Error: Unknown error opening URL` and a hung snippet-mode retry loop.

This adds single-quote variants for the existing `/textures/`, `textures/`, and `scenes/` rules so both quote styles get rewritten to the absolute `https://playground.babylonjs.com/...` form, matching the existing behavior for double-quoted paths. No behavior change for any snippet that already worked.

Verified locally on Win32 D3D11 Release that the snippet which originally hit this error now loads its texture asset and proceeds to the next stage of evaluation (separate, unrelated failure path -- not addressed here).