### PR TITLE
NativeEngine: load single-file .dds/.ktx/.ktx2 cubemaps + spherical harmonics (re-enables 7 tests)

### DIFF
--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -858,8 +858,6 @@
         {
             "title": "NMEGLTF",
             "playgroundId": "#WGZLGJ#10320",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel comparison fails (more than 20% pixels differ)",
             "referenceImage": "nmegltf.png"
         },
         {
@@ -1056,15 +1054,11 @@
         {
             "title": "Anisotropic",
             "playgroundId": "#MAXCNU#1",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel comparison fails (more than 20% pixels differ)",
             "referenceImage": "anisotropic.png"
         },
         {
             "title": "Clear Coat",
             "playgroundId": "#YACNQS#2",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel comparison fails (more than 20% pixels differ)",
             "referenceImage": "clearCoat.png"
         },
         {
@@ -1571,22 +1565,16 @@
         {
             "title": "PBRMetallicRoughnessMaterial",
             "playgroundId": "#2FDQT5#13",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel comparison fails (more than 20% pixels differ)",
             "referenceImage": "PBRMetallicRoughnessMaterial.png"
         },
         {
             "title": "PBRSpecularGlossinessMaterial",
             "playgroundId": "#Z1VL3V#4",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel comparison fails (more than 20% pixels differ)",
             "referenceImage": "PBRSpecularGlossinessMaterial.png"
         },
         {
             "title": "PBR",
             "playgroundId": "#LCA0Q4#27",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel comparison fails (more than 20% pixels differ)",
             "referenceImage": "pbr.png"
         },
         {

--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -2563,8 +2563,6 @@
             "title": "blur-cube-with-the-effect-renderer",
             "playgroundId": "#4C900K#2",
             "renderCount": 20,
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel comparison fails (more than 20% pixels differ)",
             "referenceImage": "blur-cube-with-the-effect-renderer.png"
         },
         {

--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -11,13 +11,13 @@
         "UnitTests/JavaScript"
       ],
       "dependencies": {
-        "babylonjs": "^9.3.4",
-        "babylonjs-addons": "^9.3.4",
-        "babylonjs-gltf2interface": "^9.3.4",
-        "babylonjs-gui": "^9.3.4",
-        "babylonjs-loaders": "^9.3.4",
-        "babylonjs-materials": "^9.3.4",
-        "babylonjs-serializers": "^9.3.4",
+        "babylonjs": "^9.15.0",
+        "babylonjs-addons": "^9.15.0",
+        "babylonjs-gltf2interface": "^9.15.0",
+        "babylonjs-gui": "^9.15.0",
+        "babylonjs-loaders": "^9.15.0",
+        "babylonjs-materials": "^9.15.0",
+        "babylonjs-serializers": "^9.15.0",
         "jsc-android": "^241213.1.0",
         "v8-android": "^7.8.2"
       }
@@ -2596,63 +2596,63 @@
       }
     },
     "node_modules/babylonjs": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-9.9.1.tgz",
-      "integrity": "sha512-zMH8r0l/il9PJhy2+uS+/EyeLBy/ElZg0lKLj2d+ZrUarOanjMISaACw0HUx7C1EgYoXUFSMQLYcpXguleh8GA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-9.15.0.tgz",
+      "integrity": "sha512-IJQhrxsxxj4KCg4aSsB5chLidzAfbghr8rnzo6sRLFin6ipfeayCxg7MevjaMzqdVmc/BOMU6sj49nSNrBq+yQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-addons": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-addons/-/babylonjs-addons-9.9.1.tgz",
-      "integrity": "sha512-Hi9QZqeanqG+4VAAmJmHJh7JKf1bc/Y5Ml+wuv+W+3f/dKltZpy/pii/QN4vhYRyrU0n+S8OJc+kVeaUUFjHEg==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-addons/-/babylonjs-addons-9.15.0.tgz",
+      "integrity": "sha512-7vxm0ffFXWHCZWDlYYleifb6mg1iSH7nNo+sA9706z7QIfpNnLS9+9cTYadWobvhURwaD/DHAKnm7Z8ckq9YAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1"
+        "babylonjs": "9.15.0"
       }
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.9.1.tgz",
-      "integrity": "sha512-qHE7pASEWbRORU+NEPSSL9fyVh6gBNqC1ugV94YL9Dz0HnLcH8YNcxdi6Pf+oXgFHRrXWZiJATn37HynsF7/0g==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.15.0.tgz",
+      "integrity": "sha512-Yr/WvOvnsZFN2LoyNU/ZZbT+lXMdNA9OiZzE4RibI1tnYxQjpPKT6X1cxQ/ACJPVzKwudxzJxQ/f/Tdba4TLDg==",
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-gui": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-9.9.1.tgz",
-      "integrity": "sha512-w6HSvuHSqLYUOuxvko+gkjAQMvatf7gnOPufLRslm+P4tC+5KMEd0hyC+1vHCJuQmZXXkoc/GnozzFeaqllHZw==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-9.15.0.tgz",
+      "integrity": "sha512-klF2ywhA040JMQ3Z5XaGkN4S0GIOshtnvtUd8kbYqlLYEu5i6/y/zvB8V3O4geslzV0kWcBe2mIthlr7M7p4og==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1"
+        "babylonjs": "9.15.0"
       }
     },
     "node_modules/babylonjs-loaders": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-9.9.1.tgz",
-      "integrity": "sha512-bFSe4TQTi7aA7RsWmuZHQLX4mBMoza5D+AFRD2tVrizGyGCfQJALKnKze7Z3OetFyeo72838GXJAXmyiOWcxAA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-9.15.0.tgz",
+      "integrity": "sha512-k5Kg9wmuy0n4ZAWu9woFk3C1yEwSvQHRv0Ct2GOQtuRvIHUIyRcW4KEKOsW0GOiApSjXh9nQcabdJTnUo8IBNw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1",
-        "babylonjs-gltf2interface": "9.9.1"
+        "babylonjs": "9.15.0",
+        "babylonjs-gltf2interface": "9.15.0"
       }
     },
     "node_modules/babylonjs-materials": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-9.9.1.tgz",
-      "integrity": "sha512-2ai5hk59dzHRUN28/5/Nijknn+IungSuoBsrHrNZE2T/yIT+/T/IrU0ebm53nRYliv6NG0IaxSCfnh6euZUj7A==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-9.15.0.tgz",
+      "integrity": "sha512-E9C5EB0nZJrGvT7Mb38gypAnzi1q8vr/Gi+fTeqRQilIU8mdk+YzD5unfKOROEv8arRFCXGWrtBqkIN8k2PFxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1"
+        "babylonjs": "9.15.0"
       }
     },
     "node_modules/babylonjs-serializers": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.9.1.tgz",
-      "integrity": "sha512-nZJPplzHprwJhp4JVLgB3dEpJR2HvEElPIDvOoAFf1IcaKwcDja2tZTGXIbARdWlTX547pN0qN/vEd6dYLrnDA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.15.0.tgz",
+      "integrity": "sha512-iLYwPzZrUr2SnwHcsXjHJHYdJIVC+boW6z/olE0mE5GvqmfKXTtqFr9wRGrsq85BarhHQkfVlfQdFwhFq/JG4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1",
-        "babylonjs-gltf2interface": "9.9.1"
+        "babylonjs": "9.15.0",
+        "babylonjs-gltf2interface": "9.15.0"
       }
     },
     "node_modules/balanced-match": {

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -9,13 +9,13 @@
     "getNightly": "node scripts/getNightly.js"
   },
   "dependencies": {
-    "babylonjs": "^9.3.4",
-    "babylonjs-addons": "^9.3.4",
-    "babylonjs-gltf2interface": "^9.3.4",
-    "babylonjs-gui": "^9.3.4",
-    "babylonjs-loaders": "^9.3.4",
-    "babylonjs-materials": "^9.3.4",
-    "babylonjs-serializers": "^9.3.4",
+    "babylonjs": "^9.15.0",
+    "babylonjs-addons": "^9.15.0",
+    "babylonjs-gltf2interface": "^9.15.0",
+    "babylonjs-gui": "^9.15.0",
+    "babylonjs-loaders": "^9.15.0",
+    "babylonjs-materials": "^9.15.0",
+    "babylonjs-serializers": "^9.15.0",
     "jsc-android": "^241213.1.0",
     "v8-android": "^7.8.2"
   }

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -31,6 +31,7 @@
 #include <cmath>
 #include <limits>
 #include <optional>
+#include <array>
 
 #ifdef BABYLON_NATIVE_NATIVEENGINE_TEST_HOOKS
 #include <atomic>
@@ -413,6 +414,241 @@ namespace Babylon
                             const bgfx::Memory* mem{bgfx::makeRef(imageMip.m_data, imageMip.m_size, releaseFn, image)};
                             texture->UpdateCube(0, side, mip, 0, 0, static_cast<uint16_t>(imageMip.m_width), static_cast<uint16_t>(imageMip.m_height), mem);
                         }
+                    }
+                }
+            }
+        }
+        // Parse a single self-contained cubemap container (e.g. .dds / .ktx /
+        // .ktx2) that already holds all six faces and their mip chain. bimg
+        // decodes these natively, so there is no need to split into six images
+        // on the JS side. Unlike ParseImage (which targets single-face 2D images
+        // and asserts !m_cubeMap), this keeps the container as-is.
+        bimg::ImageContainer* ParseCubeImage(bx::AllocatorI& allocator, gsl::span<uint8_t> data)
+        {
+            bx::ErrorIgnore parseError;
+            bimg::ImageContainer* image{bimg::imageParse(&allocator, data.data(), static_cast<uint32_t>(data.size()), bimg::TextureFormat::Count, &parseError)};
+            if (image == nullptr)
+            {
+                throw std::runtime_error{"Failed to parse cube image."};
+            }
+
+            if (!image->m_cubeMap)
+            {
+                bimg::imageFree(image);
+                throw std::runtime_error{"Image is not a cubemap."};
+            }
+
+            return image;
+        }
+
+        // Port of Babylon.js CubeMapToSphericalPolynomialTools.ConvertCubeMapToSphericalPolynomial.
+        // Prefiltered .dds environments need diffuse-IBL spherical harmonics, which Babylon's WebGL
+        // path computes on the CPU from the top-mip faces. The native engine cannot read cube faces
+        // back from the GPU (_readTexturePixels throws for cube faces), so we compute the harmonics
+        // here from the bimg-decoded top mip. Returns the 9x3 polynomial coefficients in
+        // SphericalPolynomial.FromArray order: x, y, z, xx, yy, zz, yz, zx, xy.
+        std::array<float, 27> ComputeCubeSphericalPolynomial(bx::AllocatorI& allocator, bimg::ImageContainer* image)
+        {
+            std::array<float, 27> result{};
+
+            bimg::ImageContainer* f32{bimg::imageConvert(&allocator, bimg::TextureFormat::RGBA32F, *image, false)};
+            if (f32 == nullptr)
+            {
+                return result;
+            }
+
+            const uint32_t size{f32->m_width};
+            constexpr double pi{3.14159265358979323846};
+
+            // Face orientations matching Babylon's _FileFaces, indexed by bimg cube side order
+            // (+X, -X, +Y, -Y, +Z, -Z): worldAxisForNormal, worldAxisForFileX, worldAxisForFileY.
+            struct FaceAxes
+            {
+                double n[3];
+                double fx[3];
+                double fy[3];
+            };
+            static const FaceAxes faces[6] = {
+                {{1, 0, 0}, {0, 0, -1}, {0, -1, 0}},  // +X right
+                {{-1, 0, 0}, {0, 0, 1}, {0, -1, 0}},  // -X left
+                {{0, 1, 0}, {1, 0, 0}, {0, 0, 1}},    // +Y up
+                {{0, -1, 0}, {1, 0, 0}, {0, 0, -1}},  // -Y down
+                {{0, 0, 1}, {1, 0, 0}, {0, -1, 0}},   // +Z front
+                {{0, 0, -1}, {-1, 0, 0}, {0, -1, 0}}, // -Z back
+            };
+
+            const double shConst[9] = {
+                std::sqrt(1.0 / (4.0 * pi)),
+                -std::sqrt(3.0 / (4.0 * pi)),
+                std::sqrt(3.0 / (4.0 * pi)),
+                -std::sqrt(3.0 / (4.0 * pi)),
+                std::sqrt(15.0 / (4.0 * pi)),
+                -std::sqrt(15.0 / (4.0 * pi)),
+                std::sqrt(5.0 / (16.0 * pi)),
+                -std::sqrt(15.0 / (4.0 * pi)),
+                std::sqrt(15.0 / (16.0 * pi)),
+            };
+            const double cosKernel[9] = {pi, 2.0 * pi / 3.0, 2.0 * pi / 3.0, 2.0 * pi / 3.0, pi / 4.0, pi / 4.0, pi / 4.0, pi / 4.0, pi / 4.0};
+
+            const auto areaElement = [](double x, double y) { return std::atan2(x * y, std::sqrt(x * x + y * y + 1.0)); };
+
+            double sh[9][3] = {};
+            double totalSolidAngle{0.0};
+
+            const double du{2.0 / static_cast<double>(size)};
+            const double halfTexel{0.5 * du};
+            const double minUV{halfTexel - 1.0};
+            const double maxHdri{4096.0};
+
+            for (uint16_t side = 0; side < 6; ++side)
+            {
+                bimg::ImageMip mip{};
+                if (!bimg::imageGetRawData(*f32, side, 0, f32->m_data, f32->m_size, mip))
+                {
+                    continue;
+                }
+
+                const float* data{reinterpret_cast<const float*>(mip.m_data)};
+                const FaceAxes& f{faces[side]};
+
+                double v{minUV};
+                for (uint32_t y = 0; y < size; ++y)
+                {
+                    double u{minUV};
+                    for (uint32_t x = 0; x < size; ++x)
+                    {
+                        double dir[3] = {
+                            f.fx[0] * u + f.fy[0] * v + f.n[0],
+                            f.fx[1] * u + f.fy[1] * v + f.n[1],
+                            f.fx[2] * u + f.fy[2] * v + f.n[2],
+                        };
+                        const double len{std::sqrt(dir[0] * dir[0] + dir[1] * dir[1] + dir[2] * dir[2])};
+                        dir[0] /= len;
+                        dir[1] /= len;
+                        dir[2] /= len;
+
+                        const double deltaSolidAngle{
+                            areaElement(u - halfTexel, v - halfTexel) -
+                            areaElement(u - halfTexel, v + halfTexel) -
+                            areaElement(u + halfTexel, v - halfTexel) +
+                            areaElement(u + halfTexel, v + halfTexel)};
+
+                        const size_t idx{(static_cast<size_t>(y) * size + x) * 4};
+                        double rgb[3] = {data[idx + 0], data[idx + 1], data[idx + 2]};
+                        for (int c = 0; c < 3; ++c)
+                        {
+                            if (std::isnan(rgb[c]))
+                            {
+                                rgb[c] = 0.0;
+                            }
+                            rgb[c] = rgb[c] < 0.0 ? 0.0 : (rgb[c] > maxHdri ? maxHdri : rgb[c]);
+                        }
+
+                        const double trig[9] = {
+                            1.0,
+                            dir[1],
+                            dir[2],
+                            dir[0],
+                            dir[0] * dir[1],
+                            dir[1] * dir[2],
+                            3.0 * dir[2] * dir[2] - 1.0,
+                            dir[0] * dir[2],
+                            dir[0] * dir[0] - dir[1] * dir[1],
+                        };
+                        for (int lm = 0; lm < 9; ++lm)
+                        {
+                            const double basis{shConst[lm] * trig[lm] * deltaSolidAngle};
+                            sh[lm][0] += rgb[0] * basis;
+                            sh[lm][1] += rgb[1] * basis;
+                            sh[lm][2] += rgb[2] * basis;
+                        }
+                        totalSolidAngle += deltaSolidAngle;
+                        u += du;
+                    }
+                    v += du;
+                }
+            }
+
+            bimg::imageFree(f32);
+
+            if (totalSolidAngle <= 0.0)
+            {
+                return result;
+            }
+
+            // scaleInPlace(correction) + convertIncidentRadianceToIrradiance + convertIrradianceToLambertianRadiance.
+            const double correction{(4.0 * pi) / totalSolidAngle};
+            for (int lm = 0; lm < 9; ++lm)
+            {
+                const double scale{correction * cosKernel[lm] / pi};
+                sh[lm][0] *= scale;
+                sh[lm][1] *= scale;
+                sh[lm][2] *= scale;
+            }
+
+            // SphericalPolynomial.FromHarmonics (updateFromHarmonics then *1/pi).
+            for (int c = 0; c < 3; ++c)
+            {
+                const double l00{sh[0][c]}, l1_1{sh[1][c]}, l10{sh[2][c]}, l11{sh[3][c]};
+                const double l2_2{sh[4][c]}, l2_1{sh[5][c]}, l20{sh[6][c]}, l21{sh[7][c]}, l22{sh[8][c]};
+                const double invPi{1.0 / pi};
+                result[0 * 3 + c] = static_cast<float>(-1.02333 * l11 * invPi);                                     // x
+                result[1 * 3 + c] = static_cast<float>(-1.02333 * l1_1 * invPi);                                    // y
+                result[2 * 3 + c] = static_cast<float>(1.02333 * l10 * invPi);                                      // z
+                result[3 * 3 + c] = static_cast<float>((0.886277 * l00 - 0.247708 * l20 + 0.429043 * l22) * invPi); // xx
+                result[4 * 3 + c] = static_cast<float>((0.886277 * l00 - 0.247708 * l20 - 0.429043 * l22) * invPi); // yy
+                result[5 * 3 + c] = static_cast<float>((0.886277 * l00 + 0.495417 * l20) * invPi);                  // zz
+                result[6 * 3 + c] = static_cast<float>(-0.858086 * l2_1 * invPi);                                   // yz
+                result[7 * 3 + c] = static_cast<float>(-0.858086 * l21 * invPi);                                    // zx
+                result[8 * 3 + c] = static_cast<float>(0.858086 * l2_2 * invPi);                                    // xy
+            }
+
+            return result;
+        }
+
+        void LoadCubeTextureFromContainer(Graphics::Texture* texture, bimg::ImageContainer* image, bool srgb)
+        {
+            assert(image->m_cubeMap);
+            assert(image->m_width == image->m_height);
+            const uint32_t size{image->m_width};
+
+            if (texture->IsValid())
+            {
+                if (texture->Width() != size || texture->Height() != size)
+                {
+                    bimg::imageFree(image);
+                    throw std::runtime_error{"Cannot update texture from image of different size"};
+                }
+            }
+            else
+            {
+                const bool hasMips{image->m_numMips > 1};
+                const bgfx::TextureFormat::Enum format{Cast(image->m_format)};
+                const uint64_t flags{srgb ? BGFX_TEXTURE_SRGB : BGFX_TEXTURE_NONE};
+                texture->CreateCube(static_cast<uint16_t>(size), hasMips, 1, format, flags);
+            }
+
+            // Every (side, mip) view points into the single container's backing
+            // store, so the allocation is released exactly once, after bgfx has
+            // consumed the final upload.
+            const uint8_t numMips{static_cast<uint8_t>(image->m_numMips)};
+            for (uint8_t side = 0; side < 6; ++side)
+            {
+                for (uint8_t mip = 0; mip < numMips; ++mip)
+                {
+                    bimg::ImageMip imageMip{};
+                    if (bimg::imageGetRawData(*image, side, mip, image->m_data, image->m_size, imageMip))
+                    {
+                        bgfx::ReleaseFn releaseFn{};
+                        if (side == 5 && mip == numMips - 1)
+                        {
+                            releaseFn = [](void*, void* userData) {
+                                bimg::imageFree(static_cast<bimg::ImageContainer*>(userData));
+                            };
+                        }
+
+                        const bgfx::Memory* mem{bgfx::makeRef(imageMip.m_data, imageMip.m_size, releaseFn, image)};
+                        texture->UpdateCube(0, side, mip, 0, 0, static_cast<uint16_t>(imageMip.m_width), static_cast<uint16_t>(imageMip.m_height), mem);
                     }
                 }
             }
@@ -1532,6 +1768,44 @@ namespace Babylon
         const auto srgb{info[4].As<Napi::Boolean>().Value()};
         const auto onSuccess{info[5].As<Napi::Function>()};
         const auto onError{info[6].As<Napi::Function>()};
+
+        // A single buffer means a self-contained cubemap container (.dds / .ktx /
+        // .ktx2) that already holds all six faces and their mip chain; hand it to
+        // bimg directly instead of expecting six pre-split face images.
+        if (data.Length() == 1)
+        {
+            const auto typedArray{data[0u].As<Napi::TypedArray>()};
+            const auto dataSpan{gsl::make_span(static_cast<uint8_t*>(typedArray.ArrayBuffer().Data()) + typedArray.ByteOffset(), typedArray.ByteLength())};
+            auto dataRef{Napi::Persistent(typedArray)};
+            arcana::make_task(arcana::threadpool_scheduler, *m_cancellationSource, [dataSpan]() {
+                return ParseCubeImage(Graphics::DeviceContext::GetDefaultAllocator(), dataSpan);
+            })
+                .then(arcana::inline_scheduler, *m_cancellationSource, [texture, srgb, cancellationSource{m_cancellationSource}](bimg::ImageContainer* image) {
+                    // Compute the spherical harmonics from the decoded top mip before the upload
+                    // hands the container's memory to bgfx.
+                    auto sphericalPolynomial = ComputeCubeSphericalPolynomial(Graphics::DeviceContext::GetDefaultAllocator(), image);
+                    LoadCubeTextureFromContainer(texture, image, srgb);
+                    return sphericalPolynomial;
+                })
+                .then(m_runtimeScheduler, *m_cancellationSource, [dataRef{std::move(dataRef)}, onSuccessRef{Napi::Persistent(onSuccess)}, onErrorRef{Napi::Persistent(onError)}, cancellationSource{m_cancellationSource}](arcana::expected<std::array<float, 27>, std::exception_ptr> result) {
+                    if (result.has_error())
+                    {
+                        onErrorRef.Call({});
+                    }
+                    else
+                    {
+                        const auto& sphericalPolynomial{result.value()};
+                        auto array{Napi::Float32Array::New(onSuccessRef.Env(), sphericalPolynomial.size())};
+                        float* dst{array.Data()};
+                        for (size_t i = 0; i < sphericalPolynomial.size(); ++i)
+                        {
+                            dst[i] = sphericalPolynomial[i];
+                        }
+                        onSuccessRef.Call({array});
+                    }
+                });
+            return;
+        }
 
         std::array<Napi::Reference<Napi::TypedArray>, 6> dataRefs;
         std::array<arcana::task<bimg::ImageContainer*, std::exception_ptr>, 6> tasks;

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -632,10 +632,9 @@ namespace Babylon
             // expected face/mip must be present; otherwise the container would leak (the callback
             // would never fire) and the texture would be left partially initialized. Validate the
             // whole face/mip grid up front and fail fast.
-            const uint8_t numMips{static_cast<uint8_t>(image->m_numMips)};
             for (uint8_t side = 0; side < 6; ++side)
             {
-                for (uint8_t mip = 0; mip < numMips; ++mip)
+                for (uint8_t mip = 0, numMips = image->m_numMips; mip < numMips; ++mip)
                 {
                     bimg::ImageMip imageMip{};
                     if (!bimg::imageGetRawData(*image, side, mip, image->m_data, image->m_size, imageMip))
@@ -651,13 +650,13 @@ namespace Babylon
             // consumed the final upload.
             for (uint8_t side = 0; side < 6; ++side)
             {
-                for (uint8_t mip = 0; mip < numMips; ++mip)
+                for (uint8_t mip = 0, numMips = image->m_numMips; mip < numMips; ++mip)
                 {
                     bimg::ImageMip imageMip{};
                     bimg::imageGetRawData(*image, side, mip, image->m_data, image->m_size, imageMip);
 
                     bgfx::ReleaseFn releaseFn{};
-                    if (side == 5 && mip == numMips - 1)
+                    if (side == 5 && mip == image->m_numMips - 1)
                     {
                         releaseFn = [](void*, void* userData) {
                             bimg::imageFree(static_cast<bimg::ImageContainer*>(userData));

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -628,28 +628,44 @@ namespace Babylon
                 texture->CreateCube(static_cast<uint16_t>(size), hasMips, 1, format, flags);
             }
 
-            // Every (side, mip) view points into the single container's backing
-            // store, so the allocation is released exactly once, after bgfx has
-            // consumed the final upload.
+            // The single release callback is attached to the last (side, mip) upload, so every
+            // expected face/mip must be present; otherwise the container would leak (the callback
+            // would never fire) and the texture would be left partially initialized. Validate the
+            // whole face/mip grid up front and fail fast.
             const uint8_t numMips{static_cast<uint8_t>(image->m_numMips)};
             for (uint8_t side = 0; side < 6; ++side)
             {
                 for (uint8_t mip = 0; mip < numMips; ++mip)
                 {
                     bimg::ImageMip imageMip{};
-                    if (bimg::imageGetRawData(*image, side, mip, image->m_data, image->m_size, imageMip))
+                    if (!bimg::imageGetRawData(*image, side, mip, image->m_data, image->m_size, imageMip))
                     {
-                        bgfx::ReleaseFn releaseFn{};
-                        if (side == 5 && mip == numMips - 1)
-                        {
-                            releaseFn = [](void*, void* userData) {
-                                bimg::imageFree(static_cast<bimg::ImageContainer*>(userData));
-                            };
-                        }
-
-                        const bgfx::Memory* mem{bgfx::makeRef(imageMip.m_data, imageMip.m_size, releaseFn, image)};
-                        texture->UpdateCube(0, side, mip, 0, 0, static_cast<uint16_t>(imageMip.m_width), static_cast<uint16_t>(imageMip.m_height), mem);
+                        bimg::imageFree(image);
+                        throw std::runtime_error{"Cubemap container is missing one or more faces/mips."};
                     }
+                }
+            }
+
+            // Every (side, mip) view points into the single container's backing
+            // store, so the allocation is released exactly once, after bgfx has
+            // consumed the final upload.
+            for (uint8_t side = 0; side < 6; ++side)
+            {
+                for (uint8_t mip = 0; mip < numMips; ++mip)
+                {
+                    bimg::ImageMip imageMip{};
+                    bimg::imageGetRawData(*image, side, mip, image->m_data, image->m_size, imageMip);
+
+                    bgfx::ReleaseFn releaseFn{};
+                    if (side == 5 && mip == numMips - 1)
+                    {
+                        releaseFn = [](void*, void* userData) {
+                            bimg::imageFree(static_cast<bimg::ImageContainer*>(userData));
+                        };
+                    }
+
+                    const bgfx::Memory* mem{bgfx::makeRef(imageMip.m_data, imageMip.m_size, releaseFn, image)};
+                    texture->UpdateCube(0, side, mip, 0, 0, static_cast<uint16_t>(imageMip.m_width), static_cast<uint16_t>(imageMip.m_height), mem);
                 }
             }
         }
@@ -1780,7 +1796,7 @@ namespace Babylon
             arcana::make_task(arcana::threadpool_scheduler, *m_cancellationSource, [dataSpan]() {
                 return ParseCubeImage(Graphics::DeviceContext::GetDefaultAllocator(), dataSpan);
             })
-                .then(arcana::inline_scheduler, *m_cancellationSource, [texture, srgb, cancellationSource{m_cancellationSource}](bimg::ImageContainer* image) {
+                .then(arcana::inline_scheduler, *m_cancellationSource, [texture, srgb, cancellationSource{m_cancellationSource}, asyncTaskScope{TrackAsyncTask()}](bimg::ImageContainer* image) {
                     // Compute the spherical harmonics from the decoded top mip before the upload
                     // hands the container's memory to bgfx.
                     auto sphericalPolynomial = ComputeCubeSphericalPolynomial(Graphics::DeviceContext::GetDefaultAllocator(), image);


### PR DESCRIPTION
# NativeEngine: load single-file `.dds`/`.ktx`/`.ktx2` cubemaps + compute spherical harmonics

## Status

- **Draft.** Rebased onto latest `master`; `Apps` lockfile bumped to `babylonjs` **9.15.0**.
- Two commits: the cube-container loading change + the folded-in #1747 blur-cube re-enable.
- **Builds clean on every target** (D3D12 / MacOS / Android / iOS / UWP all green).
- **CI is red on the D3D11 / Ubuntu validation jobs, and that is expected.** The six re-enabled
  cube tests are gated on the paired Babylon.js cube-loading TS, which is **not in any published
  `babylonjs` yet** (see "Paired Babylon.js changes"). On the current bundled 9.15.0 the first cube
  test throws `Error: Cannot load cubemap because 6 files were not defined` and aborts the run
  (`exit -1`); the C++ itself compiles and links everywhere.

## What

Adds native support for loading a self-contained cubemap container (`.dds` / `.ktx` / `.ktx2`,
the format produced by `CubeTexture.CreateFromPrefilteredData(...)`) and re-enables six PBR
environment validation tests.

This PR also **folds in #1747** (re-enabling `blur-cube-with-the-effect-renderer`) — see
"Folded-in change" below — so seven validation tests are re-enabled in total.

`Plugins/NativeEngine/Source/NativeEngine.cpp`:
- `loadCubeTexture` now accepts a **single** buffer (all six faces + mips in one container).
  `ParseCubeImage` runs it through `bimg::imageParse` (which decodes DDS/KTX/KTX2 cubemaps), and
  `LoadCubeTextureFromContainer` uploads sides 0–5 × mips.
- `ComputeCubeSphericalPolynomial` derives the diffuse-IBL spherical harmonics from the top-mip
  faces (a port of Babylon's `CubeMapToSphericalPolynomialTools.ConvertCubeMapToSphericalPolynomial`)
  and returns the 9×3 polynomial coefficients to JS.

`Apps/Playground/Scripts/config.json`: re-enables the six tests this unblocks (`NMEGLTF`,
`Anisotropic`, `Clear Coat`, `PBRMetallicRoughnessMaterial`, `PBRSpecularGlossinessMaterial`, `PBR`),
plus `blur-cube-with-the-effect-renderer` (folded-in #1747).

## Why this shape

These scenes load a prefiltered environment via a single `.dds`. WebGL gets the cube faces *and*
computes the spherical harmonics on the CPU through the texture-loader path. On native that path
is unavailable: `_uploadDataToTextureDirectly` / `_uploadCompressedDataToTextureDirectly` and cube
`_readTexturePixels` are unimplemented stubs. The `.dds` also stores no SH (Babylon computes it from
the faces). So the SH must be computed from the decoded faces, in native C++, alongside the upload —
no `.env` swap, no JS polyfill, no GPU readback.

## Folded-in change (was #1747)

Re-enables `blur-cube-with-the-effect-renderer`. The test rendered an `EffectRenderer` fullscreen
pass that produced an all-black frame on native: `EffectRenderer` disables depth via
`engine.depthCullingState.depthTest = false`, but the native engine only honored depth state set
through the explicit `setDepthBuffer()` command and never flushed `depthCullingState` at draw time,
so the fullscreen quad kept the previous draw's depth test and every fragment was discarded. Fixed
on the Babylon.js side by **#18558**, which is **merged and shipped** in the bundled `babylonjs`, so
this test's JS dependency is already satisfied.

## Paired Babylon.js changes

- **BabylonJS/Babylon.js#18567** — the single-URL container cube dispatch + spherical-harmonics
  wiring that the six cube tests depend on. **Open (draft); not yet in any `babylonjs` release.**
  (Originally proposed as #18560, which has since been **closed** — its content now lives in #18567.)
- **BabylonJS/Babylon.js#18558** — makes the native engine honor `depthCullingState.depthTest` at
  draw time (the `blur-cube-with-the-effect-renderer` fix). **Merged** (2026-06-16) and present in
  the bundled `babylonjs` 9.15.0, so that dependency is already satisfied.

> The remaining gate is **#18567**: CI goes green once its cube-loading TS lands and ships in a
> `babylonjs` release (> 9.15.0) and the `Apps` lockfile here is bumped to it.

## Verification (local)

- Against a from-source `babylon.max.js` built with the #18567 cube-loading change, the six
  cube-environment tests run via the normal path (no `--include-excluded`) and pass, matching their
  reference images. The SH integration is correct (total solid angle = 4π).
- `blur-cube-with-the-effect-renderer` passes with #18558 present (`Test '...' validated`).
- Scope note: `Prepass SSAO + depth of field` also references a `.dds` env — its cube now loads, but
  it still fails on unrelated SSAO / DoF / prepass differences, so it remains excluded (separate issue).

---

## Related PRs & landing order

- **Babylon.js (engine / TS):** https://github.com/BabylonJS/Babylon.js/pull/18567
- **BabylonNative (C++ engine + test re-enable):** https://github.com/BabylonJS/BabylonNative/pull/1748

Co-dependent; land in this order:

1. **Babylon.js #18567 first** — adds the single-URL container cube dispatch + spherical-harmonics wiring; no WebGL behavior change.
2. A **`babylonjs` npm release** ships that TS change.
3. **BabylonNative #1748 last** — bumps the bundled `babylonjs` to that release and re-enables the six prefiltered-`.dds` PBR validation tests, which only pass once the paired JS is present. The folded-in `blur-cube-with-the-effect-renderer` test's JS dependency (#18558) is already in the bundled engine.
