### PR TITLE
NativeEngine: validate JS-supplied dimensions in ResizeImageBitmap

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include <cmath>
+#include <limits>
 
 #if defined(BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES) && defined(WEBP)
 #include <webp/decode.h>
@@ -2125,7 +2126,20 @@ namespace Babylon
             image = rgba;
         }
 
-        auto outputData = Napi::Uint8Array::New(env, static_cast<size_t>(bufferWidth) * bufferHeight * 4);
+        // Compute the output size in 64-bit and reject anything that doesn't fit
+        // in size_t: on 32-bit builds size_t is 32-bit, so even within the 16-bit
+        // dimension cap above bufferWidth*bufferHeight*4 can exceed it (~17GB) and
+        // wrap to an undersized allocation that stbir_resize would then write past.
+        const uint64_t outputByteCount = static_cast<uint64_t>(bufferWidth) * bufferHeight * 4;
+        if constexpr (std::numeric_limits<size_t>::max() < std::numeric_limits<uint64_t>::max())
+        {
+            if (outputByteCount > static_cast<uint64_t>(std::numeric_limits<size_t>::max()))
+            {
+                throw Napi::Error::New(env, "Requested output buffer is too large for ResizeImageBitmap.");
+            }
+        }
+
+        auto outputData = Napi::Uint8Array::New(env, static_cast<size_t>(outputByteCount));
         if (width != bufferWidth || height != bufferHeight)
         {
             stbir_resize_uint8_linear(static_cast<unsigned char*>(image->m_data), width, height, 0,

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -2079,7 +2079,32 @@ namespace Babylon
 
         const Napi::Env env{info.Env()};
 
-        bimg::ImageContainer* image = bimg::imageAlloc(&Graphics::DeviceContext::GetDefaultAllocator(), format, static_cast<uint16_t>(width), static_cast<uint16_t>(height), 1, 1, false, false, data.Data());
+        // bufferWidth/bufferHeight are the (JS-controlled) resize target extents.
+        // They feed both the output allocation and stbir's output dimensions
+        // (which are signed int), so bound them to the same 16-bit texture limit
+        // bimg enforces for the source. This also keeps the allocation size below
+        // the 32-bit overflow the naive width*height*4 multiply would otherwise
+        // hit (and that stbir would then write past).
+        if (bufferWidth == 0 || bufferWidth > UINT16_MAX || bufferHeight == 0 || bufferHeight > UINT16_MAX)
+        {
+            throw Napi::Error::New(env, "Invalid target image dimensions for ResizeImageBitmap.");
+        }
+
+        // width/height/format come straight from the (JS-controlled) imageBitmap
+        // object and are later used as the source extents for the resize read.
+        // bimg::imageAlloc rejects dimensions that don't fit in 16 bits (it would
+        // otherwise truncate and under-allocate), so pass the full 32-bit values
+        // and let it validate; a rejected allocation surfaces as the error below.
+        // Also make sure the supplied pixel buffer is large enough for those
+        // dimensions, since imageAlloc memcpy's the source into the new container
+        // and an undersized buffer would read out of bounds of the JS array.
+        const uint64_t sourceSize = bimg::imageGetSize(nullptr, width, height, 1, false, false, 1, format);
+        if (sourceSize == 0 || data.ByteLength() < sourceSize)
+        {
+            throw Napi::Error::New(env, "Invalid source image dimensions for ResizeImageBitmap.");
+        }
+
+        bimg::ImageContainer* image = bimg::imageAlloc(&Graphics::DeviceContext::GetDefaultAllocator(), format, width, height, 1, 1, false, false, data.Data());
         if (image == nullptr)
         {
             throw Napi::Error::New(env, "Unable to allocate image for ResizeImageBitmap.");
@@ -2100,7 +2125,7 @@ namespace Babylon
             image = rgba;
         }
 
-        auto outputData = Napi::Uint8Array::New(env, bufferWidth * bufferHeight * 4);
+        auto outputData = Napi::Uint8Array::New(env, static_cast<size_t>(bufferWidth) * bufferHeight * 4);
         if (width != bufferWidth || height != bufferHeight)
         {
             stbir_resize_uint8_linear(static_cast<unsigned char*>(image->m_data), width, height, 0,


### PR DESCRIPTION
## Problem

NativeEngine::resizeImageBitmap read `width`/`height`/`format` and the pixel buffer straight from a JS-controlled object, then used them inconsistently:

- The source `width`/`height` were truncated to `uint16_t` when passed to `bimg::imageAlloc` (which sizes and `memcpy`s the backing buffer), but the **full 32-bit** values were passed to `stbir_resize`. A `width`/`height` > 65535 therefore made stbir read `width * height * 4` bytes out of a buffer allocated for `(width & 0xFFFF) * (height & 0xFFFF)` — a heap out-of-bounds **read** whose contents are resampled into the JS-visible output (information disclosure of adjacent heap memory).
- `imageAlloc` `memcpy`s `imageGetSize(...)` bytes from the JS `data` array, so a buffer smaller than the declared dimensions over-reads the JS array.
- The output allocation `bufferWidth * bufferHeight * 4` was computed in 32-bit and could overflow into an undersized buffer that stbir then **writes** past.

In normal flow these properties are produced by `createImageBitmap` from a parsed (≤ uint16) image, so the bug requires JS to mutate the bitmap object before calling `resizeImageBitmap`.

## Fix

- Pass the full 32-bit source `width`/`height` to `imageAlloc` (the updated bimg takes `uint32_t` and rejects `> UINT16_MAX`), so allocation and the resize read agree.
- Reject a source pixel buffer smaller than `bimg::imageGetSize` for the given dimensions/format.
- Bound the target `bufferWidth`/`bufferHeight` to `UINT16_MAX` and compute the output allocation in 64-bit.

## Testing

- win32 D3D11 Debug: Playground validation suite `ran=160 passed=160 failed=0`.
