### PR TITLE
Fix Area Lights PBR crash: split sampler2D function parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ FetchContent_Declare(metal-cpp
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(SPIRV-Cross
     GIT_REPOSITORY https://github.com/BabylonJS/SPIRV-Cross.git
-    GIT_TAG 866e5edcc3407997a3ed62f3edf492f91bcb2629
+    GIT_TAG a512817ddbcd879a3929aef7d1d762871bdf8635
     EXCLUDE_FROM_ALL)
 
 # --------------------------------------------------

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerDXBC.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerDXBC.cpp
@@ -107,6 +107,7 @@ namespace Babylon::Plugins
         std::map<std::string, std::string> vertexAttributeRenaming = {};
         ShaderCompilerTraversers::AssignLocationsAndNamesToVertexVaryingsD3D(program, ids, vertexAttributeRenaming);
         ShaderCompilerTraversers::SplitSamplersIntoSamplersAndTextures(program, ids);
+        ShaderCompilerTraversers::SplitSamplerFunctionParameters(program, ids);
         ShaderCompilerTraversers::InvertYDerivativeOperands(program);
 
         // clang-format off

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerDXIL.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerDXIL.cpp
@@ -183,6 +183,7 @@ namespace Babylon::Plugins
         std::map<std::string, std::string> vertexAttributeRenaming = {};
         ShaderCompilerTraversers::AssignLocationsAndNamesToVertexVaryingsD3D(program, ids, vertexAttributeRenaming);
         ShaderCompilerTraversers::SplitSamplersIntoSamplersAndTextures(program, ids);
+        ShaderCompilerTraversers::SplitSamplerFunctionParameters(program, ids);
         ShaderCompilerTraversers::InvertYDerivativeOperands(program);
 
         // clang-format off

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerMetal.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerMetal.cpp
@@ -108,6 +108,7 @@ namespace Babylon::Plugins
         std::map<std::string, std::string> vertexAttributeRenaming = {};
         ShaderCompilerTraversers::AssignLocationsAndNamesToVertexVaryingsMetal(program, ids, vertexAttributeRenaming);
         ShaderCompilerTraversers::SplitSamplersIntoSamplersAndTextures(program, ids);
+        ShaderCompilerTraversers::SplitSamplerFunctionParameters(program, ids);
         ShaderCompilerTraversers::InvertYDerivativeOperands(program);
 
         std::string vertexMSL(vertexSource.data(), vertexSource.size());

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
@@ -915,6 +915,395 @@ namespace Babylon::ShaderCompilerTraversers
             std::vector<std::pair<TIntermSymbol*, TIntermNode*>> m_symbolsToParents{};
         };
 
+        /// <summary>
+        /// Split combined sampler parameters of user-defined functions into separate
+        /// texture and sampler parameters. See `SplitSamplerFunctionParameters` in the
+        /// header for the full rationale. This pass must run AFTER `SamplerSplitterTraverser`
+        /// so that uniform sampler call-site arguments have already been rewritten into
+        /// `EOpConstructTextureSampler(t, s)` aggregates whose operands we can unpack at
+        /// call sites.
+        /// </summary>
+        class SamplerFunctionParameterSplitterTraverser final
+        {
+        public:
+            static void Traverse(TProgram& program, IdGenerator& ids)
+            {
+                SamplerFunctionParameterSplitterTraverser pass{};
+                pass.Traverse(program.getIntermediate(EShLangVertex), ids);
+                pass.Traverse(program.getIntermediate(EShLangFragment), ids);
+            }
+
+        private:
+            struct RewrittenFunction
+            {
+                std::string NewMangledName;
+                std::vector<int> OriginalSamplerParamIndices;
+            };
+
+            // Per-stage scope: the call-site rewriter must only see functions rewritten
+            // for the current stage (vertex/fragment), since each stage has its own
+            // intermediate and ID space.
+            std::map<std::string, RewrittenFunction> m_rewrittenFunctions{};
+
+            void Traverse(TIntermediate* intermediate, IdGenerator& ids)
+            {
+                if (intermediate == nullptr)
+                {
+                    return;
+                }
+
+                auto* root = intermediate->getTreeRoot()->getAsAggregate();
+                if (root == nullptr)
+                {
+                    return;
+                }
+
+                m_rewrittenFunctions.clear();
+
+                // Phase 1: rewrite function declarations that have sampler parameters.
+                for (auto* node : root->getSequence())
+                {
+                    auto* function = node->getAsAggregate();
+                    if (function != nullptr && function->getOp() == EOpFunction)
+                    {
+                        RewriteFunctionDefinition(intermediate, ids, function);
+                    }
+                }
+
+                if (m_rewrittenFunctions.empty())
+                {
+                    return;
+                }
+
+                // Phase 2: rewrite call sites in every function body to match the new
+                // parameter lists.
+                CallSiteRewriter callRewriter{m_rewrittenFunctions};
+                for (auto* node : root->getSequence())
+                {
+                    auto* function = node->getAsAggregate();
+                    if (function != nullptr && function->getOp() == EOpFunction)
+                    {
+                        function->traverse(&callRewriter);
+                    }
+                }
+            }
+
+            void RewriteFunctionDefinition(TIntermediate* intermediate, IdGenerator& ids, TIntermAggregate* function)
+            {
+                auto& functionSequence = function->getSequence();
+                if (functionSequence.empty())
+                {
+                    return;
+                }
+
+                auto* paramsAggregate = functionSequence[0]->getAsAggregate();
+                if (paramsAggregate == nullptr || paramsAggregate->getOp() != EOpParameters)
+                {
+                    return;
+                }
+
+                // Find positions of combined-sampler parameters in the original parameter list.
+                std::vector<int> originalSamplerParamIndices{};
+                auto& params = paramsAggregate->getSequence();
+                for (int i = 0; i < gsl::narrow_cast<int>(params.size()); ++i)
+                {
+                    auto* paramSymbol = params[i]->getAsSymbolNode();
+                    if (paramSymbol != nullptr && IsCombinedSamplerType(paramSymbol->getType()))
+                    {
+                        originalSamplerParamIndices.push_back(i);
+                    }
+                }
+
+                if (originalSamplerParamIndices.empty())
+                {
+                    return;
+                }
+
+                const std::string oldMangledName{function->getName().c_str()};
+
+                // For each sampler parameter, allocate a texture symbol and a sampler symbol
+                // and an `EOpConstructTextureSampler(texture, sampler)` aggregate that takes
+                // their place in the function body. Walk right-to-left so that earlier indices
+                // remain valid as we expand the parameter list in place.
+                std::map<long long, TIntermAggregate*> originalParamIdToConstruction{};
+                for (auto it = originalSamplerParamIndices.rbegin(); it != originalSamplerParamIndices.rend(); ++it)
+                {
+                    const int idx = *it;
+                    auto* originalParam = params[idx]->getAsSymbolNode();
+                    const TType& originalType = originalParam->getType();
+                    const long long originalId = originalParam->getId();
+                    const std::string originalName{originalParam->getName().c_str()};
+
+                    TIntermSymbol* newTextureSymbol;
+                    {
+                        TPublicType publicType{};
+                        publicType.qualifier.clearLayout();
+                        publicType.basicType = originalType.getBasicType();
+                        publicType.qualifier = originalType.getQualifier();
+                        publicType.sampler = originalType.getSampler();
+                        publicType.sampler.combined = false;
+
+                        TType newType{publicType};
+                        const std::string newName = originalName + "Texture";
+                        newTextureSymbol = intermediate->addSymbol(TIntermSymbol{ids.Next(), newName.c_str(), newType});
+                    }
+
+                    TIntermSymbol* newSamplerSymbol;
+                    {
+                        TPublicType publicType{};
+                        publicType.qualifier.clearLayout();
+                        publicType.basicType = originalType.getBasicType();
+                        publicType.qualifier = originalType.getQualifier();
+                        publicType.sampler.sampler = true;
+
+                        TType newType{publicType};
+                        newSamplerSymbol = intermediate->addSymbol(TIntermSymbol{ids.Next(), originalName.c_str(), newType});
+                    }
+
+                    // Build the `EOpConstructTextureSampler(texture, sampler)` aggregate that
+                    // will replace every reference to the original sampler parameter inside
+                    // the function body. Mirror the type construction performed by
+                    // SamplerSplitterTraverser for uniform samplers.
+                    auto* construction = intermediate->growAggregate(newTextureSymbol, newSamplerSymbol);
+                    construction->setOperator(EOpConstructTextureSampler);
+                    {
+                        TPublicType publicType{};
+                        publicType.basicType = originalType.getBasicType();
+                        publicType.qualifier.clearLayout();
+                        publicType.qualifier.storage = EvqTemporary;
+                        publicType.sampler = originalType.getSampler();
+                        publicType.sampler.combined = true;
+                        construction->setType(TType{publicType});
+                    }
+
+                    originalParamIdToConstruction[originalId] = construction;
+
+                    // Replace params[idx] with the new texture symbol, then insert the new
+                    // sampler symbol immediately after it. This expands one sampler parameter
+                    // into two parameters at the original position.
+                    RemoveAllTreeNodes(params[idx]);
+                    params[idx] = newTextureSymbol;
+                    params.insert(params.begin() + idx + 1, newSamplerSymbol);
+                }
+
+                // Rewrite the function body: every reference to an original sampler parameter
+                // becomes a reference to its `EOpConstructTextureSampler(t, s)` aggregate.
+                if (functionSequence.size() >= 2)
+                {
+                    BodySamplerParamReferenceRewriter bodyRewriter{originalParamIdToConstruction};
+                    functionSequence[1]->traverse(&bodyRewriter);
+                    bodyRewriter.ApplyReplacements();
+                }
+
+                // Update the function's mangled name to reflect the new parameter list and
+                // record the rewrite so Phase 2 can update matching call sites.
+                const std::string newMangledName = ComputeMangledName(oldMangledName, paramsAggregate);
+                function->setName(newMangledName.c_str());
+
+                m_rewrittenFunctions[oldMangledName] = RewrittenFunction{
+                    std::move(newMangledName),
+                    std::move(originalSamplerParamIndices),
+                };
+            }
+
+            static bool IsCombinedSamplerType(const TType& type)
+            {
+                return type.getBasicType() == EbtSampler && type.getSampler().isCombined();
+            }
+
+            static std::string ComputeMangledName(const std::string& oldMangledName, TIntermAggregate* paramsAggregate)
+            {
+                // glslang mangles function names as `funcName(typeMangle1;typeMangle2;...`.
+                // Preserve the function-name prefix from the original mangled name and
+                // re-mangle each parameter from its updated TType.
+                const auto parenPos = oldMangledName.find('(');
+                if (parenPos == std::string::npos)
+                {
+                    return oldMangledName;
+                }
+
+                TString mangled{oldMangledName.substr(0, parenPos + 1).c_str()};
+                for (auto* paramNode : paramsAggregate->getSequence())
+                {
+                    auto* paramSymbol = paramNode->getAsSymbolNode();
+                    if (paramSymbol != nullptr)
+                    {
+                        paramSymbol->getType().appendMangledName(mangled);
+                    }
+                }
+                return mangled.c_str();
+            }
+
+            /// Collects references to specific symbol IDs inside a function body and replaces
+            /// them in their parents with the corresponding `EOpConstructTextureSampler`
+            /// aggregate. Mirrors the parent-node-type dispatch from `MakeReplacements`.
+            class BodySamplerParamReferenceRewriter final : public TIntermTraverser
+            {
+            public:
+                explicit BodySamplerParamReferenceRewriter(std::map<long long, TIntermAggregate*>& idToConstruction)
+                    : m_idToConstruction{idToConstruction}
+                {
+                }
+
+                void visitSymbol(TIntermSymbol* symbol) override
+                {
+                    if (m_idToConstruction.find(symbol->getId()) != m_idToConstruction.end())
+                    {
+                        m_pendingReplacements.emplace_back(symbol, this->getParentNode());
+                    }
+                }
+
+                void ApplyReplacements()
+                {
+                    for (const auto& [symbol, parent] : m_pendingReplacements)
+                    {
+                        TIntermAggregate* replacement = m_idToConstruction.at(symbol->getId());
+                        ReplaceInParent(parent, symbol, replacement);
+                    }
+                }
+
+            private:
+                static void ReplaceInParent(TIntermNode* parent, TIntermSymbol* oldSymbol, TIntermAggregate* replacement)
+                {
+                    if (auto* aggregate = parent->getAsAggregate())
+                    {
+                        auto& sequence = aggregate->getSequence();
+                        for (size_t i = 0; i < sequence.size(); ++i)
+                        {
+                            if (sequence[i] == oldSymbol)
+                            {
+                                sequence[i] = replacement;
+                            }
+                        }
+                    }
+                    else if (auto* binary = parent->getAsBinaryNode())
+                    {
+                        if (binary->getLeft() == oldSymbol)
+                        {
+                            binary->setLeft(replacement);
+                        }
+                        else if (binary->getRight() == oldSymbol)
+                        {
+                            binary->setRight(replacement);
+                        }
+                    }
+                    else if (auto* unary = parent->getAsUnaryNode())
+                    {
+                        if (unary->getOperand() == oldSymbol)
+                        {
+                            unary->setOperand(replacement);
+                        }
+                    }
+                    else if (auto* selection = parent->getAsSelectionNode())
+                    {
+                        if (oldSymbol == selection->getCondition())
+                        {
+                            selection->setCondition(replacement);
+                        }
+                        else if (oldSymbol == selection->getTrueBlock())
+                        {
+                            selection->setTrueBlock(replacement);
+                        }
+                        else if (oldSymbol == selection->getFalseBlock())
+                        {
+                            selection->setFalseBlock(replacement);
+                        }
+                    }
+                    else
+                    {
+                        throw std::runtime_error{
+                            "SamplerFunctionParameterSplitter: unsupported parent node when rewriting body sampler reference"};
+                    }
+                }
+
+                std::map<long long, TIntermAggregate*>& m_idToConstruction;
+                std::vector<std::pair<TIntermSymbol*, TIntermNode*>> m_pendingReplacements{};
+            };
+
+            /// Walks function bodies looking for `EOpFunctionCall` nodes that call a
+            /// rewritten function. For each, unpacks the `EOpConstructTextureSampler(t, s)`
+            /// aggregate at each original sampler parameter position into two separate
+            /// arguments (the texture and the sampler), and updates the call's mangled name.
+            class CallSiteRewriter final : public TIntermTraverser
+            {
+            public:
+                explicit CallSiteRewriter(const std::map<std::string, RewrittenFunction>& rewrittenFunctions)
+                    : m_rewrittenFunctions{rewrittenFunctions}
+                {
+                }
+
+                bool visitAggregate(TVisit visit, TIntermAggregate* node) override
+                {
+                    if (visit == EvPreVisit && node->getOp() == EOpFunctionCall)
+                    {
+                        auto it = m_rewrittenFunctions.find(node->getName().c_str());
+                        if (it != m_rewrittenFunctions.end())
+                        {
+                            RewriteCallSite(node, it->second);
+                        }
+                    }
+                    return true;
+                }
+
+            private:
+                static void RewriteCallSite(TIntermAggregate* call, const RewrittenFunction& info)
+                {
+                    auto& args = call->getSequence();
+                    // glslang's SPIR-V emitter (handleUserFunctionCall) indexes its qualifier
+                    // list in lockstep with the args sequence. Expanding args without expanding
+                    // the qualifier list reads past-the-end memory for the trailing args, which
+                    // silently elides their OpStore instructions and yields uninitialized
+                    // function-call temporaries in the generated HLSL/SPIR-V.
+                    auto& qualifiers = call->getQualifierList();
+
+                    // Process right-to-left so earlier sampler indices remain valid as we
+                    // expand each `EOpConstructTextureSampler(t, s)` argument into two args.
+                    for (auto it = info.OriginalSamplerParamIndices.rbegin(); it != info.OriginalSamplerParamIndices.rend(); ++it)
+                    {
+                        const int idx = *it;
+                        if (idx < 0 || idx >= gsl::narrow_cast<int>(args.size()))
+                        {
+                            throw std::runtime_error{
+                                "SamplerFunctionParameterSplitter: call site argument index out of bounds"};
+                        }
+
+                        auto* argAggregate = args[idx]->getAsAggregate();
+                        if (argAggregate == nullptr || argAggregate->getOp() != EOpConstructTextureSampler)
+                        {
+                            throw std::runtime_error{
+                                "SamplerFunctionParameterSplitter: expected EOpConstructTextureSampler at sampler argument position"};
+                        }
+
+                        auto& constructionOperands = argAggregate->getSequence();
+                        if (constructionOperands.size() != 2)
+                        {
+                            throw std::runtime_error{
+                                "SamplerFunctionParameterSplitter: EOpConstructTextureSampler aggregate must have exactly two operands"};
+                        }
+
+                        TIntermNode* textureOperand = constructionOperands[0];
+                        TIntermNode* samplerOperand = constructionOperands[1];
+
+                        args[idx] = textureOperand;
+                        args.insert(args.begin() + idx + 1, samplerOperand);
+
+                        // Keep the qualifier list aligned with args. Both the texture and the
+                        // sampler inherit the original sampler argument's qualifier (typically
+                        // EvqIn for function parameters); samplers are opaque types so glslang
+                        // takes the originalParam l-value path regardless.
+                        if (idx < gsl::narrow_cast<int>(qualifiers.size()))
+                        {
+                            qualifiers.insert(qualifiers.begin() + idx + 1, qualifiers[idx]);
+                        }
+                    }
+
+                    call->setName(info.NewMangledName.c_str());
+                }
+
+                const std::map<std::string, RewrittenFunction>& m_rewrittenFunctions;
+            };
+        };
+
         class InvertYDerivativeOperandsTraverser : public TIntermTraverser
         {
         public:
@@ -979,6 +1368,11 @@ namespace Babylon::ShaderCompilerTraversers
     void SplitSamplersIntoSamplersAndTextures(TProgram& program, IdGenerator& ids)
     {
         SamplerSplitterTraverser::Traverse(program, ids);
+    }
+
+    void SplitSamplerFunctionParameters(TProgram& program, IdGenerator& ids)
+    {
+        SamplerFunctionParameterSplitterTraverser::Traverse(program, ids);
     }
 
     void InvertYDerivativeOperands(TProgram& program)

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
@@ -1256,6 +1256,17 @@ namespace Babylon::ShaderCompilerTraversers
                     // function-call temporaries in the generated HLSL/SPIR-V.
                     auto& qualifiers = call->getQualifierList();
 
+                    // Invariant: glslang populates the qualifier list in lockstep with args for
+                    // every EOpFunctionCall reaching this rewriter. If they ever disagree, we
+                    // must fail loudly -- silently degrading would re-introduce the very bug
+                    // this pass exists to fix (qualifiers OOB-read -> elided OpStore ->
+                    // uninitialized texture access -> accessChain.isRValue() assert).
+                    if (qualifiers.size() != args.size())
+                    {
+                        throw std::runtime_error{
+                            "SamplerFunctionParameterSplitter: call qualifier list size does not match argument list size"};
+                    }
+
                     // Process right-to-left so earlier sampler indices remain valid as we
                     // expand each `EOpConstructTextureSampler(t, s)` argument into two args.
                     for (auto it = info.OriginalSamplerParamIndices.rbegin(); it != info.OriginalSamplerParamIndices.rend(); ++it)
@@ -1291,10 +1302,7 @@ namespace Babylon::ShaderCompilerTraversers
                         // sampler inherit the original sampler argument's qualifier (typically
                         // EvqIn for function parameters); samplers are opaque types so glslang
                         // takes the originalParam l-value path regardless.
-                        if (idx < gsl::narrow_cast<int>(qualifiers.size()))
-                        {
-                            qualifiers.insert(qualifiers.begin() + idx + 1, qualifiers[idx]);
-                        }
+                        qualifiers.insert(qualifiers.begin() + idx + 1, qualifiers[idx]);
                     }
 
                     call->setName(info.NewMangledName.c_str());

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.h
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.h
@@ -78,6 +78,32 @@ namespace Babylon::ShaderCompilerTraversers
     /// the expectations of native platforms.
     void SplitSamplersIntoSamplersAndTextures(glslang::TProgram& program, IdGenerator& ids);
 
+    /// Split combined `sampler2D`/`samplerCube`/etc. function parameters of user-defined
+    /// functions into separate texture and sampler parameters. Must be called AFTER
+    /// SplitSamplersIntoSamplersAndTextures.
+    ///
+    /// The GLSL emitted by Babylon.js contains user functions that take combined
+    /// samplers as parameters and pass uniform samplers to them at the call site, e.g.
+    ///
+    ///     vec3 fetch(sampler2D s, vec2 uv) { return texture(s, uv).rgb; }
+    ///     void main() { ... fetch(myUniformSampler, uv); }
+    ///
+    /// glslang's SPIR-V emitter requires opaque (sampler) function arguments to be
+    /// l-values (it calls `accessChainGetLValue()` on them). After
+    /// SplitSamplersIntoSamplersAndTextures has rewritten the call-site sampler argument
+    /// into an `EOpConstructTextureSampler(t, s)` aggregate (an r-value), glslang
+    /// asserts at `SpvBuilder.cpp:accessChainGetLValue()`. See TPC #1584 for details.
+    ///
+    /// This pass fixes the assert by:
+    ///   1. Rewriting each user function with sampler parameters: each `sampler2D s`
+    ///      parameter becomes two parameters `texture2D sTexture, sampler s`, and every
+    ///      reference to the original `s` in the body becomes an
+    ///      `EOpConstructTextureSampler(sTexture, s)` aggregate.
+    ///   2. Rewriting every call site to such functions: the single
+    ///      `EOpConstructTextureSampler(t, s)` argument is replaced with two separate
+    ///      arguments (t and s).
+    void SplitSamplerFunctionParameters(glslang::TProgram& program, IdGenerator& ids);
+
     /// Invert dFdy operands similar to bgfx_shader.sh
     /// https://github.com/bkaradzic/bgfx/blob/7be225bf490bb1cd231cfb4abf7e617bf35b59cb/src/bgfx_shader.sh#L44-L45
     /// https://github.com/bkaradzic/bgfx/blob/7be225bf490bb1cd231cfb4abf7e617bf35b59cb/src/bgfx_shader.sh#L62-L65

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerVulkan.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerVulkan.cpp
@@ -83,6 +83,7 @@ namespace Babylon::Plugins
         std::map<std::string, std::string> vertexAttributeRenaming = {};
         ShaderCompilerTraversers::AssignLocationsAndNamesToVertexVaryingsD3D(program, ids, vertexAttributeRenaming);
         ShaderCompilerTraversers::SplitSamplersIntoSamplersAndTextures(program, ids);
+        ShaderCompilerTraversers::SplitSamplerFunctionParameters(program, ids);
         ShaderCompilerTraversers::InvertYDerivativeOperands(program);
 
         std::vector<uint32_t> spirvVS;


### PR DESCRIPTION
## Summary

Fixes a long-standing crash on shaders that use `sampler2D` as a function parameter — most visibly the Babylon.js "Area Lights - PBR" Playground visual test (idx 194), which uses `sampler2D` parameters in the LTC code path of PBRMaterial. Before this PR the crash was a deep `accessChain.isRValue()` assert in glslang's `SpvBuilder`; with debug builds disabled, the assert fired through `BX_ASSERT` and exited with code 3.

Two things had to be fixed to make idx 194 render end-to-end on the default Windows/D3D11 build:

### 1. New traverser: `SamplerFunctionParameterSplitter`

The existing `SplitSamplersIntoSamplersAndTextures` pass rewrites global `sampler2D` uniforms into a `(texture2D, sampler)` pair. It does **not** rewrite user-defined functions that take `sampler2D` *by value*. Such helpers — common in Babylon.js — were therefore left with a parameter type the rest of the pipeline can no longer satisfy.

`SamplerFunctionParameterSplitter` does the missing two halves:

1. **Function-definition rewrite** — every `sampler2D` parameter is replaced with a `(texture2D t, sampler s)` pair, and uses of the original parameter inside the body are rewritten to `sampler2D(t, s)` constructor calls.
2. **Call-site rewrite** — at each `EOpFunctionCall` that resolves to a rewritten function, every `sampler2D` argument is replaced by the `(texture, sampler)` pair, sourced from the global rewrite ids produced by `SplitSamplers…`.

The subtle bit — and the reason this had to be a dedicated traverser rather than an extension of `SplitSamplers…` — is that glslang's call nodes carry a parallel **qualifier list** alongside the argument list. `GlslangToSpv.cpp::handleUserFunctionCall` reads `qualifiers[i]` for arg `i`. If the qualifier list isn't extended in lockstep with the inserted texture/sampler args, the SPIR-V emitter walks off the end of the qualifier list, the trailing arg never gets the `OpStore` that materializes its value, and the access chain into the uninitialized texture variable trips the `accessChain.isRValue()` assert deep in `SpvBuilder`.

Concretely:
```cpp
args.insert(begin + i + 1, samplerOperand);
qualifiers.insert(begin + i + 1, qualifiers[i]); // <-- this line is the actual fix
```

Wired into all four backends that consume `SplitSamplers…` (DXBC, DXIL, Metal, Vulkan), with the new pass running immediately after.

### 2. SPIRV-Cross pin bump (BabylonJS/SPIRV-Cross#12)

Once glslang stopped asserting, the same Area Lights test reached SPIRV-Cross HLSL emission and threw `Invalid call.` from the WEBMIN stub at `spirv_hlsl.cpp:20234` (`CompilerHLSL::image_type_hlsl`). BabylonJS/SPIRV-Cross#12 un-guards `image_type_hlsl` and `image_type_hlsl_legacy` in WEBMIN builds (same un-guarding pattern as the earlier #11). This PR bumps the `SPIRV-Cross` pin in `CMakeLists.txt` to pick up that change.

## Testing

- Built `RelWithDebInfo` against the new SPIRV-Cross pin.
- Playground visual test idx 194 **"Area Lights - PBR"** now renders and validates against the reference image (`Test 'Area Lights - PBR' validated`, exit 0).
- Regression sweep on the default config (no `--include-excluded`) at idx 0/10/50: all `validated`. Idx 100/200/300/400/500 are pre-existing exclusions in `config.json` and remain `skipped=1` — no behavior change.

## Files

| File | Change |
|---|---|
| `Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.h` | +26 (public decl + rationale) |
| `Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp` | +394 (the new traverser) |
| `Plugins/ShaderCompiler/Source/ShaderCompiler{DXBC,DXIL,Metal,Vulkan}.cpp` | +1 each (one call site) |
| `CMakeLists.txt` | SPIRV-Cross `GIT_TAG` bump |
