### PR TITLE
NativeEngine: support standalone sampleable depth/stencil textures

### DIFF
--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -11,13 +11,13 @@
         "UnitTests/JavaScript"
       ],
       "dependencies": {
-        "babylonjs": "^9.3.4",
-        "babylonjs-addons": "^9.3.4",
-        "babylonjs-gltf2interface": "^9.3.4",
-        "babylonjs-gui": "^9.3.4",
-        "babylonjs-loaders": "^9.3.4",
-        "babylonjs-materials": "^9.3.4",
-        "babylonjs-serializers": "^9.3.4",
+        "babylonjs": "^9.15.0",
+        "babylonjs-addons": "^9.15.0",
+        "babylonjs-gltf2interface": "^9.15.0",
+        "babylonjs-gui": "^9.15.0",
+        "babylonjs-loaders": "^9.15.0",
+        "babylonjs-materials": "^9.15.0",
+        "babylonjs-serializers": "^9.15.0",
         "jsc-android": "^241213.1.0",
         "v8-android": "^7.8.2"
       }
@@ -2596,63 +2596,63 @@
       }
     },
     "node_modules/babylonjs": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-9.9.1.tgz",
-      "integrity": "sha512-zMH8r0l/il9PJhy2+uS+/EyeLBy/ElZg0lKLj2d+ZrUarOanjMISaACw0HUx7C1EgYoXUFSMQLYcpXguleh8GA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-9.15.0.tgz",
+      "integrity": "sha512-IJQhrxsxxj4KCg4aSsB5chLidzAfbghr8rnzo6sRLFin6ipfeayCxg7MevjaMzqdVmc/BOMU6sj49nSNrBq+yQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-addons": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-addons/-/babylonjs-addons-9.9.1.tgz",
-      "integrity": "sha512-Hi9QZqeanqG+4VAAmJmHJh7JKf1bc/Y5Ml+wuv+W+3f/dKltZpy/pii/QN4vhYRyrU0n+S8OJc+kVeaUUFjHEg==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-addons/-/babylonjs-addons-9.15.0.tgz",
+      "integrity": "sha512-7vxm0ffFXWHCZWDlYYleifb6mg1iSH7nNo+sA9706z7QIfpNnLS9+9cTYadWobvhURwaD/DHAKnm7Z8ckq9YAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1"
+        "babylonjs": "9.15.0"
       }
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.9.1.tgz",
-      "integrity": "sha512-qHE7pASEWbRORU+NEPSSL9fyVh6gBNqC1ugV94YL9Dz0HnLcH8YNcxdi6Pf+oXgFHRrXWZiJATn37HynsF7/0g==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.15.0.tgz",
+      "integrity": "sha512-Yr/WvOvnsZFN2LoyNU/ZZbT+lXMdNA9OiZzE4RibI1tnYxQjpPKT6X1cxQ/ACJPVzKwudxzJxQ/f/Tdba4TLDg==",
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-gui": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-9.9.1.tgz",
-      "integrity": "sha512-w6HSvuHSqLYUOuxvko+gkjAQMvatf7gnOPufLRslm+P4tC+5KMEd0hyC+1vHCJuQmZXXkoc/GnozzFeaqllHZw==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-9.15.0.tgz",
+      "integrity": "sha512-klF2ywhA040JMQ3Z5XaGkN4S0GIOshtnvtUd8kbYqlLYEu5i6/y/zvB8V3O4geslzV0kWcBe2mIthlr7M7p4og==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1"
+        "babylonjs": "9.15.0"
       }
     },
     "node_modules/babylonjs-loaders": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-9.9.1.tgz",
-      "integrity": "sha512-bFSe4TQTi7aA7RsWmuZHQLX4mBMoza5D+AFRD2tVrizGyGCfQJALKnKze7Z3OetFyeo72838GXJAXmyiOWcxAA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-9.15.0.tgz",
+      "integrity": "sha512-k5Kg9wmuy0n4ZAWu9woFk3C1yEwSvQHRv0Ct2GOQtuRvIHUIyRcW4KEKOsW0GOiApSjXh9nQcabdJTnUo8IBNw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1",
-        "babylonjs-gltf2interface": "9.9.1"
+        "babylonjs": "9.15.0",
+        "babylonjs-gltf2interface": "9.15.0"
       }
     },
     "node_modules/babylonjs-materials": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-9.9.1.tgz",
-      "integrity": "sha512-2ai5hk59dzHRUN28/5/Nijknn+IungSuoBsrHrNZE2T/yIT+/T/IrU0ebm53nRYliv6NG0IaxSCfnh6euZUj7A==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-9.15.0.tgz",
+      "integrity": "sha512-E9C5EB0nZJrGvT7Mb38gypAnzi1q8vr/Gi+fTeqRQilIU8mdk+YzD5unfKOROEv8arRFCXGWrtBqkIN8k2PFxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1"
+        "babylonjs": "9.15.0"
       }
     },
     "node_modules/babylonjs-serializers": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.9.1.tgz",
-      "integrity": "sha512-nZJPplzHprwJhp4JVLgB3dEpJR2HvEElPIDvOoAFf1IcaKwcDja2tZTGXIbARdWlTX547pN0qN/vEd6dYLrnDA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.15.0.tgz",
+      "integrity": "sha512-iLYwPzZrUr2SnwHcsXjHJHYdJIVC+boW6z/olE0mE5GvqmfKXTtqFr9wRGrsq85BarhHQkfVlfQdFwhFq/JG4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1",
-        "babylonjs-gltf2interface": "9.9.1"
+        "babylonjs": "9.15.0",
+        "babylonjs-gltf2interface": "9.15.0"
       }
     },
     "node_modules/balanced-match": {

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -9,13 +9,13 @@
     "getNightly": "node scripts/getNightly.js"
   },
   "dependencies": {
-    "babylonjs": "^9.3.4",
-    "babylonjs-addons": "^9.3.4",
-    "babylonjs-gltf2interface": "^9.3.4",
-    "babylonjs-gui": "^9.3.4",
-    "babylonjs-loaders": "^9.3.4",
-    "babylonjs-materials": "^9.3.4",
-    "babylonjs-serializers": "^9.3.4",
+    "babylonjs": "^9.15.0",
+    "babylonjs-addons": "^9.15.0",
+    "babylonjs-gltf2interface": "^9.15.0",
+    "babylonjs-gui": "^9.15.0",
+    "babylonjs-loaders": "^9.15.0",
+    "babylonjs-materials": "^9.15.0",
+    "babylonjs-serializers": "^9.15.0",
     "jsc-android": "^241213.1.0",
     "v8-android": "^7.8.2"
   }

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1856,7 +1856,13 @@ namespace Babylon
         std::array<bgfx::Attachment, 2> attachments{};
         uint8_t numAttachments = 0;
 
-        if (texture != nullptr)
+        // Babylon's NativeEngine._createDepthStencilTexture asks for a standalone, *sampleable* depth/stencil
+        // texture by passing a freshly created (and therefore uninitialized) color texture: its bgfx handle is
+        // still kInvalidHandle. Detect that here so we (a) don't attach the invalid handle as a color target and
+        // (b) create a readable depth attachment and alias it back into the supplied texture so it can be sampled.
+        const bool requestDepthStencilTexture = (texture != nullptr && !bgfx::isValid(texture->Handle()));
+
+        if (texture != nullptr && bgfx::isValid(texture->Handle()))
         {
             const bgfx::Caps* caps = bgfx::getCaps();
             // bgfx validation now asserts when trying to use BGFX_RESOLVE_AUTO_GEN_MIPS with a texture that doesn't have the BGFX_CAPS_FORMAT_TEXTURE_MIP_AUTOGEN flag,
@@ -1869,6 +1875,8 @@ namespace Babylon
 
         bgfx::TextureHandle depthStencilTextureHandle = BGFX_INVALID_HANDLE;
         int8_t depthStencilAttachmentIndex = -1;
+        bgfx::TextureFormat::Enum depthStencilTextureFormat = bgfx::TextureFormat::Unknown;
+        uint64_t depthStencilTextureFlags = 0;
         if (generateStencilBuffer || generateDepth)
         {
             if (generateStencilBuffer && !generateDepth)
@@ -1876,7 +1884,9 @@ namespace Babylon
                 JsConsoleLogger::LogWarn(info.Env(), "Stencil without depth is not supported, assuming depth and stencil");
             }
 
-            auto flags = BGFX_TEXTURE_RT_WRITE_ONLY | RenderTargetSamplesToBgfxMsaaFlag(samples);
+            // A standalone depth/stencil texture must be readable; render-target-only depth attachments stay
+            // write-only (cheaper, and the resolve path below relies on it).
+            auto flags = (requestDepthStencilTexture ? BGFX_TEXTURE_RT : BGFX_TEXTURE_RT_WRITE_ONLY) | RenderTargetSamplesToBgfxMsaaFlag(samples);
 #ifdef ANDROID
             // On Android with Mali GPU (Oppo Find x5 lite, Google Pixel 8, Samsung Galaxy Tab Active 3, ...)
             // D32 depth buffer gives glitches. Everything is fine with D24S8.
@@ -1888,6 +1898,8 @@ namespace Babylon
 #endif
             assert(bgfx::isTextureValid(0, false, 1, depthStencilFormat, flags));
             depthStencilTextureHandle = bgfx::createTexture2D(width, height, false, 1, depthStencilFormat, flags);
+            depthStencilTextureFormat = depthStencilFormat;
+            depthStencilTextureFlags = flags;
 
             // bgfx doesn't add flag D3D11_RESOURCE_MISC_GENERATE_MIPS for depth textures (missing that flag will crash D3D with resolving)
             // And not sure it makes sense to generate mipmaps from a depth buffer with exponential values.
@@ -1909,6 +1921,16 @@ namespace Babylon
         }
 
         Graphics::FrameBuffer* frameBuffer = new Graphics::FrameBuffer(m_deviceContext, frameBufferHandle, width, height, false, generateDepth, generateStencilBuffer, depthStencilAttachmentIndex);
+
+        // For a standalone depth/stencil texture request, alias the framebuffer's readable depth attachment back
+        // into the caller-supplied texture so Babylon can sample it (e.g. fluid rendering's depth copy). The
+        // framebuffer owns the handle (its destructor destroys it), so the texture must not own it.
+        if (requestDepthStencilTexture && depthStencilAttachmentIndex >= 0)
+        {
+            texture->Attach(bgfx::getTexture(frameBufferHandle, static_cast<uint8_t>(depthStencilAttachmentIndex)),
+                false, width, height, false, 1, depthStencilTextureFormat, depthStencilTextureFlags);
+        }
+
         return Napi::Pointer<Graphics::FrameBuffer>::Create(info.Env(), frameBuffer, Napi::NapiPointerDeleter(frameBuffer));
     }
 

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1920,7 +1920,11 @@ namespace Babylon
             throw Napi::Error::New(info.Env(), "Failed to create frame buffer");
         }
 
-        Graphics::FrameBuffer* frameBuffer = new Graphics::FrameBuffer(m_deviceContext, frameBufferHandle, width, height, false, generateDepth, generateStencilBuffer, depthStencilAttachmentIndex);
+        // Stencil-without-depth still allocates a combined depth/stencil attachment above, so the framebuffer
+        // genuinely has depth in that case too. Report hasDepth accordingly, otherwise Clear/DrawInternal would
+        // skip depth clear and Z-writes against a depth buffer that actually exists.
+        const bool hasDepthAttachment = generateDepth || generateStencilBuffer;
+        Graphics::FrameBuffer* frameBuffer = new Graphics::FrameBuffer(m_deviceContext, frameBufferHandle, width, height, false, hasDepthAttachment, generateStencilBuffer, depthStencilAttachmentIndex);
 
         // For a standalone depth/stencil texture request, alias the framebuffer's readable depth attachment back
         // into the caller-supplied texture so Babylon can sample it (e.g. fluid rendering's depth copy). The


### PR DESCRIPTION
## What

`NativeEngine::CreateFrameBuffer` now supports Babylon's request for a standalone, **sampleable** depth/stencil texture.

`thinNativeEngine.pure.ts::_createDepthStencilTexture` creates such a texture by calling `createFrameBuffer(...)` with a freshly-created (and therefore *uninitialized*) color texture — its bgfx handle is still `kInvalidHandle`. `CreateFrameBuffer` only guarded against a *null* texture, so it attached the invalid handle as a color target. bgfx framebuffer validation then rejected it (`Invalid texture attachment`) and threw, which **aborted the entire headless Playground sweep**, not just the offending test.

## How

Detect the request (non-null texture whose bgfx handle is invalid) and instead:

- skip attaching the invalid color handle → build a **depth-only** framebuffer;
- allocate the depth attachment as a readable `BGFX_TEXTURE_RT` (instead of `BGFX_TEXTURE_RT_WRITE_ONLY`) so it can be sampled;
- alias the framebuffer's depth attachment back into the caller-supplied texture (`ownsHandle = false`, since the framebuffer owns/destroys the handle) so Babylon can sample it (e.g. fluid rendering's depth copy).

## Verification

- Built `Playground` (Win32 D3D11, RelWithDebInfo) off `master` + this change.
- The fluid-rendering test that previously threw `Invalid texture attachment` and aborted the sweep now runs to completion with a clean exit (no abort, no stderr). RenderDoc confirms the aliased depth/stencil texture holds correct scene depth.

## Does this re-enable any excluded tests?

Honest answer: **not on its own.** I A/B-tested every crash-reason–excluded test (built with and without this change, run in isolation):

- No currently-excluded test except the fluid one exercises this code path, so none are unblocked by this fix.
- The fluid test itself still cannot be re-enabled: with the crash gone it renders **black** because of a *separate, pre-existing* NativeEngine GPU-particle limitation — the fluid particle vertex shader never receives per-instance particle positions (they're uploaded to bgfx instance slot `TEXCOORD7`/`i_data0`, but the compiled shader reads `POSITION0` from the per-vertex buffer), so all particles render zero-area quads and produce no fragments. That's tracked separately and needs a fix in NativeEngine's instanced-attribute routing.

This PR is therefore a **robustness/correctness fix**: it removes a whole-sweep abort and makes standalone depth/stencil textures behave per Babylon's contract (sampleable), independent of the unrelated particle issue.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
