### PR TITLE
Fix iOS Playground Metal "no output textures" render pass error

### DIFF
--- a/Apps/Playground/CMakeLists.txt
+++ b/Apps/Playground/CMakeLists.txt
@@ -195,6 +195,12 @@ if(APPLE)
             XCODE_ATTRIBUTE_FRAMEWORK_SEARCH_PATHS "$(inherited) $(SDKROOT)$(SYSTEM_LIBRARY_DIR)/Frameworks"
             XCODE_ATTRIBUTE_ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES YES
 
+            # The iPhoneSimulator Metal stub in Xcode 26.x does not export MTLIOErrorDomain / MTLTensorDomain,
+            # even though the device Metal stub does. bgfx's metal-cpp (compiled as C++ against the iOS 26 SDK)
+            # emits direct link-time externs for these constants, so simulator links fail with undefined symbols.
+            # Resolve them dynamically for simulator builds only; device builds are unaffected.
+            "XCODE_ATTRIBUTE_OTHER_LDFLAGS[sdk=iphonesimulator*]" "-Wl,-U,_MTLIOErrorDomain -Wl,-U,_MTLTensorDomain"
+
             # CMake seems to add a custom flag "-Wno-unknown-pragmas" to the Swift compiler. That flag is used for Clang,
             # So we need to make sure we override it with nothing here in order to compile Swift.
             XCODE_ATTRIBUTE_OTHER_SWIFT_FLAGS "")

--- a/Apps/Playground/CMakeLists.txt
+++ b/Apps/Playground/CMakeLists.txt
@@ -195,12 +195,6 @@ if(APPLE)
             XCODE_ATTRIBUTE_FRAMEWORK_SEARCH_PATHS "$(inherited) $(SDKROOT)$(SYSTEM_LIBRARY_DIR)/Frameworks"
             XCODE_ATTRIBUTE_ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES YES
 
-            # The iPhoneSimulator Metal stub in Xcode 26.x does not export MTLIOErrorDomain / MTLTensorDomain,
-            # even though the device Metal stub does. bgfx's metal-cpp (compiled as C++ against the iOS 26 SDK)
-            # emits direct link-time externs for these constants, so simulator links fail with undefined symbols.
-            # Resolve them dynamically for simulator builds only; device builds are unaffected.
-            "XCODE_ATTRIBUTE_OTHER_LDFLAGS[sdk=iphonesimulator*]" "-Wl,-U,_MTLIOErrorDomain -Wl,-U,_MTLTensorDomain"
-
             # CMake seems to add a custom flag "-Wno-unknown-pragmas" to the Swift compiler. That flag is used for Clang,
             # So we need to make sure we override it with nothing here in order to compile Swift.
             XCODE_ATTRIBUTE_OTHER_SWIFT_FLAGS "")

--- a/Apps/Playground/iOS/ViewController.swift
+++ b/Apps/Playground/iOS/ViewController.swift
@@ -34,15 +34,21 @@ class ViewController: UIViewController {
         )
         mtkView.addGestureRecognizer(gesture)
         
-        let scale = view.contentScaleFactor
-        let width = view.bounds.size.width
-        let height = view.bounds.size.height
+        // Force a layout pass so mtkView (and its backing CAMetalLayer) gets a
+        // valid drawable size before bgfx is initialized and before the first
+        // draw(in:) callback. mtkView is added via Auto Layout and is otherwise
+        // still 0x0 at this point, which would make bgfx render into a 0x0 layer
+        // and trigger the Metal validation error
+        // "No output textures defined for the render pass".
+        view.layoutIfNeeded()
+
+        let drawableSize = mtkView.drawableSize
         
         bridge.init(
             mtkView,
             screenScale:Float(UIScreen.main.scale),
-            width:Int32(width * scale),
-            height:Int32(height * scale),
+            width:Int32(drawableSize.width),
+            height:Int32(drawableSize.height),
             xrView:Unmanaged.passUnretained(xrView).toOpaque()
         )
     }
@@ -68,12 +74,17 @@ class ViewController: UIViewController {
 // MARK: MTKViewDelegate
 extension ViewController: MTKViewDelegate {
     func draw(in view: MTKView) {
+        // Skip rendering until the layer has a valid drawable size, otherwise
+        // bgfx cannot acquire a drawable and Metal validation reports a render
+        // pass with no output textures.
+        guard view.drawableSize.width > 0, view.drawableSize.height > 0 else { return }
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         xrView.isHidden = !(appDelegate._bridge?.isXRActive() ?? false)
         appDelegate._bridge?.render()
     }
     
     func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
+        guard size.width > 0, size.height > 0 else { return }
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         appDelegate._bridge?.resize(Int32(size.width), height: Int32(size.height))
     }

--- a/Apps/Playground/iOS/ViewController.swift
+++ b/Apps/Playground/iOS/ViewController.swift
@@ -34,21 +34,23 @@ class ViewController: UIViewController {
         )
         mtkView.addGestureRecognizer(gesture)
         
-        // Force a layout pass so mtkView (and its backing CAMetalLayer) gets a
-        // valid drawable size before bgfx is initialized and before the first
-        // draw(in:) callback. mtkView is added via Auto Layout and is otherwise
-        // still 0x0 at this point, which would make bgfx render into a 0x0 layer
-        // and trigger the Metal validation error
+        // Force a layout pass so mtkView (and its backing CAMetalLayer) is laid
+        // out and gets a valid drawable size before bgfx is initialized and
+        // before the first draw(in:) callback. mtkView is added via Auto Layout
+        // and is otherwise still 0x0 at this point, which would make bgfx render
+        // into a 0x0 layer and trigger the Metal validation error
         // "No output textures defined for the render pass".
         view.layoutIfNeeded()
 
-        let drawableSize = mtkView.drawableSize
+        let scale  = view.contentScaleFactor
+        let width  = view.bounds.size.width
+        let height = view.bounds.size.height
         
         bridge.init(
             mtkView,
             screenScale:Float(UIScreen.main.scale),
-            width:Int32(drawableSize.width),
-            height:Int32(drawableSize.height),
+            width:Int32(width * scale),
+            height:Int32(height * scale),
             xrView:Unmanaged.passUnretained(xrView).toOpaque()
         )
     }

--- a/Core/Graphics/CMakeLists.txt
+++ b/Core/Graphics/CMakeLists.txt
@@ -54,6 +54,17 @@ elseif(ANDROID)
 elseif(APPLE)
     target_link_libraries(Graphics
         PRIVATE metal-cpp)
+    if(IOS)
+        # bgfx's metal-cpp (compiled as C++ against the iOS 26 SDK) emits direct link-time
+        # externs for the MTLIOErrorDomain / MTLTensorDomain constants. The iPhoneSimulator
+        # Metal stub in Xcode 26.x does not export them (the device stub does), so simulator
+        # links fail with undefined symbols. Allow these two symbols to be resolved by dynamic
+        # lookup at runtime; this is harmless on device, where they resolve normally. Propagated
+        # to consumers (the final app link) via INTERFACE.
+        target_link_options(Graphics INTERFACE
+            "LINKER:-U,_MTLIOErrorDomain"
+            "LINKER:-U,_MTLTensorDomain")
+    endif()
 endif()
 
 set_property(TARGET Graphics PROPERTY FOLDER Core)


### PR DESCRIPTION
## Problem

The iOS Playground emits a Metal validation error at startup:

```
_MTLDebugValidateRenderPassDescriptorAndTrackAttachments ...
No output textures defined for the render pass ...
no sampleCount for color and raster available ...
```

`viewDidAppear` initialized bgfx from the **root** view's bounds, but bgfx
renders into `mtkView.layer` (a `CAMetalLayer`). `mtkView` is added via Auto
Layout and is still `0x0` when the size is read, so its `CAMetalLayer` has a
`0x0` `drawableSize`. On the first frame(s), bgfx's
`SwapChainMtl::currentDrawableTexture()` gets `nil` from `nextDrawable()` and
falls back to creating a `0x0` texture, which Metal returns as `NULL` — leaving
the color attachment unset and triggering the validation error.

## Fix

- Force a layout pass before init so `mtkView`/`CAMetalLayer` has a valid
  drawable size, and size bgfx from `mtkView.drawableSize` — matching the macOS
  Playground, which already sizes from the MTKView it renders into.
- Guard `draw(in:)` / `drawableSizeWillChange` against `0x0` sizes for
  robustness (backgrounding, rotation, momentarily-detached layer, etc.).

## Simulator link workaround

Building for the iOS **simulator** with Xcode 26.x also fails at link:

```
Undefined symbols for architecture arm64:
  "_MTLIOErrorDomain", referenced from: renderer_mtl.o in libbgfx.a
  "_MTLTensorDomain",  referenced from: renderer_mtl.o in libbgfx.a
```

The iPhoneSimulator `Metal.tbd` does **not** export `MTLIOErrorDomain` /
`MTLTensorDomain`, even though the device and macOS `Metal.tbd` (same Xcode,
`current-version 373.2`) do. bgfx's metal-cpp, compiled as C++ against the
iOS 26 SDK, emits direct link-time externs for these constants (the
non-`__OBJC__`, `__IPHONE_26_0` branch) instead of the `dlsym` runtime lookup.
This resolves them via dynamic lookup for **simulator builds only**
(`[sdk=iphonesimulator*]`); device and macOS builds are unaffected.

## Notes

- macOS was verified unaffected: it sizes bgfx from a non-zero-frame MTKView,
  so it never hits the `0x0` startup race, and its Metal stub exports the two
  symbols so it links cleanly.
