### PR TITLE
Fix UnitTests shader compilation crash on macOS Metal

### DIFF
--- a/Plugins/ShaderCompiler/Source/ShaderCompilerCommon.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerCommon.cpp
@@ -198,7 +198,10 @@ namespace Babylon::ShaderCompilerCommon
                 auto& type = compiler.get_type_from_variable(id);
                 if (var.storage == spv::StorageClassUniformConstant &&
                     type.basetype != spirv_cross::SPIRType::BaseType::SampledImage &&
-                    type.basetype != spirv_cross::SPIRType::BaseType::Sampler)
+                    type.basetype != spirv_cross::SPIRType::BaseType::Sampler &&
+                    type.basetype != spirv_cross::SPIRType::BaseType::Image &&
+                    type.basetype != spirv_cross::SPIRType::BaseType::Struct &&
+                    type.basetype != spirv_cross::SPIRType::BaseType::AtomicCounter)
                 {
                     auto& uniform = info.Uniforms.emplace_back();
                     uniform.Name = compiler.get_name(id);

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
@@ -805,13 +805,25 @@ namespace Babylon::ShaderCompilerTraversers
 
             static void Traverse(TProgram& program, IdGenerator& ids)
             {
-                unsigned int layoutBinding{0};
-                Traverse(program.getIntermediate(EShLangVertex), ids, layoutBinding);
-                Traverse(program.getIntermediate(EShLangFragment), ids, layoutBinding);
+                // bgfx binds samplers using a single per-name "stage" index that is shared between
+                // vertex and fragment shaders (e.g. bgfx Metal's TextureMtl::commit uses the same
+                // `_stage` for both `setVertexTexture` and `setFragmentTexture`). The same sampler
+                // name appearing in both stages must therefore receive the SAME binding number,
+                // otherwise:
+                //   * AppendSamplers' per-name stage map records only one of the two bindings,
+                //     so the other stage cannot resolve the binding and ends up reading garbage.
+                //   * Backends with a per-stage binding limit (Metal allows binding indices 0-15)
+                //     run out of slots much faster if bindings are sequential across stages.
+                // Sharing the binding map across stages also keeps the binding space compact for
+                // shaders that declare many sampler uniforms but only use a few.
+                std::map<std::string, unsigned int> nameToBinding{};
+                unsigned int nextBinding{0};
+                Traverse(program.getIntermediate(EShLangVertex), ids, nameToBinding, nextBinding);
+                Traverse(program.getIntermediate(EShLangFragment), ids, nameToBinding, nextBinding);
             }
 
         private:
-            static void Traverse(TIntermediate* intermediate, IdGenerator& ids, unsigned int& layoutBinding)
+            static void Traverse(TIntermediate* intermediate, IdGenerator& ids, std::map<std::string, unsigned int>& nameToBinding, unsigned int& nextBinding)
             {
                 SamplerSplitterTraverser traverser{};
                 intermediate->getTreeRoot()->traverse(&traverser);
@@ -825,6 +837,21 @@ namespace Babylon::ShaderCompilerTraversers
                 // Create all the new replacers.
                 for (const auto& [name, symbol] : traverser.m_samplerNameToSymbol)
                 {
+                    // Reuse the binding assigned in a previous stage if this sampler name was
+                    // already seen, otherwise assign a new sequential binding. See the comment
+                    // on the public Traverse() overload for why bindings are shared.
+                    unsigned int layoutBinding;
+                    const auto bindingIt = nameToBinding.find(name);
+                    if (bindingIt != nameToBinding.end())
+                    {
+                        layoutBinding = bindingIt->second;
+                    }
+                    else
+                    {
+                        layoutBinding = nextBinding++;
+                        nameToBinding[name] = layoutBinding;
+                    }
+
                     // For each name and symbol, create a replacer.
                     const auto& type = symbol->getType();
 
@@ -879,7 +906,6 @@ namespace Babylon::ShaderCompilerTraversers
                     }
 
                     nameToReplacement[name] = aggregate;
-                    ++layoutBinding;
                 }
 
                 // Perform linker object replacements.


### PR DESCRIPTION
## Summary

The `ShaderCompilation.CompileComprehensiveGLSL` test crashes on macOS Debug builds with a real Metal device. Two coupled bugs in the shader compiler:

1. **`CollectNonSamplerUniforms` misclassified textures as Vec4.** After `SplitSamplersIntoSamplersAndTextures` runs, textures appear as standalone `Image` SPIRV vars with default `vecsize=1, columns=1` and were emitted as Vec4 non-sampler uniforms, then re-emitted as Samplers — bgfx hit `Uniform type mismatch` on the resulting name conflict. Extended the exclusion list to also skip `Image`, `Struct`, and `AtomicCounter` basetypes.

2. **`SamplerSplitterTraverser` assigned bindings sequentially across vertex AND fragment.** The same sampler name used in both stages received two different bindings, which (a) breaks `AppendSamplers`' per-name stage map and (b) pushes Metal's per-stage sampler index past its `0..15` limit on shaders that declare many sampler uniforms. Now the splitter shares a `name → binding` map across stages so a sampler appearing in both stages keeps the same binding.

## Why CI didn't catch this

Both bugs were silently latent on CI:
- `BX_ASSERT` compiles out in `RelWithDebInfo` (`BX_CONFIG_DEBUG=0`), masking bug 1.
- `BABYLON_NATIVE_TESTS_USE_NOOP_METAL_DEVICE=ON` makes bgfx use the NOOP renderer, so the generated MSL is never fed to Apple's Metal compiler — masking bug 2.

fixes #1713 