### PR TITLE
Validate dimensions and sizes in loadRawTexture2DArray

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1401,9 +1401,9 @@ namespace Babylon
 #else
         const auto texture{info[0].As<Napi::Pointer<Graphics::Texture>>().Get()};
         const auto data = info[1].As<Napi::TypedArray>();
-        const auto width{static_cast<uint16_t>(info[2].As<Napi::Number>().Uint32Value())};
-        const auto height{static_cast<uint16_t>(info[3].As<Napi::Number>().Uint32Value())};
-        const auto depth{static_cast<uint16_t>(info[4].As<Napi::Number>().Int32Value())};
+        const auto rawWidth{info[2].As<Napi::Number>().Uint32Value()};
+        const auto rawHeight{info[3].As<Napi::Number>().Uint32Value()};
+        const auto rawDepth{info[4].As<Napi::Number>().Uint32Value()};
         const auto format{static_cast<bimg::TextureFormat::Enum>(info[5].As<Napi::Number>().Uint32Value())};
         const auto generateMips = info[6].As<Napi::Boolean>().Value();
         const auto invertY = info[7].As<Napi::Boolean>().Value();
@@ -1418,19 +1418,24 @@ namespace Babylon
             throw Napi::Error::New(Env(), "Texture 2D array currently do not support invert Y.");
         }
 
-        // width/height/depth originate from JS and are otherwise only truncated to
-        // uint16_t. Reject zero or out-of-range dimensions against the GPU limits
-        // before creating the texture so a crafted size can't drive an oversized
-        // allocation or an out-of-bounds read in the renderer.
+        // width/height/depth originate from JS. Validate the raw 32-bit values
+        // against the GPU limits before narrowing to uint16_t, otherwise an
+        // out-of-range value (e.g. 70000) would wrap into an in-range uint16_t
+        // and slip past this check, driving an oversized allocation or an
+        // out-of-bounds read in the renderer.
         const auto maxTextureSize = bgfx::getCaps()->limits.maxTextureSize;
         const auto maxTextureLayers = bgfx::getCaps()->limits.maxTextureLayers;
-        if (width == 0 || height == 0 || depth == 0 ||
-            width > maxTextureSize ||
-            height > maxTextureSize ||
-            depth > maxTextureLayers)
+        if (rawWidth == 0 || rawHeight == 0 || rawDepth == 0 ||
+            rawWidth > maxTextureSize ||
+            rawHeight > maxTextureSize ||
+            rawDepth > maxTextureLayers)
         {
             throw Napi::Error::New(Env(), "Invalid width, height, or depth for the 2D texture array.");
         }
+
+        const auto width{static_cast<uint16_t>(rawWidth)};
+        const auto height{static_cast<uint16_t>(rawHeight)};
+        const auto depth{static_cast<uint16_t>(rawDepth)};
 
         uint64_t flags{BGFX_TEXTURE_NONE | BGFX_SAMPLER_NONE | BGFX_CAPS_TEXTURE_2D_ARRAY};
         texture->Create2D(width, height, generateMips, depth, Cast(format), flags);

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1418,12 +1418,29 @@ namespace Babylon
             throw Napi::Error::New(Env(), "Texture 2D array currently do not support invert Y.");
         }
 
+        // width/height/depth originate from JS and are otherwise only truncated to
+        // uint16_t. Reject zero or out-of-range dimensions against the GPU limits
+        // before creating the texture so a crafted size can't drive an oversized
+        // allocation or an out-of-bounds read in the renderer.
+        const bgfx::Caps* caps = bgfx::getCaps();
+        if (width == 0 || height == 0 || depth == 0 ||
+            width > caps->limits.maxTextureSize ||
+            height > caps->limits.maxTextureSize ||
+            depth > caps->limits.maxTextureLayers)
+        {
+            throw Napi::Error::New(Env(), "Invalid width, height, or depth for the 2D texture array.");
+        }
+
         uint64_t flags{BGFX_TEXTURE_NONE | BGFX_SAMPLER_NONE | BGFX_CAPS_TEXTURE_2D_ARRAY};
         texture->Create2D(width, height, generateMips, depth, Cast(format), flags);
 
         if (!data.IsNull())
         {
-            if (data.ByteLength() != bimg::imageGetSize(nullptr, width, height, 1, false, false, depth, format))
+            // imageGetSize returns the full size in 64-bit; compare against the
+            // 64-bit byte length so a crafted width/height/depth cannot wrap the
+            // expected size and slip an undersized buffer past this check.
+            const uint64_t expectedSize{bimg::imageGetSize(nullptr, width, height, 1, false, false, depth, format)};
+            if (expectedSize == 0 || static_cast<uint64_t>(data.ByteLength()) != expectedSize)
             {
                 throw Napi::Error::New(Env(), "The data size does not match width, height, depth and format");
             }
@@ -1432,6 +1449,13 @@ namespace Babylon
             size_t dataSize = data.ByteLength();
 
             size_t textureSize = dataSize / static_cast<size_t>(depth);
+
+            // bgfx::Memory uses a 32-bit size; reject a per-layer payload that
+            // would be truncated by the bgfx::copy cast below.
+            if (textureSize > UINT32_MAX)
+            {
+                throw Napi::Error::New(Env(), "The 2D texture array layer size is too large.");
+            }
 
             for (uint16_t i = 0; i < depth; i++)
             {

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1422,11 +1422,12 @@ namespace Babylon
         // uint16_t. Reject zero or out-of-range dimensions against the GPU limits
         // before creating the texture so a crafted size can't drive an oversized
         // allocation or an out-of-bounds read in the renderer.
-        const bgfx::Caps* caps = bgfx::getCaps();
+        const auto maxTextureSize = bgfx::getCaps()->limits.maxTextureSize;
+        const auto maxTextureLayers = bgfx::getCaps()->limits.maxTextureLayers;
         if (width == 0 || height == 0 || depth == 0 ||
-            width > caps->limits.maxTextureSize ||
-            height > caps->limits.maxTextureSize ||
-            depth > caps->limits.maxTextureLayers)
+            width > maxTextureSize ||
+            height > maxTextureSize ||
+            depth > maxTextureLayers)
         {
             throw Napi::Error::New(Env(), "Invalid width, height, or depth for the 2D texture array.");
         }


### PR DESCRIPTION
## Summary
Hardens NativeEngine::LoadRawTexture2DArray against JS-controlled width/height/depth.

Previously these arguments were only truncated to `uint16_t`, the texture was created via `Create2D` **before** any validation, and the per-layer payload size was cast to a 32-bit value for `bgfx::copy` while `Update2D` used the full width/height. A crafted size could drive an oversized allocation or a truncated copy whose backing `bgfx::Memory` is smaller than the dimensions handed to the renderer, leading to an out-of-bounds read.

## Changes
- Reject zero or out-of-range dimensions against the GPU caps limits (`maxTextureSize` / `maxTextureLayers`) **before** `Create2D`.
- Compare `data.ByteLength()` against the expected `imageGetSize` in full 64-bit precision.
- Reject a per-layer payload that does not fit in the 32-bit `bgfx::Memory` size (the cast feeding `bgfx::copy`).

## Testing
- `NativeEngine` + `Playground` build clean (Win32 Debug).
- `validation_native.js` headless: `ran=160 passed=160 failed=0`.