### PR TITLE
Add native cube render target support (re-enables 2 shadow-with-instances tests)

### DIFF
--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -1823,16 +1823,12 @@
             "title": "Shadows with instances in left handed system",
             "playgroundId": "#MSAHKR#79",
             "renderCount": 10,
-            "excludeFromAutomaticTesting": true,
-            "reason": "Test crashes or hangs on Babylon Native",
             "referenceImage": "shadowsinstancesleft.png"
         },
         {
             "title": "Shadows with instances in right handed system",
             "playgroundId": "#MSAHKR#13",
             "renderCount": 10,
-            "excludeFromAutomaticTesting": true,
-            "reason": "Test crashes or hangs on Babylon Native",
             "referenceImage": "shadowsinstancesright.png"
         },
         {

--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -11,13 +11,13 @@
         "UnitTests/JavaScript"
       ],
       "dependencies": {
-        "babylonjs": "^9.3.4",
-        "babylonjs-addons": "^9.3.4",
-        "babylonjs-gltf2interface": "^9.3.4",
-        "babylonjs-gui": "^9.3.4",
-        "babylonjs-loaders": "^9.3.4",
-        "babylonjs-materials": "^9.3.4",
-        "babylonjs-serializers": "^9.3.4",
+        "babylonjs": "^9.15.0",
+        "babylonjs-addons": "^9.15.0",
+        "babylonjs-gltf2interface": "^9.15.0",
+        "babylonjs-gui": "^9.15.0",
+        "babylonjs-loaders": "^9.15.0",
+        "babylonjs-materials": "^9.15.0",
+        "babylonjs-serializers": "^9.15.0",
         "jsc-android": "^241213.1.0",
         "v8-android": "^7.8.2"
       }
@@ -2596,63 +2596,63 @@
       }
     },
     "node_modules/babylonjs": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-9.9.1.tgz",
-      "integrity": "sha512-zMH8r0l/il9PJhy2+uS+/EyeLBy/ElZg0lKLj2d+ZrUarOanjMISaACw0HUx7C1EgYoXUFSMQLYcpXguleh8GA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-9.15.0.tgz",
+      "integrity": "sha512-IJQhrxsxxj4KCg4aSsB5chLidzAfbghr8rnzo6sRLFin6ipfeayCxg7MevjaMzqdVmc/BOMU6sj49nSNrBq+yQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-addons": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-addons/-/babylonjs-addons-9.9.1.tgz",
-      "integrity": "sha512-Hi9QZqeanqG+4VAAmJmHJh7JKf1bc/Y5Ml+wuv+W+3f/dKltZpy/pii/QN4vhYRyrU0n+S8OJc+kVeaUUFjHEg==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-addons/-/babylonjs-addons-9.15.0.tgz",
+      "integrity": "sha512-7vxm0ffFXWHCZWDlYYleifb6mg1iSH7nNo+sA9706z7QIfpNnLS9+9cTYadWobvhURwaD/DHAKnm7Z8ckq9YAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1"
+        "babylonjs": "9.15.0"
       }
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.9.1.tgz",
-      "integrity": "sha512-qHE7pASEWbRORU+NEPSSL9fyVh6gBNqC1ugV94YL9Dz0HnLcH8YNcxdi6Pf+oXgFHRrXWZiJATn37HynsF7/0g==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.15.0.tgz",
+      "integrity": "sha512-Yr/WvOvnsZFN2LoyNU/ZZbT+lXMdNA9OiZzE4RibI1tnYxQjpPKT6X1cxQ/ACJPVzKwudxzJxQ/f/Tdba4TLDg==",
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-gui": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-9.9.1.tgz",
-      "integrity": "sha512-w6HSvuHSqLYUOuxvko+gkjAQMvatf7gnOPufLRslm+P4tC+5KMEd0hyC+1vHCJuQmZXXkoc/GnozzFeaqllHZw==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-9.15.0.tgz",
+      "integrity": "sha512-klF2ywhA040JMQ3Z5XaGkN4S0GIOshtnvtUd8kbYqlLYEu5i6/y/zvB8V3O4geslzV0kWcBe2mIthlr7M7p4og==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1"
+        "babylonjs": "9.15.0"
       }
     },
     "node_modules/babylonjs-loaders": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-9.9.1.tgz",
-      "integrity": "sha512-bFSe4TQTi7aA7RsWmuZHQLX4mBMoza5D+AFRD2tVrizGyGCfQJALKnKze7Z3OetFyeo72838GXJAXmyiOWcxAA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-9.15.0.tgz",
+      "integrity": "sha512-k5Kg9wmuy0n4ZAWu9woFk3C1yEwSvQHRv0Ct2GOQtuRvIHUIyRcW4KEKOsW0GOiApSjXh9nQcabdJTnUo8IBNw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1",
-        "babylonjs-gltf2interface": "9.9.1"
+        "babylonjs": "9.15.0",
+        "babylonjs-gltf2interface": "9.15.0"
       }
     },
     "node_modules/babylonjs-materials": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-9.9.1.tgz",
-      "integrity": "sha512-2ai5hk59dzHRUN28/5/Nijknn+IungSuoBsrHrNZE2T/yIT+/T/IrU0ebm53nRYliv6NG0IaxSCfnh6euZUj7A==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-9.15.0.tgz",
+      "integrity": "sha512-E9C5EB0nZJrGvT7Mb38gypAnzi1q8vr/Gi+fTeqRQilIU8mdk+YzD5unfKOROEv8arRFCXGWrtBqkIN8k2PFxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1"
+        "babylonjs": "9.15.0"
       }
     },
     "node_modules/babylonjs-serializers": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.9.1.tgz",
-      "integrity": "sha512-nZJPplzHprwJhp4JVLgB3dEpJR2HvEElPIDvOoAFf1IcaKwcDja2tZTGXIbARdWlTX547pN0qN/vEd6dYLrnDA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.15.0.tgz",
+      "integrity": "sha512-iLYwPzZrUr2SnwHcsXjHJHYdJIVC+boW6z/olE0mE5GvqmfKXTtqFr9wRGrsq85BarhHQkfVlfQdFwhFq/JG4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1",
-        "babylonjs-gltf2interface": "9.9.1"
+        "babylonjs": "9.15.0",
+        "babylonjs-gltf2interface": "9.15.0"
       }
     },
     "node_modules/balanced-match": {

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -9,13 +9,13 @@
     "getNightly": "node scripts/getNightly.js"
   },
   "dependencies": {
-    "babylonjs": "^9.3.4",
-    "babylonjs-addons": "^9.3.4",
-    "babylonjs-gltf2interface": "^9.3.4",
-    "babylonjs-gui": "^9.3.4",
-    "babylonjs-loaders": "^9.3.4",
-    "babylonjs-materials": "^9.3.4",
-    "babylonjs-serializers": "^9.3.4",
+    "babylonjs": "^9.15.0",
+    "babylonjs-addons": "^9.15.0",
+    "babylonjs-gltf2interface": "^9.15.0",
+    "babylonjs-gui": "^9.15.0",
+    "babylonjs-loaders": "^9.15.0",
+    "babylonjs-materials": "^9.15.0",
+    "babylonjs-serializers": "^9.15.0",
     "jsc-android": "^241213.1.0",
     "v8-android": "^7.8.2"
   }

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1348,6 +1348,7 @@ namespace Babylon
         const bool renderTarget = info[5].As<Napi::Boolean>();
         const bool srgb = info[6].As<Napi::Boolean>();
         const uint32_t samples = info[7].IsUndefined() ? 1 : info[7].As<Napi::Number>().Uint32Value();
+        const bool isCube = info.Length() > 8 && !info[8].IsUndefined() && info[8].As<Napi::Boolean>();
 
         auto flags = BGFX_TEXTURE_NONE;
         if (renderTarget)
@@ -1359,7 +1360,15 @@ namespace Babylon
             flags |= BGFX_TEXTURE_SRGB;
         }
 
-        texture->Create2D(width, height, hasMips, 1, format, flags);
+        if (isCube)
+        {
+            // Cube render target: width is the per-face size.
+            texture->CreateCube(width, hasMips, 1, format, flags);
+        }
+        else
+        {
+            texture->Create2D(width, height, hasMips, 1, format, flags);
+        }
     }
 
     void NativeEngine::LoadTexture(const Napi::CallbackInfo& info)
@@ -1852,6 +1861,8 @@ namespace Babylon
         const bool generateStencilBuffer = info[3].As<Napi::Boolean>();
         const bool generateDepth = info[4].As<Napi::Boolean>();
         const uint32_t samples = info[5].IsUndefined() ? 1 : info[5].As<Napi::Number>().Uint32Value();
+        // Optional cube-face / array layer for the color attachment (single-face cube render targets).
+        const uint16_t layer = (info.Length() > 6 && !info[6].IsUndefined()) ? static_cast<uint16_t>(info[6].As<Napi::Number>().Uint32Value()) : 0;
 
         std::array<bgfx::Attachment, 2> attachments{};
         uint8_t numAttachments = 0;
@@ -1862,7 +1873,7 @@ namespace Babylon
             // bgfx validation now asserts when trying to use BGFX_RESOLVE_AUTO_GEN_MIPS with a texture that doesn't have the BGFX_CAPS_FORMAT_TEXTURE_MIP_AUTOGEN flag,
             // but before it would just ignore the flag and not generate mips without any warning. This prevents validation assert, but rendering might be broken if autogen
             // mips were expected. Basically this change preserves previous behavior.
-            attachments[numAttachments++].init(texture->Handle(), bgfx::Access::Write, 0, 1, 0
+            attachments[numAttachments++].init(texture->Handle(), bgfx::Access::Write, layer, 1, 0
                 , 0 != (caps->formats[texture->Format()] & BGFX_CAPS_FORMAT_TEXTURE_MIP_AUTOGEN) ? BGFX_RESOLVE_AUTO_GEN_MIPS : BGFX_RESOLVE_NONE
                 );
         }


### PR DESCRIPTION
Paired engine PR: BabylonJS/Babylon.js#18561

## What

Implements cube render targets on the native engine so `ReflectionProbe` and
point-light cube shadow maps render instead of crashing on the null WebGL
context. Pairs with the Babylon.js change that adds the JS-side overrides.

## Changes

- `Plugins/NativeEngine/Source/NativeEngine.cpp`
  - `InitializeTexture`: optional `isCube` param → `Texture::CreateCube`.
  - `CreateFrameBuffer`: optional `layer` param so the color attachment targets
    a single cube face (`bgfx::Attachment` layer). The JS side creates one
    framebuffer per face and binds the matching one per face.
- `Apps/Playground/Scripts/config.json`: re-enables "Shadows with instances in
  left/right handed system" (previously excluded as crash/hang).

## CI

The validation suite uses the published `babylonjs` npm, which does not yet
contain the paired JS overrides, so the re-enabled tests stay red until a
`babylonjs` release with the Babylon.js change ships and the dependency is
bumped here. Draft until then.

## Verified locally

Built against a local `babylon.max.js` with the paired change: the two
re-enabled tests pass and there are no regressions in post-process / 2D
render-target tests.

---

## Related PRs & landing order

- **Babylon.js (engine / TS):** https://github.com/BabylonJS/Babylon.js/pull/18561
- **BabylonNative (C++ engine + test re-enable):** https://github.com/BabylonJS/BabylonNative/pull/1750

Co-dependent; land in this order:
1. **Babylon.js #18561 first** — adds the cube render-target TS overrides; no WebGL behavior change.
2. A **`babylonjs` npm release** ships that TS change.
3. **BabylonNative #1750 last** — bumps the bundled `babylonjs` and re-enables the 2 `Shadows with instances` (left/right handed) validation tests, which only pass once the paired JS is present in the bundled engine.
