### PR TITLE
NativeEngine: fix 32-bit overflow in ReadTexture bounds check

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1669,11 +1669,11 @@ namespace Babylon
             buffer = Napi::ArrayBuffer::New(env, bufferLength);
         }
 
-        // Make sure the buffer is big enough for the offset + length. bufferOffset
-        // and bufferLength are JS-supplied uint32_t, so widen the addition to 64-bit:
-        // computing it in 32-bit can wrap around (e.g. offset 0xF0000000 + length
-        // 0x20000000), letting an out-of-range offset pass this gate and overflow
-        // the ArrayBuffer backing store in the memcpy below.
+        // Make sure the buffer is big enough for the offset + length. Both
+        // bufferOffset and bufferLength are JS-supplied uint32_t, so widen the
+        // addition to 64-bit: computing it in 32-bit can wrap around (e.g. offset
+        // 0xF0000000 + length 0x20000000), letting an out-of-range offset pass this
+        // gate and overflow the ArrayBuffer backing store in the memcpy below.
         if (buffer.ByteLength() < static_cast<uint64_t>(bufferOffset) + bufferLength)
         {
             deferred.Reject(Napi::Error::New(env, "Provided buffer is too small for the specified offset and length.").Value());

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1669,8 +1669,12 @@ namespace Babylon
             buffer = Napi::ArrayBuffer::New(env, bufferLength);
         }
 
-        // Make sure the buffer is big enough for the offset + length.
-        if (buffer.ByteLength() < bufferOffset + bufferLength)
+        // Make sure the buffer is big enough for the offset + length. bufferOffset
+        // and bufferLength are JS-supplied uint32_t, so widen the addition to 64-bit:
+        // computing it in 32-bit can wrap around (e.g. offset 0xF0000000 + length
+        // 0x20000000), letting an out-of-range offset pass this gate and overflow
+        // the ArrayBuffer backing store in the memcpy below.
+        if (buffer.ByteLength() < static_cast<uint64_t>(bufferOffset) + bufferLength)
         {
             deferred.Reject(Napi::Error::New(env, "Provided buffer is too small for the specified offset and length.").Value());
         }


### PR DESCRIPTION
## Problem

`NativeEngine::ReadTexture` validates the destination ArrayBuffer with:

```cpp
if (buffer.ByteLength() < bufferOffset + bufferLength)
```

`bufferOffset` and `bufferLength` are both JS-supplied `uint32_t` (from `engine.readTexture(...)`), so `bufferOffset + bufferLength` is evaluated in **32-bit** and can wrap around before being promoted to `size_t` for the comparison. For example `bufferOffset = 0xF0000000` and `bufferLength = 0x20000000` wrap to `0x10000000` (256 MiB) and pass the check against any sufficiently large buffer. The subsequent `storageSize > bufferLength` gate also passes (the real pixel payload is small), and the async continuation then runs:

```cpp
std::memcpy(buffer + bufferOffset, textureBuffer.data(), textureBuffer.size());
```

writing the pixel data at the out-of-range `bufferOffset` and overflowing the ArrayBuffer backing store (heap OOB write, CWE-190 → CWE-787).

## Fix

Widen the addition to 64-bit so `bufferOffset + bufferLength` can't wrap:

```cpp
if (buffer.ByteLength() < static_cast<uint64_t>(bufferOffset) + bufferLength)
```

With the existing `storageSize <= bufferLength` gate, this guarantees `bufferOffset + storageSize <= ByteLength` before the memcpy.

## Testing

- win32 D3D11 Debug: Playground validation suite `ran=160 passed=160 failed=0` (every screenshot pixel comparison exercises `ReadTexture`).
