### PR TITLE
Playground: bundle babylonjs-addons

### DIFF
--- a/Apps/Playground/CMakeLists.txt
+++ b/Apps/Playground/CMakeLists.txt
@@ -1,6 +1,7 @@
 FILE(GLOB REFERENCE_IMAGES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "ReferenceImages/*")
 
 set(BABYLON_SCRIPTS
+    "../node_modules/babylonjs-addons/babylonjs.addons.js"
     "../node_modules/babylonjs-loaders/babylonjs.loaders.js"
     "../node_modules/babylonjs/babylon.max.js"
     "../node_modules/babylonjs-materials/babylonjs.materials.js"

--- a/Apps/Playground/Shared/AppContext.cpp
+++ b/Apps/Playground/Shared/AppContext.cpp
@@ -223,6 +223,7 @@ AppContext::AppContext(
     // Commenting out recast.js for now because v8jsi is incompatible with asm.js.
     // m_scriptLoader->LoadScript("app:///Scripts/recast.js");
     m_scriptLoader->LoadScript("app:///Scripts/babylon.max.js");
+    m_scriptLoader->LoadScript("app:///Scripts/babylonjs.addons.js");
     m_scriptLoader->LoadScript("app:///Scripts/babylonjs.loaders.js");
     m_scriptLoader->LoadScript("app:///Scripts/babylonjs.materials.js");
     m_scriptLoader->LoadScript("app:///Scripts/babylon.gui.js");

--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -12,6 +12,7 @@
       ],
       "dependencies": {
         "babylonjs": "^9.3.4",
+        "babylonjs-addons": "^9.3.4",
         "babylonjs-gltf2interface": "^9.3.4",
         "babylonjs-gui": "^9.3.4",
         "babylonjs-loaders": "^9.3.4",
@@ -2600,6 +2601,15 @@
       "integrity": "sha512-zMH8r0l/il9PJhy2+uS+/EyeLBy/ElZg0lKLj2d+ZrUarOanjMISaACw0HUx7C1EgYoXUFSMQLYcpXguleh8GA==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/babylonjs-addons": {
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/babylonjs-addons/-/babylonjs-addons-9.9.1.tgz",
+      "integrity": "sha512-Hi9QZqeanqG+4VAAmJmHJh7JKf1bc/Y5Ml+wuv+W+3f/dKltZpy/pii/QN4vhYRyrU0n+S8OJc+kVeaUUFjHEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "babylonjs": "9.9.1"
+      }
     },
     "node_modules/babylonjs-gltf2interface": {
       "version": "9.9.1",

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "babylonjs": "^9.3.4",
+    "babylonjs-addons": "^9.3.4",
     "babylonjs-gltf2interface": "^9.3.4",
     "babylonjs-gui": "^9.3.4",
     "babylonjs-loaders": "^9.3.4",


### PR DESCRIPTION
Bundles `babylonjs-addons` in the Playground app.

Babylon Native ships `babylonjs`, `babylonjs-gui`, `babylonjs-loaders`,
`babylonjs-materials`, and `babylonjs-serializers` alongside its Playground app
but not `babylonjs-addons`. The addons package hosts newer Babylon.js components
(Atmosphere, `LiquidRenderingSceneComponent`, ...) under the global `ADDONS`
namespace, so any Playground snippet that uses them throws
`ReferenceError: 'ADDONS' is not defined`.

**Change (4 files):**
- `Apps/package.json` / `Apps/package-lock.json` — add `babylonjs-addons`
  (`^9.3.4`, resolves/dedupes to 9.9.1, matching the other bundled Babylon
  scripts; single `babylonjs` version in `node_modules`).
- `Apps/Playground/CMakeLists.txt` — ship `babylonjs.addons.js` as a Playground
  resource via `BABYLON_SCRIPTS`.
- `Apps/Playground/Shared/AppContext.cpp` — load it right after `babylon.max.js`
  so addons init sees a fully constructed `BABYLON` global.

**Scope:** this PR is addons-bundling only. The ES2019/ES2022 Chakra
compatibility shims (`ErrorCause` / `StringTrim`, in either JS or C++ form) that
were previously part of this branch are **dropped** — per review, those Chakra
parse/runtime gaps should be handled separately (run Playground validation on an
ES-compliant engine such as `Win32_x64_V8_D3D11`, or bundle `babel-standalone`;
degraded Node-API error surfacing on Chakra to be fixed in JsRuntimeHost).

**Verified (Win32/Chakra):** rebased onto current master, Playground builds and
links cleanly, and the Atmosphere snippets no longer throw
`'ADDONS' is not defined` (addons loads; they now hit the separate Chakra
parse / texture-layer gaps, tracked elsewhere).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
