### PR TITLE
Re-enable blur-cube-with-the-effect-renderer validation test

### DIFF
--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -2583,8 +2583,6 @@
             "title": "blur-cube-with-the-effect-renderer",
             "playgroundId": "#4C900K#2",
             "renderCount": 20,
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel comparison fails (more than 20% pixels differ)",
             "referenceImage": "blur-cube-with-the-effect-renderer.png"
         },
         {


### PR DESCRIPTION
# Re-enable `blur-cube-with-the-effect-renderer` validation test

## What

Removes the `excludeFromAutomaticTesting` flag from the
`blur-cube-with-the-effect-renderer` Playground validation test
(`Apps/Playground/Scripts/config.json`) so it runs in the automatic suite again.

## Why

The test renders an `EffectRenderer` / `EffectWrapper` fullscreen pass and used to
produce an all-black frame on Babylon Native, failing the pixel comparison. Root cause
was in the **native engine**: `EffectRenderer` disables depth testing through
`engine.depthCullingState.depthTest = false`, but the native engine only honored depth
state set via the explicit `setDepthBuffer()` command and never flushed
`depthCullingState` at draw time (unlike the WebGL/WebGPU `applyStates()` path). The
fullscreen quad therefore kept the previous draw's depth test and every fragment was
discarded.

Fixed upstream in the native engine:

- Babylon.js PR: https://github.com/BabylonJS/Babylon.js/pull/18558 (branch `native-honor-depthcullingstate-depthtest`)

> Depends on the above Babylon.js fix being released and the `babylonjs` dependency bumped
> to a version that contains it. Until then this PR is a draft — CI will only pass once the
> updated dependency is in place. (Verified locally against a patched native engine: see
> below.)

## Verification (local, against the patched native engine)

- `blur-cube-with-the-effect-renderer` now runs through the normal path (no
  `--include-excluded`) and passes:
  `Test 'blur-cube-with-the-effect-renderer' validated`.
- Full standard validation sweep: `ran=274 passed=274 failed=0` — no regressions, and the
  re-enabled test is included.
- Scope check: this is the only excluded validation test fixed by the native-engine change
  (the other `EffectWrapper`-based excluded tests — the `Atmosphere *` set — still fail for
  unrelated reasons and remain excluded).
