### PR TITLE
Route bx asserts and SEH crashes to stderr

### DIFF
--- a/Apps/Playground/Shared/Diagnostics.cpp
+++ b/Apps/Playground/Shared/Diagnostics.cpp
@@ -124,11 +124,19 @@ namespace
     bool OnBxAssert(const bx::Location& location, uint32_t skip, const char* format, va_list args)
     {
         // Guard against re-entry if formatting/stack-walking itself faults.
+        // Returning false here would tell bx to *continue* past the failed
+        // assert / propagate the exception, i.e. keep running in an
+        // already-failing state. Instead fail fast deterministically: skip the
+        // (faulting) formatting path, emit a minimal marker, and exit.
         static std::atomic<bool> s_inHandler{false};
         bool expected = false;
         if (!s_inHandler.compare_exchange_strong(expected, true))
         {
-            return false;
+            std::fputs("\n--- BN: CRASH (re-entrant) ---\n", stderr);
+            std::fflush(stderr);
+            Diagnostics::SetExitCode(3);
+            Diagnostics::PrintFinishLine();
+            std::_Exit(3);
         }
 
         // bx's exception-handler call sites (SEH filter, pure-call) pass

--- a/Apps/Playground/Shared/Diagnostics.cpp
+++ b/Apps/Playground/Shared/Diagnostics.cpp
@@ -1,5 +1,6 @@
 #include "Diagnostics.h"
 
+#include <bx/bx.h>
 #include <bx/debug.h>
 #include <bx/error.h>
 #include <bx/platform.h>
@@ -110,6 +111,49 @@ namespace
         std::_Exit(3);
     }
 #endif
+
+    // bx routes BOTH BX_ASSERT failures and the Windows SEH top-level
+    // exception filter (bx::installExceptionHandler) through its assert
+    // handler. bx's built-in default writes the banner only to
+    // bx::getDebugOut() (OutputDebugString), which is invisible in a console /
+    // CI run, and then tears the process down via TerminateProcess -- so the
+    // native callstack never reaches the log and atexit (the finish line)
+    // never runs. Route it through DumpFailure instead, which writes to stderr
+    // (captured by CI), then exit deterministically with code 3 like the other
+    // hard-failure handlers above.
+    bool OnBxAssert(const bx::Location& location, uint32_t skip, const char* format, va_list args)
+    {
+        // Guard against re-entry if formatting/stack-walking itself faults.
+        static std::atomic<bool> s_inHandler{false};
+        bool expected = false;
+        if (!s_inHandler.compare_exchange_strong(expected, true))
+        {
+            return false;
+        }
+
+        // bx's exception-handler call sites (SEH filter, pure-call) pass
+        // UINT32_MAX as the line and a synthetic file ("Exception Handler");
+        // real BX_ASSERT sites pass an actual file/line.
+        const bool isException = (location.line == UINT32_MAX);
+        Diagnostics::DumpFailureV(
+            isException ? "CRASH" : "ASSERT",
+            isException ? nullptr : location.filePath,
+            isException ? 0 : static_cast<int>(location.line),
+            skip,
+            format,
+            args);
+
+#if defined(_MSC_VER)
+        if (::IsDebuggerPresent())
+        {
+            bx::debugBreak();
+        }
+#endif
+
+        Diagnostics::SetExitCode(3);
+        Diagnostics::PrintFinishLine();
+        std::_Exit(3);
+    }
 }
 
 namespace Diagnostics
@@ -123,6 +167,10 @@ namespace Diagnostics
         }
 
         bx::installExceptionHandler();
+
+        // Route bx asserts + the SEH top-level exception filter to DumpFailure
+        // (stderr-visible) instead of bx's OutputDebugString-only default.
+        bx::setAssertHandler(&OnBxAssert);
 
 #if defined(_MSC_VER)
         // Route assert() to stderr instead of UCRT's modal dialog. Covers the


### PR DESCRIPTION
## What

bx''s `installExceptionHandler()` and `BX_ASSERT` both dispatch through bx''s assert handler. The built-in default writes the failure banner and native callstack **only** to `bx::getDebugOut()` (`OutputDebugString` on Windows) and then tears the process down via `TerminateProcess(1)`. In a non-headless console / CI run that means:

- the native callstack never reaches the log,
- the finish line never prints (atexit is skipped),
- and the only signal is a bare exit code `1` — indistinguishable from an uncaught JS error.

This is exactly what happened in a recent CI Validation Tests failure: the process died mid-render with exit code 1 and **no** `--- BN: ... ---` banner.

## Change

Install a Playground assert handler (`bx::setAssertHandler`) right after `bx::installExceptionHandler()` that routes **both** paths through `Diagnostics::DumpFailure` — which writes to **stderr** (captured by CI) as well as `OutputDebugString` — then exits deterministically with code `3`, matching the other hard-failure handlers in this file.

- Exception-filter invocations (`location.line == UINT32_MAX`) are labeled `CRASH`.
- Real `BX_ASSERT` sites keep their file/line and are labeled `ASSERT`.
- Re-entrancy guarded; breaks into the debugger when one is attached.

Single file, +48 lines (`Apps/Playground/Shared/Diagnostics.cpp`).

## Validation

Forced an access violation (the same mid-render SEH path) via a temporary env-gated injection (reverted before commit) and confirmed stderr now shows:

```
--- BN: CRASH ---
Access violation. Exception Code c0000005
Callstack (8):
  1: .../Apps/Playground/Win32/App.cpp  166  wWinMain
  ...
Build info: MSVC 17.0, ... C++20 ...
--- END ---
```

Exit code `3`, finish line printed.

## Notes

- This is debuggability infrastructure, independent of the JSI mid-render crash itself (a separate pre-existing/flaky issue) — this change simply makes such crashes **visible** in CI logs instead of swallowing them.
- Trade-off: the self-terminate path does not produce a WER `.dmp` (today''s default path produces none either). Preserving `.dmp` on real crashes can be a follow-up.
