### PR TITLE
Add setRenderResetCallback alias for setDeviceLostCallback

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -734,11 +734,8 @@ namespace Babylon
 
                 InstanceMethod("populateFrameStats", &NativeEngine::PopulateFrameStats),
 
+                // setDeviceLostCallback is a deprecated alias. Prefer setRenderResetCallback.
                 InstanceMethod("setRenderResetCallback", &NativeEngine::SetRenderResetCallback),
-                // Deprecated: prefer setRenderResetCallback. Kept for backward compatibility with
-                // older Babylon.js builds. The callback fires when bgfx is (re)initialized on the
-                // graphics device, which is the device-restored point, not device-lost; the legacy
-                // name remains for source compatibility.
                 InstanceMethod("setDeviceLostCallback", &NativeEngine::SetRenderResetCallback),
             });
 

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -734,6 +734,11 @@ namespace Babylon
 
                 InstanceMethod("populateFrameStats", &NativeEngine::PopulateFrameStats),
 
+                InstanceMethod("setRenderResetCallback", &NativeEngine::SetRenderResetCallback),
+                // Deprecated: prefer setRenderResetCallback. Kept for backward compatibility with
+                // older Babylon.js builds. The callback fires when bgfx is (re)initialized on the
+                // graphics device, which is the device-restored point, not device-lost; the legacy
+                // name remains for source compatibility.
                 InstanceMethod("setDeviceLostCallback", &NativeEngine::SetRenderResetCallback),
             });
 


### PR DESCRIPTION
JS-exposed `setDeviceLostCallback` actually fires on device-**restored** (after `bgfx::init` on re-`EnableRendering`), not on loss. C++-internal `SetRenderResetCallback` is accurate; only the JS name was misleading.

Add `setRenderResetCallback` as the preferred name. Keep `setDeviceLostCallback` as a deprecated alias so existing BJS works unchanged. BJS [#18518](https://github.com/BabylonJS/Babylon.js/pull/18518) switches to the new name with a fallback.

[Created by Copilot on behalf of @bghgary]
