### PR TITLE
Drain in-flight graphics tasks before NativeEngine teardown

### DIFF
--- a/Apps/UnitTests/CMakeLists.txt
+++ b/Apps/UnitTests/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SOURCES
     "Source/Tests.ExternalTexture.Msaa.cpp"
     "Source/Tests.ExternalTexture.Render.cpp"
     "Source/Tests.JavaScript.cpp"
+    "Source/Tests.NativeEngine.Teardown.cpp"
     "Source/Tests.ShaderCache.cpp"
     "Source/Tests.ShaderCompilation.cpp"
     "Source/Tests.UniformPadding.cpp"

--- a/Apps/UnitTests/Source/Tests.NativeEngine.Teardown.cpp
+++ b/Apps/UnitTests/Source/Tests.NativeEngine.Teardown.cpp
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+
+#include <Babylon/AppRuntime.h>
+#include <Babylon/Graphics/Device.h>
+#include <Babylon/Plugins/NativeEngine.h>
+
+#include <chrono>
+#include <future>
+#include <iostream>
+#include <thread>
+
+extern Babylon::Graphics::Configuration g_deviceConfig;
+
+namespace Babylon::Plugins
+{
+    // Test-only accessors defined in NativeEngine.cpp (compiled in when BABYLON_NATIVE_BUILD_APPS
+    // is set). The native engine exposes a JS method "_disposeDrainTestSchedule" that schedules a
+    // tracked threadpool task which sets "started", sleeps, then sets "finished".
+    bool NativeEngineDisposeDrainTestTaskStarted();
+    bool NativeEngineDisposeDrainTestTaskFinished();
+}
+
+// Regression test for the loadTexture async-teardown race. NativeEngine::Dispose must drain
+// in-flight threadpool tasks (created via TrackAsyncTask, the same mechanism the async texture
+// and shader loaders use) before teardown frees the resources those tasks touch.
+//
+// The native engine's test-only "_disposeDrainTestSchedule" schedules such a tracked task that
+// signals start, sleeps, then signals finish. We let it get in flight, dispose the engine, and
+// then check whether it had finished by the time Dispose returned:
+//   * With the drain, Dispose blocks until the task finishes      -> finished == true.
+//   * Without it, Dispose returns while the task is still running -> finished == false.
+// The task touches no graphics resources, so the test is deterministic and never relies on
+// undefined behaviour.
+TEST(NativeEngineTeardown, DisposeDrainsInFlightAsyncTask)
+{
+    Babylon::Graphics::Device device{g_deviceConfig};
+    device.StartRenderingCurrentFrame();
+
+    Babylon::AppRuntime::Options options{};
+    options.UnhandledExceptionHandler = [](const Napi::Error& error) {
+        std::cerr << "[Uncaught Error] " << Napi::GetErrorString(error) << std::endl;
+        std::quick_exit(1);
+    };
+
+    Babylon::AppRuntime runtime{options};
+
+    // Create a native engine and schedule the in-flight tracked task.
+    runtime.Dispatch([&device](Napi::Env env) {
+        device.AddToJavaScript(env);
+        Babylon::Plugins::NativeEngine::Initialize(env);
+
+        auto nativeObject = env.Global().Get("_native").As<Napi::Object>();
+        auto engine = nativeObject.Get("Engine").As<Napi::Function>().New({});
+        env.Global().Set("_testEngine", engine);
+        engine.Get("_disposeDrainTestSchedule").As<Napi::Function>().Call(engine, {});
+    });
+
+    // Wait until the task is actually in flight (running on the threadpool).
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+    while (!Babylon::Plugins::NativeEngineDisposeDrainTestTaskStarted() && std::chrono::steady_clock::now() < deadline)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ASSERT_TRUE(Babylon::Plugins::NativeEngineDisposeDrainTestTaskStarted())
+        << "async task never started; cannot exercise the teardown drain";
+    ASSERT_FALSE(Babylon::Plugins::NativeEngineDisposeDrainTestTaskFinished())
+        << "async task finished before dispose; increase the task delay";
+
+    // Dispose the engine on the JS thread while the task is in flight. With the drain in place,
+    // dispose() blocks until the task completes before returning.
+    std::promise<void> disposed;
+    runtime.Dispatch([&disposed](Napi::Env env) {
+        auto engine = env.Global().Get("_testEngine").As<Napi::Object>();
+        engine.Get("dispose").As<Napi::Function>().Call(engine, {});
+        disposed.set_value();
+    });
+    disposed.get_future().wait();
+
+    // If Dispose drained the in-flight task, it has finished by the time dispose() returned.
+    EXPECT_TRUE(Babylon::Plugins::NativeEngineDisposeDrainTestTaskFinished())
+        << "NativeEngine::Dispose returned while an async task was still in flight (drain missing)";
+
+    device.FinishRenderingCurrentFrame();
+}

--- a/Plugins/NativeEngine/CMakeLists.txt
+++ b/Plugins/NativeEngine/CMakeLists.txt
@@ -73,5 +73,11 @@ endif()
 target_compile_definitions(NativeEngine
     PRIVATE $<UPPER_CASE:${GRAPHICS_API}>)
 
+# Expose test-only hooks (used by Apps/UnitTests) when building apps; excluded from consumer builds.
+if(BABYLON_NATIVE_BUILD_APPS)
+    target_compile_definitions(NativeEngine
+        PUBLIC BABYLON_NATIVE_NATIVEENGINE_TEST_HOOKS)
+endif()
+
 set_property(TARGET NativeEngine PROPERTY FOLDER Plugins)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -774,6 +774,37 @@ namespace Babylon
         m_deviceContext.SetRenderResetCallback(nullptr);
 
         m_cancellationSource->cancel();
+
+        // Cancellation doesn't stop work already running on a threadpool thread, so wait for
+        // any in-flight graphics tasks to finish before teardown frees the resources they use.
+        m_asyncTaskTracker->Wait();
+    }
+
+    NativeEngine::AsyncTaskTracker::Scope::Scope(std::shared_ptr<AsyncTaskTracker> tracker)
+        : m_tracker{std::move(tracker)}
+    {
+        std::lock_guard<std::mutex> lock{m_tracker->m_mutex};
+        ++m_tracker->m_count;
+    }
+
+    NativeEngine::AsyncTaskTracker::Scope::~Scope()
+    {
+        {
+            std::lock_guard<std::mutex> lock{m_tracker->m_mutex};
+            --m_tracker->m_count;
+        }
+        m_tracker->m_condition.notify_all();
+    }
+
+    void NativeEngine::AsyncTaskTracker::Wait()
+    {
+        std::unique_lock<std::mutex> lock{m_mutex};
+        m_condition.wait(lock, [this]() { return m_count == 0; });
+    }
+
+    std::shared_ptr<void> NativeEngine::TrackAsyncTask()
+    {
+        return std::make_shared<AsyncTaskTracker::Scope>(m_asyncTaskTracker);
     }
 
     void NativeEngine::Dispose(const Napi::CallbackInfo& /*info*/)
@@ -984,7 +1015,12 @@ namespace Babylon
         program->SetSources(vertexSource, fragmentSource);
 
         arcana::make_task(arcana::threadpool_scheduler, *m_cancellationSource,
-            [this, vertexSource = std::move(vertexSource), fragmentSource = std::move(fragmentSource), program, cancellationSource{m_cancellationSource}]() {
+            [this, vertexSource = std::move(vertexSource), fragmentSource = std::move(fragmentSource), program, cancellationSource{m_cancellationSource}, asyncTaskScope{TrackAsyncTask()}]() {
+                // Skip touching graphics resources if teardown has already begun.
+                if (cancellationSource->cancelled())
+                {
+                    return;
+                }
                 program->Initialize(m_shaderProvider.Get(vertexSource, fragmentSource));
             })
             .then(m_runtimeScheduler, *m_cancellationSource, [jsProgramRef{Napi::Persistent(jsProgram)}, onSuccessRef{Napi::Persistent(onSuccess)}, onErrorRef{Napi::Persistent(onError)}, cancellationSource{m_cancellationSource}](const arcana::expected<void, std::exception_ptr>& result) {
@@ -1334,7 +1370,12 @@ namespace Babylon
         const auto dataSpan = gsl::make_span(static_cast<uint8_t*>(data.ArrayBuffer().Data()) + data.ByteOffset(), data.ByteLength());
 
         arcana::make_task(arcana::threadpool_scheduler, *m_cancellationSource,
-            [dataSpan, generateMips, invertY, srgb, texture, cancellationSource{m_cancellationSource}]() {
+            [dataSpan, generateMips, invertY, srgb, texture, cancellationSource{m_cancellationSource}, asyncTaskScope{TrackAsyncTask()}]() {
+                // Skip touching graphics resources if teardown has already begun.
+                if (cancellationSource->cancelled())
+                {
+                    return;
+                }
                 arcana::trace_region loadRegion{"NativeEngine::LoadTexture"};
                 bimg::ImageContainer* image{ParseImage(Graphics::DeviceContext::GetDefaultAllocator(), dataSpan)};
                 image = PrepareImage(Graphics::DeviceContext::GetDefaultAllocator(), image, invertY, srgb, generateMips);
@@ -1499,7 +1540,7 @@ namespace Babylon
         }
 
         arcana::when_all(gsl::make_span(tasks))
-            .then(arcana::inline_scheduler, *m_cancellationSource, [texture, srgb, cancellationSource{m_cancellationSource}](std::vector<bimg::ImageContainer*> images) {
+            .then(arcana::inline_scheduler, *m_cancellationSource, [texture, srgb, cancellationSource{m_cancellationSource}, asyncTaskScope{TrackAsyncTask()}](std::vector<bimg::ImageContainer*> images) {
                 LoadCubeTextureFromImages(texture, images, srgb);
             })
             .then(m_runtimeScheduler, *m_cancellationSource, [dataRefs{std::move(dataRefs)}, onSuccessRef{Napi::Persistent(onSuccess)}, onErrorRef{Napi::Persistent(onError)}, cancellationSource{m_cancellationSource}](arcana::expected<void, std::exception_ptr> result) {
@@ -1547,7 +1588,7 @@ namespace Babylon
         }
 
         arcana::when_all(gsl::make_span(tasks))
-            .then(arcana::inline_scheduler, *m_cancellationSource, [texture, srgb, cancellationSource{m_cancellationSource}](std::vector<bimg::ImageContainer*> images) {
+            .then(arcana::inline_scheduler, *m_cancellationSource, [texture, srgb, cancellationSource{m_cancellationSource}, asyncTaskScope{TrackAsyncTask()}](std::vector<bimg::ImageContainer*> images) {
                 LoadCubeTextureFromImages(texture, images, srgb);
             })
             .then(m_runtimeScheduler, *m_cancellationSource, [dataRefs{std::move(dataRefs)}, onSuccessRef{Napi::Persistent(onSuccess)}, onErrorRef{Napi::Persistent(onError)}, cancellationSource{m_cancellationSource}](arcana::expected<void, std::exception_ptr> result) {

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -32,6 +32,11 @@
 #include <limits>
 #include <optional>
 
+#ifdef BABYLON_NATIVE_NATIVEENGINE_TEST_HOOKS
+#include <atomic>
+#include <chrono>
+#include <thread>
+#endif
 namespace Babylon
 {
     namespace
@@ -684,6 +689,9 @@ namespace Babylon
                 StaticValue("COMMAND_COPYTEXTURE", Napi::FunctionPointer::Create(env, &NativeEngine::CopyTexture)),
 
                 InstanceMethod("dispose", &NativeEngine::Dispose),
+#ifdef BABYLON_NATIVE_NATIVEENGINE_TEST_HOOKS
+                InstanceMethod("_disposeDrainTestSchedule", &NativeEngine::DisposeDrainTestSchedule),
+#endif
 
                 InstanceMethod("requestAnimationFrame", &NativeEngine::RequestAnimationFrame),
 
@@ -2512,4 +2520,40 @@ namespace Babylon
         assert(encoder != nullptr);
         return encoder;
     }
+
+#ifdef BABYLON_NATIVE_NATIVEENGINE_TEST_HOOKS
+    static std::atomic<bool> s_disposeDrainTestTaskStarted{false};
+    static std::atomic<bool> s_disposeDrainTestTaskFinished{false};
+
+    // Test-only: schedules a tracked threadpool task (the same TrackAsyncTask mechanism used by
+    // the async texture/shader loaders) that signals start, sleeps, then signals finish. The task
+    // touches no graphics resources, so the test can observe purely whether Dispose drains it.
+    void NativeEngine::DisposeDrainTestSchedule(const Napi::CallbackInfo&)
+    {
+        s_disposeDrainTestTaskStarted = false;
+        s_disposeDrainTestTaskFinished = false;
+        arcana::make_task(arcana::threadpool_scheduler, *m_cancellationSource,
+            [asyncTaskScope{TrackAsyncTask()}]() {
+                s_disposeDrainTestTaskStarted = true;
+                std::this_thread::sleep_for(std::chrono::milliseconds(500));
+                s_disposeDrainTestTaskFinished = true;
+            });
+    }
+#endif
 }
+
+#ifdef BABYLON_NATIVE_NATIVEENGINE_TEST_HOOKS
+namespace Babylon::Plugins
+{
+    // Test-only accessors for the DisposeDrainTestSchedule task state (see NativeEngine.cpp).
+    bool NativeEngineDisposeDrainTestTaskStarted()
+    {
+        return ::Babylon::s_disposeDrainTestTaskStarted.load();
+    }
+
+    bool NativeEngineDisposeDrainTestTaskFinished()
+    {
+        return ::Babylon::s_disposeDrainTestTaskFinished.load();
+    }
+}
+#endif

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -25,7 +25,10 @@
 #include <gsl/gsl>
 
 #include <arcana/threading/cancellation.h>
+#include <condition_variable>
 #include <map>
+#include <memory>
+#include <mutex>
 #include <optional>
 
 namespace Babylon
@@ -137,6 +140,42 @@ namespace Babylon
         Graphics::FrameBuffer& GetBoundFrameBuffer();
 
         std::shared_ptr<arcana::cancellation_source> m_cancellationSource{};
+
+        // Tracks in-flight threadpool work that touches graphics resources (bgfx handles,
+        // textures, the shader provider). Cancellation only short-circuits scheduling, so a
+        // task already running on a threadpool thread keeps going; Dispose() drains these
+        // before teardown frees the resources they reference.
+        struct AsyncTaskTracker
+        {
+            // RAII token: increments the in-flight count on construction and decrements it
+            // (notifying any waiter) on destruction. Counting is tied to the token's lifetime
+            // so the Enter/Leave pair can never be split by an exception.
+            struct Scope
+            {
+                explicit Scope(std::shared_ptr<AsyncTaskTracker> tracker);
+                ~Scope();
+                Scope(const Scope&) = delete;
+                Scope& operator=(const Scope&) = delete;
+
+            private:
+                std::shared_ptr<AsyncTaskTracker> m_tracker;
+            };
+
+            // Blocks until the in-flight count reaches zero.
+            void Wait();
+
+        private:
+            std::mutex m_mutex{};
+            std::condition_variable m_condition{};
+            uint32_t m_count{};
+        };
+
+        std::shared_ptr<AsyncTaskTracker> m_asyncTaskTracker{std::make_shared<AsyncTaskTracker>()};
+
+        // Returns an RAII token whose destruction marks the tracked task complete. Call on the
+        // JS thread and capture the token into the graphics-touching lambda; it decrements when
+        // the lambda runs or is discarded on cancellation.
+        std::shared_ptr<void> TrackAsyncTask();
 
         ShaderProvider m_shaderProvider{};
 

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -49,6 +49,11 @@ namespace Babylon
         void Dispose();
 
         void Dispose(const Napi::CallbackInfo& info);
+#ifdef BABYLON_NATIVE_NATIVEENGINE_TEST_HOOKS
+        // Test-only: schedules a tracked threadpool task that signals start, sleeps, then signals
+        // finish, so unit tests can verify Dispose drains in-flight async work. See NativeEngine.cpp.
+        void DisposeDrainTestSchedule(const Napi::CallbackInfo& info);
+#endif
         void RequestAnimationFrame(const Napi::CallbackInfo& info);
         Napi::Value CreateVertexArray(const Napi::CallbackInfo& info);
         void DeleteVertexArray(NativeDataStream::Reader& data);


### PR DESCRIPTION
### Problem

`NativeEngine::Dispose` only called `m_cancellationSource->cancel()`. arcana cancellation short-circuits work at **scheduling** boundaries, but a task body that is **already running** on a threadpool thread keeps going to completion.

The graphics-loading entry points (`loadProgram`, `loadTexture`, `loadCubeTexture`) schedule their work as threadpool tasks that capture a raw `Graphics::Texture*` / call into bgfx. On app teardown, if the suite finishes while one of these bodies is mid-flight, `Dispose` cancels and teardown proceeds to free the texture / tear down the bgfx context — and the still-running task then touches freed resources, causing an access violation:

```
Access violation. Exception Code c0000005
  2: Plugins/NativeEngine/Source/NativeEngine.cpp  LoadTextureFromImage
  3: arcana .../internal_task.h  output_wrapper<...>::invoke<...LoadTexture...lambda...>
  ...
  6: cppwinrt .../Windows.System.Threading.h  WorkItemHandler::Invoke
```

This reproduces at shutdown, after the test run reports it finished.

### Fix

Add a small `AsyncTaskTracker` (mutex + condition_variable + counter) whose RAII `Scope` token is captured into the four graphics-touching threadpool lambdas (the `loadProgram` body, the `loadTexture` body, and the two `LoadCubeTextureFromImages` inline continuations). The CPU-only image-parse bodies are intentionally not tracked.

`Dispose` now cancels and then **waits** for those tokens to drain before returning, so teardown can't free graphics resources out from under a running task. The token decrements on the threadpool thread (never on a JS-thread `.then` continuation), so `Dispose` — which runs on the JS thread — can never deadlock waiting on its own continuations. Counting is bound to the token's lifetime, so the increment/decrement pair can't be split by an exception.

A defensive `if (cancellationSource->cancelled()) return;` early-out is also added at the top of the two threadpool load bodies, so once teardown has begun they skip touching graphics resources entirely.

### Testing

- `NativeEngine` and `Playground` build clean (RelWithDebInfo, x64, D3D11).
- Ran the previously-crashing `Sprites` test (`loadTexture` path) and a cubemap test (`LoadCubeTextureFromImages` path) headless — both exercise the load paths and tear down promptly with no hang and no crash.
