### PR TITLE
Remove libwebp dependency; rely on bimg for WebP decoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,10 +55,6 @@ FetchContent_Declare(ios-cmake
 FetchContent_Declare(JsRuntimeHost
     GIT_REPOSITORY https://github.com/BabylonJS/JsRuntimeHost.git
     GIT_TAG c88625b6d61b55c4589f02408d03826e83199870)
-FetchContent_Declare(libwebp
-    GIT_REPOSITORY https://github.com/webmproject/libwebp.git
-    GIT_TAG 57e324e2eb99be46df46d77b65705e34a7ae616c
-    EXCLUDE_FROM_ALL)
 FetchContent_Declare(metal-cpp
     GIT_REPOSITORY https://github.com/bkaradzic/metal-cpp.git
     GIT_TAG metal-cpp_26
@@ -123,12 +119,7 @@ option(BABYLON_NATIVE_PLUGIN_NATIVECAMERA "Include Babylon Native Plugin NativeC
 option(BABYLON_NATIVE_PLUGIN_NATIVECAPTURE "Include Babylon Native Plugin NativeCapture." ON)
 option(BABYLON_NATIVE_PLUGIN_NATIVEENCODING "Include Babylon Native Plugin NativeEncoding." ON)
 option(BABYLON_NATIVE_PLUGIN_NATIVEENGINE "Include Babylon Native Plugin NativeEngine." ON)
-option(BABYLON_NATIVE_PLUGIN_NATIVEENGINE_WEBP "Include Babylon Native Plugin NativeEngine - WebP." ON)
-option(BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES "Enable image loading in NativeEngine (LoadTexture, image bitmap, bimg, WebP)." ON)
-if(NOT BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES)
-    # WebP support relies on image loading code paths; force it off when image loading is disabled.
-    set(BABYLON_NATIVE_PLUGIN_NATIVEENGINE_WEBP OFF CACHE BOOL "Include Babylon Native Plugin NativeEngine - WebP." FORCE)
-endif()
+option(BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES "Enable image loading in NativeEngine (LoadTexture, image bitmap, bimg)." ON)
 option(BABYLON_NATIVE_PLUGIN_NATIVEENGINE_COMPILESHADERS "Include Babylon Native Plugin NativeEngine - Compile Shaders." ON)
 option(BABYLON_NATIVE_PLUGIN_NATIVEINPUT "Include Babylon Native Plugin NativeInput." ON)
 option(BABYLON_NATIVE_PLUGIN_NATIVEOPTIMIZATIONS "Include Babylon Native Plugin NativeOptimizations." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,12 @@ option(BABYLON_NATIVE_PLUGIN_NATIVECAMERA "Include Babylon Native Plugin NativeC
 option(BABYLON_NATIVE_PLUGIN_NATIVECAPTURE "Include Babylon Native Plugin NativeCapture." ON)
 option(BABYLON_NATIVE_PLUGIN_NATIVEENCODING "Include Babylon Native Plugin NativeEncoding." ON)
 option(BABYLON_NATIVE_PLUGIN_NATIVEENGINE "Include Babylon Native Plugin NativeEngine." ON)
+option(BABYLON_NATIVE_PLUGIN_NATIVEENGINE_WEBP "Enable WebP image parsing in NativeEngine (via bimg)." ON)
 option(BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES "Enable image loading in NativeEngine (LoadTexture, image bitmap, bimg)." ON)
+if(NOT BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES)
+    # WebP support relies on image loading code paths; force it off when image loading is disabled.
+    set(BABYLON_NATIVE_PLUGIN_NATIVEENGINE_WEBP OFF CACHE BOOL "Enable WebP image parsing in NativeEngine (via bimg)." FORCE)
+endif()
 option(BABYLON_NATIVE_PLUGIN_NATIVEENGINE_COMPILESHADERS "Include Babylon Native Plugin NativeEngine - Compile Shaders." ON)
 option(BABYLON_NATIVE_PLUGIN_NATIVEINPUT "Include Babylon Native Plugin NativeInput." ON)
 option(BABYLON_NATIVE_PLUGIN_NATIVEOPTIMIZATIONS "Include Babylon Native Plugin NativeOptimizations." ON)

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -102,6 +102,13 @@ foreach(_bimg_target IN ITEMS bimg_decode bimg_encode tinyexr)
     endif()
 endforeach()
 
+# WebP parsing is provided by bimg's bundled simplewebp decoder. Toggle it
+# through bimg's own config macro so disabling the option compiles the parser
+# out of bimg_decode instead of pulling in a separate libwebp dependency.
+if(NOT BABYLON_NATIVE_PLUGIN_NATIVEENGINE_WEBP AND TARGET bimg_decode)
+    target_compile_definitions(bimg_decode PRIVATE BIMG_CONFIG_PARSE_WEBP=0)
+endif()
+
 if(UNIX AND NOT APPLE AND NOT ANDROID AND CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64|AMD64)")
     # The new bx requires SSE4.2 on x86_64 (see bx scripts/toolchain.lua and
     # include/bx/inline/simd128_sse.inl which uses _mm_round_ps / _mm_blendv_ps

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -279,34 +279,6 @@ if(TARGET MachineIndependent)
 endif()
 
 # --------------------------------------------------
-# WebP
-# --------------------------------------------------
-if(BABYLON_NATIVE_PLUGIN_NATIVEENGINE_WEBP)
-    set(WEBP_BUILD_ANIM_UTILS OFF)
-    set(WEBP_BUILD_CWEBP OFF)
-    set(WEBP_BUILD_DWEBP OFF)
-    set(WEBP_BUILD_GIF2WEBP OFF)
-    set(WEBP_BUILD_IMG2WEBP OFF)
-    set(WEBP_BUILD_VWEBP OFF)
-    set(WEBP_BUILD_WEBPINFO OFF)
-    set(WEBP_BUILD_LIBWEBPMUX OFF)
-    set(WEBP_BUILD_WEBPMUX OFF)
-    set(WEBP_BUILD_EXTRAS OFF)
-    FetchContent_MakeAvailable_With_Message(libwebp)
-
-    set_property(TARGET sharpyuv PROPERTY FOLDER Dependencies/libwebp)
-    set_property(TARGET webp PROPERTY FOLDER Dependencies/libwebp)
-    set_property(TARGET webpdecode PROPERTY FOLDER Dependencies/libwebp)
-    set_property(TARGET webpdecoder PROPERTY FOLDER Dependencies/libwebp)
-    set_property(TARGET webpdemux PROPERTY FOLDER Dependencies/libwebp)
-    set_property(TARGET webpdsp PROPERTY FOLDER Dependencies/libwebp)
-    set_property(TARGET webpdspdecode PROPERTY FOLDER Dependencies/libwebp)
-    set_property(TARGET webpencode PROPERTY FOLDER Dependencies/libwebp)
-    set_property(TARGET webputils PROPERTY FOLDER Dependencies/libwebp)
-    set_property(TARGET webputilsdecode PROPERTY FOLDER Dependencies/libwebp)
-endif()
-
-# --------------------------------------------------
 # WindowsAppSDK
 # --------------------------------------------------
 if(WINDOWS_STORE)

--- a/Install/Install.cmake
+++ b/Install/Install.cmake
@@ -48,11 +48,6 @@ install_lib(bimg_encode bimg_decode bgfx bimg bx minz)
 ## glslang
 install_lib(GenericCodeGen glslang glslang-default-resource-limits MachineIndependent OGLCompiler OSDependent SPIRV)
 
-## libwebp
-if(TARGET webp)
-    install_lib(webp)
-endif()
-
 ## metal-cpp
 if(APPLE)
     install_lib(metal-cpp)

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -416,6 +416,37 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \\****************************************************************************/
 ```
 
+# simplewebp
+
+```
+Copyright (c) 2010 Google Inc., 2023 Miku AuahDark
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+```
+
 # Node.js
 
 ```

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -416,40 +416,6 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \\****************************************************************************/
 ```
 
-# libwebp
-
-```
-Copyright (c) 2010, Google Inc. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-  * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-
-  * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in
-    the documentation and/or other materials provided with the
-    distribution.
-
-  * Neither the name of Google nor the names of its contributors may
-    be used to endorse or promote products derived from this software
-    without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-```
-
 # Node.js
 
 ```

--- a/Plugins/NativeEngine/CMakeLists.txt
+++ b/Plugins/NativeEngine/CMakeLists.txt
@@ -45,13 +45,6 @@ if(BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES)
         PRIVATE bimg_decode)
 endif()
 
-if(BABYLON_NATIVE_PLUGIN_NATIVEENGINE_WEBP)
-    target_compile_definitions(NativeEngine
-        PRIVATE WEBP)
-    target_link_libraries(NativeEngine
-        PRIVATE webp)
-endif()
-
 if(BABYLON_NATIVE_PLUGIN_SHADERCACHE)
     target_compile_definitions(NativeEngine
         PRIVATE SHADER_CACHE)

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -32,10 +32,6 @@
 #include <limits>
 #include <optional>
 
-#if defined(BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES) && defined(WEBP)
-#include <webp/decode.h>
-#endif
-
 namespace Babylon
 {
     namespace
@@ -196,26 +192,13 @@ namespace Babylon
         bimg::ImageContainer* ParseImage(bx::AllocatorI& allocator, gsl::span<uint8_t> data)
         {
             // Pass a bx::ErrorIgnore so bimg::imageParse reports unrecognized
-            // formats (e.g. WebP, handled by the fallback below) by returning
-            // nullptr instead of tripping its internal BX_ERROR_SCOPE assert.
-            // ErrorIgnore intentionally swallows any error that is set.
+            // or corrupt images by returning nullptr instead of tripping its
+            // internal BX_ERROR_SCOPE assert. ErrorIgnore intentionally
+            // swallows any error that is set.
             bx::ErrorIgnore parseError;
             bimg::ImageContainer* image{bimg::imageParse(&allocator, data.data(), static_cast<uint32_t>(data.size()), bimg::TextureFormat::Count, &parseError)};
             if (image == nullptr)
             {
-#ifdef WEBP
-                int width;
-                int height;
-                if (WebPGetInfo(data.data(), data.size(), &width, &height))
-                {
-                    image = bimg::imageAlloc(&allocator, bimg::TextureFormat::RGBA8, static_cast<uint16_t>(width), static_cast<uint16_t>(height), 1, 1, false, false);
-                    if (WebPDecodeRGBAInto(data.data(), data.size(), static_cast<uint8_t*>(image->m_data), static_cast<size_t>(image->m_size), width * 4))
-                    {
-                        return image;
-                    }
-                }
-#endif
-
                 throw std::runtime_error{"Failed to parse image."};
             }
 


### PR DESCRIPTION
## What

bimg now parses WebP natively via its bundled `simplewebp` decoder (`BIMG_CONFIG_PARSE_WEBP` defaults to on), so the standalone **libwebp** dependency and the WebP decode fallback in NativeEngine are now redundant. This removes them and routes WebP support through bimg.

## Changes

- Drop the `libwebp` `FetchContent` declaration (root `CMakeLists.txt`) and its dependency build block (`Dependencies/CMakeLists.txt`), and remove the `libwebp` install entry (`Install/Install.cmake`).
- **Keep** the `BABYLON_NATIVE_PLUGIN_NATIVEENGINE_WEBP` option, but repurpose it: instead of compiling the old libwebp fallback, it now toggles bimg's `BIMG_CONFIG_PARSE_WEBP` (so WebP decoding can still be disabled — `OFF` sets `BIMG_CONFIG_PARSE_WEBP=0` on `bimg_decode`). The old `WEBP` compile definition / `webp` link on the NativeEngine target are removed.
- Remove the `<webp/decode.h>` include and the `WebPGetInfo` / `WebPDecodeRGBAInto` fallback in `ParseImage`; `bimg::imageParse` now handles WebP directly.
- Replace the `libwebp` `NOTICE.md` section with a `simplewebp` entry (bimg's vendored decoder; BSD-3-Clause, © 2010 Google Inc., 2023 Miku AuahDark).

## Verification

- CMake configures with no libwebp fetch and no dangling target references.
- Playground builds clean (D3D11).
- The `EXT_texture_webp` Playground visual test passes with **no pixel difference** using bimg's decoder (`ran=1 passed=1 failed=0`). CI exercises this test on all backends.
- Rebased onto latest `master`.
