### PR TITLE
Bump npm_config_fetch_retries to 5 in build workflows

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -12,6 +12,9 @@ on:
 
 env:
   NDK_VERSION: '28.2.13676358'
+  # Absorb transient npm registry / CDN flakes during `npm install` in Apps/CMakeLists.txt.
+  # npm's default fetch-retries is 2; bump to 5 (npm's own exponential backoff handles spacing).
+  npm_config_fetch_retries: '5'
 
 jobs:
   build:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -15,6 +15,11 @@ on:
         type: string
         default: macos-latest
 
+# Absorb transient npm registry / CDN flakes during `npm install` in Apps/CMakeLists.txt.
+# npm's default fetch-retries is 2; bump to 5 (npm's own exponential backoff handles spacing).
+env:
+  npm_config_fetch_retries: '5'
+
 jobs:
   build:
     runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -20,6 +20,9 @@ on:
 env:
   UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
   ASAN_OPTIONS: abort_on_error=1
+  # Absorb transient npm registry / CDN flakes during `npm install` in Apps/CMakeLists.txt.
+  # npm's default fetch-retries is 2; bump to 5 (npm's own exponential backoff handles spacing).
+  npm_config_fetch_retries: '5'
 
 jobs:
   build:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -23,6 +23,9 @@ on:
 env:
   UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
   ASAN_OPTIONS: abort_on_error=1
+  # Absorb transient npm registry / CDN flakes during `npm install` in Apps/CMakeLists.txt.
+  # npm's default fetch-retries is 2; bump to 5 (npm's own exponential backoff handles spacing).
+  npm_config_fetch_retries: '5'
 
 jobs:
   build:

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -11,6 +11,11 @@ on:
         type: string
         default: direct
 
+# Absorb transient npm registry / CDN flakes during `npm install` in Apps/CMakeLists.txt.
+# npm's default fetch-retries is 2; bump to 5 (npm's own exponential backoff handles spacing).
+env:
+  npm_config_fetch_retries: '5'
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/build-win32-shader.yml
+++ b/.github/workflows/build-win32-shader.yml
@@ -8,6 +8,11 @@ on:
         type: string
         default: x64
 
+# Absorb transient npm registry / CDN flakes during `npm install` in Apps/CMakeLists.txt.
+# npm's default fetch-retries is 2; bump to 5 (npm's own exponential backoff handles spacing).
+env:
+  npm_config_fetch_retries: '5'
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/build-win32.yml
+++ b/.github/workflows/build-win32.yml
@@ -19,6 +19,11 @@ on:
         type: boolean
         default: false
 
+# Absorb transient npm registry / CDN flakes during `npm install` in Apps/CMakeLists.txt.
+# npm's default fetch-retries is 2; bump to 5 (npm's own exponential backoff handles spacing).
+env:
+  npm_config_fetch_retries: '5'
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
## Problem

`npm install` in `Apps/CMakeLists.txt` (via the `npm()` helper in CMakeExtensions) is fatal-on-failure, so a transient `ECONNRESET` / `ETIMEDOUT` exhausting npm's default 2-retry budget fails the whole CMake configure step. Recent recurrence: https://github.com/BabylonJS/BabylonNative/actions/runs/26657850601/job/78572542598 (Win32 D3D12).

## Fix

Set `npm_config_fetch_retries=5` at workflow level in each `build-*.yml`. npm's own exponential backoff (10s mintimeout, 60s maxtimeout — defaults kept) handles spacing.

`test-install-*.yml` build with `BABYLON_NATIVE_BUILD_APPS=OFF` and don't invoke npm, so they're not modified.

[Created by Copilot on behalf of @bghgary]