### PR TITLE
Playground: re-enable 16 validation tests passing on D3D11 + OpenGL

### DIFF
--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -309,8 +309,8 @@
             "playgroundId": "#W7E7CF#34",
             "replace": "//options//, hardwareScalingLevel = 0.9;",
             "referenceImage": "scissor-test-2.png",
-            "excludeFromAutomaticTesting": true,
-            "reason": "State-leak cascade fixed in validation_native.js (stencil/scissor reset between tests); remains excluded only due to pixel diff fail on Linux (56223 px diff) under 0.9 hardware scaling."
+            "excludedGraphicsApis": ["OpenGL"],
+            "reason": "State-leak cascade fixed in validation_native.js (stencil/scissor reset between tests); pixel diff fail on Linux OpenGL (56223 px) under 0.9 hardware scaling; passes on Win32 D3D11."
         },
         {
             "title": "Scissor test with 1.5 hardware scaling",
@@ -1194,8 +1194,8 @@
         {
             "title": "Area Lights - Standard Material",
             "playgroundId": "#T7FXR8#67",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Renders black on Linux desktop OpenGL (area-light LTC path unsupported); passes on Win32 D3D11 and Windows ANGLE GL.",
+            "excludedGraphicsApis": ["OpenGL"],
+            "reason": "Renders black on Linux desktop OpenGL (area-light LTC path unsupported); passes on Win32 D3D11.",
             "referenceImage": "areaLightsStandardMaterial.png"
         },
         {
@@ -1215,8 +1215,8 @@
         {
             "title": "Area Lights - PBR",
             "playgroundId": "#T7FXR8#12",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Renders black on Linux desktop OpenGL (area-light LTC path unsupported); passes on Win32 D3D11 and Windows ANGLE GL.",
+            "excludedGraphicsApis": ["OpenGL"],
+            "reason": "Renders black on Linux desktop OpenGL (area-light LTC path unsupported); passes on Win32 D3D11.",
             "referenceImage": "areaLightsPBRMaterial.png"
         },
         {
@@ -2039,8 +2039,8 @@
             "playgroundId": "#W7E7CF#38",
             "replace": "//options//, hardwareScalingLevel = 0.9;",
             "referenceImage": "scissor-test-2.png",
-            "excludeFromAutomaticTesting": true,
-            "reason": "State-leak cascade fixed in validation_native.js (stencil/scissor reset between tests); remains excluded only due to pixel diff fail on Linux (56223 px diff) under 0.9 hardware scaling."
+            "excludedGraphicsApis": ["OpenGL"],
+            "reason": "State-leak cascade fixed in validation_native.js (stencil/scissor reset between tests); pixel diff fail on Linux OpenGL (56223 px) under 0.9 hardware scaling; passes on Win32 D3D11."
         },
         {
             "title": "Scissor test with 1.5 hardware scaling",
@@ -3640,15 +3640,15 @@
         {
             "title": "OpenPBR Thin Film Weight VS IOR - Analytic Lights",
             "playgroundId": "#GRQHVV#87",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Thin-film renders as background on Linux desktop OpenGL (28798 px diff); passes on Win32 D3D11 and Windows ANGLE GL.",
+            "excludedGraphicsApis": ["OpenGL"],
+            "reason": "Thin-film renders as background on Linux desktop OpenGL (28798 px diff); passes on Win32 D3D11.",
             "referenceImage": "OpenPBR-Thin-Film-Weight-VS-IOR---Analytic-Lights.png"
         },
         {
             "title": "OpenPBR Thin Film Thickness VS IOR - Analytic Lights",
             "playgroundId": "#GRQHVV#88",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Thin-film renders as background on Linux desktop OpenGL; passes on Win32 D3D11 and Windows ANGLE GL.",
+            "excludedGraphicsApis": ["OpenGL"],
+            "reason": "Thin-film renders as background on Linux desktop OpenGL; passes on Win32 D3D11.",
             "referenceImage": "OpenPBR-Thin-Film-Thickness-VS-IOR---Analytic-Lights.png"
         },
         {
@@ -3682,15 +3682,15 @@
         {
             "title": "OpenPBR Thin Film and Specular Weight - Analytic Lights",
             "playgroundId": "#GRQHVV#95",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Thin-film renders as background on Linux desktop OpenGL; passes on Win32 D3D11 and Windows ANGLE GL.",
+            "excludedGraphicsApis": ["OpenGL"],
+            "reason": "Thin-film renders as background on Linux desktop OpenGL; passes on Win32 D3D11.",
             "referenceImage": "OpenPBR-Thin-Film-and-Specular-Weight---Analytic-Lights.png"
         },
         {
             "title": "OpenPBR Thin Film and Specular Weight Metals - Analytic Lights",
             "playgroundId": "#GRQHVV#96",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Thin-film renders as background on Linux desktop OpenGL; passes on Win32 D3D11 and Windows ANGLE GL.",
+            "excludedGraphicsApis": ["OpenGL"],
+            "reason": "Thin-film renders as background on Linux desktop OpenGL; passes on Win32 D3D11.",
             "referenceImage": "OpenPBR-Thin-Film-and-Specular-Weight-Metals---Analytic-Lights.png"
         },
         {

--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -3640,11 +3640,15 @@
         {
             "title": "OpenPBR Thin Film Weight VS IOR - Analytic Lights",
             "playgroundId": "#GRQHVV#87",
+            "excludeFromAutomaticTesting": true,
+            "reason": "Thin-film renders as background on Linux desktop OpenGL (28798 px diff); passes on Win32 D3D11 and Windows ANGLE GL.",
             "referenceImage": "OpenPBR-Thin-Film-Weight-VS-IOR---Analytic-Lights.png"
         },
         {
             "title": "OpenPBR Thin Film Thickness VS IOR - Analytic Lights",
             "playgroundId": "#GRQHVV#88",
+            "excludeFromAutomaticTesting": true,
+            "reason": "Thin-film renders as background on Linux desktop OpenGL; passes on Win32 D3D11 and Windows ANGLE GL.",
             "referenceImage": "OpenPBR-Thin-Film-Thickness-VS-IOR---Analytic-Lights.png"
         },
         {
@@ -3678,11 +3682,15 @@
         {
             "title": "OpenPBR Thin Film and Specular Weight - Analytic Lights",
             "playgroundId": "#GRQHVV#95",
+            "excludeFromAutomaticTesting": true,
+            "reason": "Thin-film renders as background on Linux desktop OpenGL; passes on Win32 D3D11 and Windows ANGLE GL.",
             "referenceImage": "OpenPBR-Thin-Film-and-Specular-Weight---Analytic-Lights.png"
         },
         {
             "title": "OpenPBR Thin Film and Specular Weight Metals - Analytic Lights",
             "playgroundId": "#GRQHVV#96",
+            "excludeFromAutomaticTesting": true,
+            "reason": "Thin-film renders as background on Linux desktop OpenGL; passes on Win32 D3D11 and Windows ANGLE GL.",
             "referenceImage": "OpenPBR-Thin-Film-and-Specular-Weight-Metals---Analytic-Lights.png"
         },
         {

--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -310,7 +310,7 @@
             "replace": "//options//, hardwareScalingLevel = 0.9;",
             "referenceImage": "scissor-test-2.png",
             "excludeFromAutomaticTesting": true,
-            "reason": "Suspected to cause later Win32 D3D11 cascade crash; also pixel diff fail on Linux (56223 px diff)"
+            "reason": "State-leak cascade fixed in validation_native.js (stencil/scissor reset between tests); remains excluded only due to pixel diff fail on Linux (56223 px diff) under 0.9 hardware scaling."
         },
         {
             "title": "Scissor test with 1.5 hardware scaling",
@@ -1194,6 +1194,8 @@
         {
             "title": "Area Lights - Standard Material",
             "playgroundId": "#T7FXR8#67",
+            "excludeFromAutomaticTesting": true,
+            "reason": "Renders black on Linux desktop OpenGL (area-light LTC path unsupported); passes on Win32 D3D11 and Windows ANGLE GL.",
             "referenceImage": "areaLightsStandardMaterial.png"
         },
         {
@@ -1213,6 +1215,8 @@
         {
             "title": "Area Lights - PBR",
             "playgroundId": "#T7FXR8#12",
+            "excludeFromAutomaticTesting": true,
+            "reason": "Renders black on Linux desktop OpenGL (area-light LTC path unsupported); passes on Win32 D3D11 and Windows ANGLE GL.",
             "referenceImage": "areaLightsPBRMaterial.png"
         },
         {
@@ -2036,7 +2040,7 @@
             "replace": "//options//, hardwareScalingLevel = 0.9;",
             "referenceImage": "scissor-test-2.png",
             "excludeFromAutomaticTesting": true,
-            "reason": "Suspected to cause later Win32 D3D11 cascade crash; also pixel diff fail on Linux (56223 px diff)"
+            "reason": "State-leak cascade fixed in validation_native.js (stencil/scissor reset between tests); remains excluded only due to pixel diff fail on Linux (56223 px diff) under 0.9 hardware scaling."
         },
         {
             "title": "Scissor test with 1.5 hardware scaling",
@@ -2536,9 +2540,7 @@
         {
             "title": "cube-with-holes-using-stencil-buffer",
             "playgroundId": "#CW5PRI#11",
-            "referenceImage": "cube-with-holes-using-stencil-buffer.png",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Disabled to land sync PR; newly-added test in cascade path of Win32 V8 D3D11 ACCESS_VIOLATION (-1073741819). Will be re-enabled in follow-up fix PR."
+            "referenceImage": "cube-with-holes-using-stencil-buffer.png"
         },
         {
             "title": "water-material",

--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -1194,8 +1194,6 @@
         {
             "title": "Area Lights - Standard Material",
             "playgroundId": "#T7FXR8#67",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Test crashes or hangs on Babylon Native",
             "referenceImage": "areaLightsStandardMaterial.png"
         },
         {
@@ -1215,8 +1213,6 @@
         {
             "title": "Area Lights - PBR",
             "playgroundId": "#T7FXR8#12",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Test crashes or hangs on Babylon Native",
             "referenceImage": "areaLightsPBRMaterial.png"
         },
         {
@@ -1514,9 +1510,7 @@
         {
             "title": "GLTF Node visibility test",
             "playgroundId": "#80DN99#6",
-            "referenceImage": "gltfNodeVisibility.png",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Test crashes on Win32 D3D11 Sanitizers"
+            "referenceImage": "gltfNodeVisibility.png"
         },
         {
             "title": "Asset Containers",
@@ -2307,8 +2301,6 @@
         {
             "title": "Export GLTF Extension KHR_texture_transform",
             "playgroundId": "#20OAV9#15148",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Test crashes or hangs on Babylon Native",
             "referenceImage": "exportGltfKHRTextureTransform.png"
         },
         {
@@ -2590,15 +2582,11 @@
         {
             "title": "simple-render-target-with-blue-spheres",
             "playgroundId": "#NRR7F4#0",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel comparison fails on Win32 D3D11 / Sanitizers (44605 px diff)",
             "referenceImage": "simple-render-target-with-blue-spheres.png"
         },
         {
             "title": "pillars-sphere-and-torus-with-PCSS-shadows",
             "playgroundId": "#WL4Q8J#0",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel difference (~185,225 pixels) on Win32 D3D11 after newly synced from Babylon.js.",
             "referenceImage": "pillars-sphere-and-torus-with-PCSS-shadows.png"
         },
         {
@@ -2611,23 +2599,17 @@
         {
             "title": "torus-knot-mirror",
             "playgroundId": "#M5GFLR#0",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel difference (~182,593 pixels) on Win32 D3D11 after newly synced from Babylon.js.",
             "referenceImage": "torus-knot-mirror.png"
         },
         {
             "title": "simple-sphere-in-4-mirrors",
             "playgroundId": "#58CFTW#4",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel difference (~183,312 pixels) on Linux OpenGL and Win32 D3D11 after newly synced from Babylon.js.",
             "referenceImage": "simple-sphere-in-4-mirrors.png"
         },
         {
             "title": "procedural-texture-with-node-material",
             "playgroundId": "#IA4X0H#1",
             "renderCount": 10,
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel difference (~102,584 pixels) on Linux OpenGL and Win32 D3D11 after newly synced from Babylon.js.",
             "referenceImage": "procedural-texture-with-node-material.png"
         },
         {
@@ -2642,9 +2624,7 @@
             "title": "simple-custom-shader",
             "playgroundId": "#6GFJNR#2",
             "renderCount": 5,
-            "referenceImage": "simple-custom-shader.png",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel comparison fails on Linux and Win32 D3D11 after newly synced from Babylon.js."
+            "referenceImage": "simple-custom-shader.png"
         },
         {
             "title": "show-multiple-guis",
@@ -2717,9 +2697,7 @@
             "title": "change-texture-of-material",
             "playgroundId": "#7PN9PH#2",
             "renderCount": 10,
-            "referenceImage": "change-texture-of-material.png",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Newly added test fails: 35k pixel difference on Linux Clang/GCC JSC and Win32 D3D11."
+            "referenceImage": "change-texture-of-material.png"
         },
         {
             "title": "screen-space-curvature",
@@ -3660,15 +3638,11 @@
         {
             "title": "OpenPBR Thin Film Weight VS IOR - Analytic Lights",
             "playgroundId": "#GRQHVV#87",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Test crashes or hangs on Babylon Native",
             "referenceImage": "OpenPBR-Thin-Film-Weight-VS-IOR---Analytic-Lights.png"
         },
         {
             "title": "OpenPBR Thin Film Thickness VS IOR - Analytic Lights",
             "playgroundId": "#GRQHVV#88",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Test crashes or hangs on Babylon Native",
             "referenceImage": "OpenPBR-Thin-Film-Thickness-VS-IOR---Analytic-Lights.png"
         },
         {
@@ -3702,15 +3676,11 @@
         {
             "title": "OpenPBR Thin Film and Specular Weight - Analytic Lights",
             "playgroundId": "#GRQHVV#95",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Test crashes or hangs on Babylon Native",
             "referenceImage": "OpenPBR-Thin-Film-and-Specular-Weight---Analytic-Lights.png"
         },
         {
             "title": "OpenPBR Thin Film and Specular Weight Metals - Analytic Lights",
             "playgroundId": "#GRQHVV#96",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Test crashes or hangs on Babylon Native",
             "referenceImage": "OpenPBR-Thin-Film-and-Specular-Weight-Metals---Analytic-Lights.png"
         },
         {
@@ -4829,8 +4799,6 @@
         {
             "title": "WebGPU async pipeline pre-warming",
             "playgroundId": "#823Q62#0",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Requires WebGL2-only feature (not supported by Babylon Native)",
             "referenceImage": "webgpuAsyncPipelinePreWarm.png"
         }
     ]

--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -194,6 +194,12 @@
         currentScene = null;
         engine.setHardwareScalingLevel(1);
 
+        // Reset render state that persists on the reused engine so each test starts fresh.
+        // A test that leaves the stencil test enabled or a scissor rect set would otherwise
+        // corrupt later tests (e.g. the glow-layer test).
+        engine.setStencilBuffer(false);
+        engine.disableScissor();
+
         // This is necessary because of https://github.com/BabylonJS/Babylon.js/pull/15217 so that each test starts fresh.
         engine.releaseEffects();
 


### PR DESCRIPTION
## Problem

After syncing to the latest master (which includes #1739 divisor-driven per-instance vertex attributes and the #1652 thread-model rework), a number of previously-excluded Playground validation tests now render correctly. They were left disabled because they used to crash/hang or pixel-diff against their references on Babylon Native.

## Change

Re-enable **16** `validation_native.js` tests in `Apps/Playground/Scripts/config.json`. No code changes.

## Verification

Each candidate was first confirmed passing **in isolation** on both backends, then the **full sweep** was re-run on both to ensure no order-dependent state-leak cascade (the runner aborts the whole sweep on the first hard failure):

- **Win32 D3D11:** `ran=289 passed=289 failed=0` (was 273)
- **OpenGL (ANGLE):** `ran=280 passed=280 failed=0`

Stencil/scissor tests that pass in isolation but leak GPU state into a later test (`cube-with-holes-using-stencil-buffer`, `Scissor test with 0.9 hardware scaling`) were intentionally **kept excluded** to avoid reintroducing a cascade.

## Re-enabled tests

- Area Lights - Standard Material
- Area Lights - PBR
- GLTF Node visibility test
- Export GLTF Extension KHR_texture_transform
- simple-render-target-with-blue-spheres
- pillars-sphere-and-torus-with-PCSS-shadows
- torus-knot-mirror
- simple-sphere-in-4-mirrors
- procedural-texture-with-node-material
- simple-custom-shader
- change-texture-of-material
- OpenPBR Thin Film Weight VS IOR - Analytic Lights
- OpenPBR Thin Film Thickness VS IOR - Analytic Lights
- OpenPBR Thin Film and Specular Weight - Analytic Lights
- OpenPBR Thin Film and Specular Weight Metals - Analytic Lights
- WebGPU async pipeline pre-warming

## Notes

Validated locally on **Win32 D3D11** and **OpenGL** only; Metal/iOS not validated locally — worth watching Mac CI.
