### PR TITLE
Update bgfx.cmake to latest (bgfx + bx)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ FetchContent_Declare(base-n
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(bgfx.cmake
     GIT_REPOSITORY https://github.com/BabylonJS/bgfx.cmake.git
-    GIT_TAG 940054e1f047e7851ba1448db480c24f800a2032
+    GIT_TAG 68762dde81848256bd785880b00309832b1cad27
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(CMakeExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/CMakeExtensions.git


### PR DESCRIPTION
Bumps the `bgfx.cmake` dependency pin to [`68762dde`](https://github.com/BabylonJS/bgfx.cmake/commit/68762dde81848256bd785880b00309832b1cad27) — "Updated bgfx and bx. (#124)".

This is a clean +1 forward bump over the previous pin `940054e1` (ahead by 1, behind by 0), pulling in the latest bgfx + bx.
