### PR TITLE
Fix ExternalTexture_OpenGL throw-stubs to avoid MSVC C4702 under /WX

### DIFF
--- a/Plugins/ExternalTexture/CMakeLists.txt
+++ b/Plugins/ExternalTexture/CMakeLists.txt
@@ -6,9 +6,6 @@ set(SOURCES
 
 add_library(ExternalTexture ${SOURCES})
 warnings_as_errors(ExternalTexture)
-if(GRAPHICS_API STREQUAL "OpenGL" AND MSVC)
-    target_compile_options(ExternalTexture PRIVATE /wd4702)
-endif()
 
 target_include_directories(ExternalTexture
     PUBLIC "Include")

--- a/Plugins/ExternalTexture/Source/ExternalTexture_OpenGL.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_OpenGL.cpp
@@ -11,26 +11,8 @@
 
 namespace Babylon::Plugins
 {
-    // ExternalTexture is not implemented on the OpenGL backend. The Impl
-    // stubs throw "not implemented" so callers get an unambiguous diagnostic
-    // matching every other backend's unimplemented path. The shared
-    // dispatchers in ExternalTexture_Shared.h (included below) call these
-    // stubs unconditionally, so MSVC's flow analysis would otherwise flag
-    // the dispatcher's post-call code as unreachable (C4702) under /WX. The
-    // pragma block around the include suppresses C4702 only for the
-    // dispatcher code instantiated in this translation unit; any other code
-    // in this file is still subject to /WX C4702 enforcement.
-    //
-    // Alternatives considered:
-    //   - [[noreturn]] on the stubs: MSVC propagates "never returns" through
-    //     the shared dispatcher, which flags *more* post-call statements as
-    //     unreachable. Tried and rejected (it made the warning worse).
-    //   - TU-wide /wd4702 via target_compile_options: silences any future
-    //     legitimate C4702 elsewhere in the same TU, defeating /WX.
-    //   - Replacing the throws with inert return-default stubs: changes
-    //     product behaviour (callers would silently receive a null texture
-    //     instead of a clear "not implemented" error) to work around a
-    //     compiler warning. Rejected on principle.
+    // Suppress C4702 for the shared dispatcher - Impl stubs always throw,
+    // making the dispatcher's post-call code unreachable.
     class ExternalTexture::Impl final : public ImplBase
     {
     public:

--- a/Plugins/ExternalTexture/Source/ExternalTexture_OpenGL.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_OpenGL.cpp
@@ -11,6 +11,13 @@
 
 namespace Babylon::Plugins
 {
+    // The OpenGL backend does not implement ExternalTexture. The Impl methods
+    // below return default-constructed values rather than throwing so that the
+    // shared dispatchers in ExternalTexture_Shared.h (which is included after
+    // this class definition) don't produce unreachable-code paths that MSVC
+    // flags as C4702 under /WX. Any caller that actually invokes an
+    // ExternalTexture API on OpenGL will receive an inert/null texture and
+    // get a graphics-level error downstream.
     class ExternalTexture::Impl final : public ImplBase
     {
     public:
@@ -20,18 +27,16 @@ namespace Babylon::Plugins
 
         Graphics::TextureT Get() const
         {
-            throw std::runtime_error{"not implemented"};
+            return Graphics::TextureT{};
         }
 
     private:
         static void GetInfo(Graphics::TextureT, std::optional<Graphics::TextureFormatT>, Info&)
         {
-            throw std::runtime_error{"not implemented"};
         }
 
         void Set(Graphics::TextureT)
         {
-            throw std::runtime_error{"not implemented"};
         }
     };
 }

--- a/Plugins/ExternalTexture/Source/ExternalTexture_OpenGL.cpp
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_OpenGL.cpp
@@ -11,13 +11,26 @@
 
 namespace Babylon::Plugins
 {
-    // The OpenGL backend does not implement ExternalTexture. The Impl methods
-    // below return default-constructed values rather than throwing so that the
-    // shared dispatchers in ExternalTexture_Shared.h (which is included after
-    // this class definition) don't produce unreachable-code paths that MSVC
-    // flags as C4702 under /WX. Any caller that actually invokes an
-    // ExternalTexture API on OpenGL will receive an inert/null texture and
-    // get a graphics-level error downstream.
+    // ExternalTexture is not implemented on the OpenGL backend. The Impl
+    // stubs throw "not implemented" so callers get an unambiguous diagnostic
+    // matching every other backend's unimplemented path. The shared
+    // dispatchers in ExternalTexture_Shared.h (included below) call these
+    // stubs unconditionally, so MSVC's flow analysis would otherwise flag
+    // the dispatcher's post-call code as unreachable (C4702) under /WX. The
+    // pragma block around the include suppresses C4702 only for the
+    // dispatcher code instantiated in this translation unit; any other code
+    // in this file is still subject to /WX C4702 enforcement.
+    //
+    // Alternatives considered:
+    //   - [[noreturn]] on the stubs: MSVC propagates "never returns" through
+    //     the shared dispatcher, which flags *more* post-call statements as
+    //     unreachable. Tried and rejected (it made the warning worse).
+    //   - TU-wide /wd4702 via target_compile_options: silences any future
+    //     legitimate C4702 elsewhere in the same TU, defeating /WX.
+    //   - Replacing the throws with inert return-default stubs: changes
+    //     product behaviour (callers would silently receive a null texture
+    //     instead of a clear "not implemented" error) to work around a
+    //     compiler warning. Rejected on principle.
     class ExternalTexture::Impl final : public ImplBase
     {
     public:
@@ -27,18 +40,29 @@ namespace Babylon::Plugins
 
         Graphics::TextureT Get() const
         {
-            return Graphics::TextureT{};
+            throw std::runtime_error{"not implemented"};
         }
 
     private:
         static void GetInfo(Graphics::TextureT, std::optional<Graphics::TextureFormatT>, Info&)
         {
+            throw std::runtime_error{"not implemented"};
         }
 
         void Set(Graphics::TextureT)
         {
+            throw std::runtime_error{"not implemented"};
         }
     };
 }
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4702) // unreachable code (Impl stubs always throw)
+#endif
+
 #include "ExternalTexture_Shared.h"
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif


### PR DESCRIPTION
Fixes MSVC C4702 (unreachable code) under `/WX` in `Plugins/ExternalTexture/Source/ExternalTexture_OpenGL.cpp` so the OpenGL TU builds cleanly without the project-wide `/wd4702` workaround.

## What changed

`Plugins/ExternalTexture/Source/ExternalTexture_OpenGL.cpp` keeps the unimplemented `Impl` stubs as `throw std::runtime_error{"not implemented"}` (so callers get an unambiguous diagnostic matching every other backend's unimplemented path) and wraps the `#include "ExternalTexture_Shared.h"` line in `#pragma warning(push)/(disable: 4702)/(pop)`. The shared dispatchers instantiated by that include unconditionally call the stubs, so MSVC's flow analysis flags the dispatcher's post-call code as unreachable; the pragma suppresses C4702 only for the dispatcher code instantiated in this translation unit. Any other code in this file is still subject to `/WX` C4702 enforcement.

`Plugins/ExternalTexture/CMakeLists.txt` - drop the `/wd4702` target compile option, which previously silenced C4702 across the whole target.

## Alternatives considered

- **`[[noreturn]]` on the stubs**: MSVC propagates "never returns" through the shared dispatcher, which flags *more* post-call statements as unreachable. Tried and rejected (it made the warning worse).
- **TU-wide `/wd4702` via `target_compile_options`**: silences any future legitimate C4702 elsewhere in the same TU, defeating `/WX`. The current localized `#pragma warning(push/pop)` block keeps the rest of the TU under `/WX` enforcement.
- **Replacing the throws with inert return-default stubs**: changes product behaviour (callers would silently receive a null texture instead of a clear "not implemented" error) to work around a compiler warning. Rejected on principle.

## Verified

Clean under Debug + Release + RelWithDebInfo on OpenGL (`win32-gl`, `GRAPHICS_API=OpenGLWindowsDevOnly`) and D3D11 (`win32`).

---

## Landing context

This PR is one of **7 splits** from the proven CI-green combined preview in **draft PR #1702** (see [#1702](https://github.com/BabylonJS/BabylonNative/pull/1702) for the full intended end-state and verified CI run [26044922430](https://github.com/BabylonJS/BabylonNative/actions/runs/26044922430)).

> Note: the original split included an 8th PR (#1709, ES2020+ -> ES2019 syntax-repair polyfill for Chakra). It was closed in favour of investigating `@babel/standalone` properly (#1711).

### Recommended landing order

**Tier 1 - parallel-reviewable, no source conflicts:**
1. #1703 - ExternalTexture C4702 build fix
2. #1704 - config.json `reason` rewrites (5 entries)
3. #1705 - config.json `reason` rewrites (17 entries)

**Tier 2 - sequential, each touches `Apps/Playground/CMakeLists.txt` SCRIPTS list + `Apps/Playground/Shared/AppContext.cpp` LoadScript order; rebase the next branch after the previous merges:**

4. #1706 - File/Blob/FileReader polyfill (largest test impact: 19 re-enables)
5. #1707 - fetch polyfill
6. #1708 - DOM globals + native AbortController + Android CMake link
7. #1710 - Cubemap auto-expand polyfill (loaded after babylon.max.js)

### Reference policy reminder

Reference PNGs across all 7 PRs come from Babylon.js; never re-baked by BN. Combined diff: **0 PNGs**.