### PR TITLE
NativeEngine: MultiRenderTarget framebuffers + OIT alpha blend modes

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -77,6 +77,8 @@ namespace Babylon
             constexpr uint64_t MULTIPLY = BGFX_STATE_BLEND_FUNC_SEPARATE(BGFX_STATE_BLEND_DST_COLOR, BGFX_STATE_BLEND_ZERO, BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_ONE);
             constexpr uint64_t MAXIMIZED = BGFX_STATE_BLEND_FUNC_SEPARATE(BGFX_STATE_BLEND_SRC_ALPHA, BGFX_STATE_BLEND_INV_SRC_COLOR, BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_ONE);
             constexpr uint64_t ONEONE = BGFX_STATE_BLEND_FUNC_SEPARATE(BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_ZERO, BGFX_STATE_BLEND_ONE);
+            constexpr uint64_t ONEONE_ONEONE = BGFX_STATE_BLEND_FUNC_SEPARATE(BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_ONE);
+            constexpr uint64_t LAYER_ACCUMULATE = BGFX_STATE_BLEND_FUNC_SEPARATE(BGFX_STATE_BLEND_SRC_ALPHA, BGFX_STATE_BLEND_INV_SRC_ALPHA, BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_INV_SRC_ALPHA);
             constexpr uint64_t PREMULTIPLIED = BGFX_STATE_BLEND_FUNC_SEPARATE(BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_INV_SRC_ALPHA, BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_ONE);
             constexpr uint64_t PREMULTIPLIED_PORTERDUFF = BGFX_STATE_BLEND_FUNC_SEPARATE(BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_INV_SRC_ALPHA, BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_INV_SRC_ALPHA);
             constexpr uint64_t INTERPOLATE = BGFX_STATE_BLEND_FUNC_SEPARATE(BGFX_STATE_BLEND_FACTOR, BGFX_STATE_BLEND_INV_FACTOR, BGFX_STATE_BLEND_FACTOR, BGFX_STATE_BLEND_INV_FACTOR);
@@ -598,6 +600,8 @@ namespace Babylon
                 StaticValue("ALPHA_MULTIPLY", Napi::Number::From(env, AlphaMode::MULTIPLY)),
                 StaticValue("ALPHA_MAXIMIZED", Napi::Number::From(env, AlphaMode::MAXIMIZED)),
                 StaticValue("ALPHA_ONEONE", Napi::Number::From(env, AlphaMode::ONEONE)),
+                StaticValue("ALPHA_ONEONE_ONEONE", Napi::Number::From(env, AlphaMode::ONEONE_ONEONE)),
+                StaticValue("ALPHA_LAYER_ACCUMULATE", Napi::Number::From(env, AlphaMode::LAYER_ACCUMULATE)),
                 StaticValue("ALPHA_PREMULTIPLIED", Napi::Number::From(env, AlphaMode::PREMULTIPLIED)),
                 StaticValue("ALPHA_PREMULTIPLIED_PORTERDUFF", Napi::Number::From(env, AlphaMode::PREMULTIPLIED_PORTERDUFF)),
                 StaticValue("ALPHA_INTERPOLATE", Napi::Number::From(env, AlphaMode::INTERPOLATE)),
@@ -726,6 +730,7 @@ namespace Babylon
                 InstanceMethod("resizeImageBitmap", &NativeEngine::ResizeImageBitmap),
 
                 InstanceMethod("createFrameBuffer", &NativeEngine::CreateFrameBuffer),
+                InstanceMethod("createMultiFrameBuffer", &NativeEngine::CreateMultiFrameBuffer),
 
                 InstanceMethod("getRenderWidth", &NativeEngine::GetRenderWidth),
                 InstanceMethod("getRenderHeight", &NativeEngine::GetRenderHeight),
@@ -1906,6 +1911,66 @@ namespace Babylon
             }
 
             throw Napi::Error::New(info.Env(), "Failed to create frame buffer");
+        }
+
+        Graphics::FrameBuffer* frameBuffer = new Graphics::FrameBuffer(m_deviceContext, frameBufferHandle, width, height, false, generateDepth, generateStencilBuffer, depthStencilAttachmentIndex);
+        return Napi::Pointer<Graphics::FrameBuffer>::Create(info.Env(), frameBuffer, Napi::NapiPointerDeleter(frameBuffer));
+    }
+
+    Napi::Value NativeEngine::CreateMultiFrameBuffer(const Napi::CallbackInfo& info)
+    {
+        const auto colorTextures = info[0].As<Napi::Array>();
+        const uint16_t width = static_cast<uint16_t>(info[1].As<Napi::Number>().Uint32Value());
+        const uint16_t height = static_cast<uint16_t>(info[2].As<Napi::Number>().Uint32Value());
+        const bool generateStencilBuffer = info[3].As<Napi::Boolean>();
+        const bool generateDepth = info[4].As<Napi::Boolean>();
+        const uint32_t samples = info[5].IsUndefined() ? 1 : info[5].As<Napi::Number>().Uint32Value();
+
+        const bgfx::Caps* caps = bgfx::getCaps();
+        const uint32_t colorCount = colorTextures.Length();
+        // One slot per color attachment plus a single depth/stencil attachment. bgfx caps the total via
+        // maxFBAttachments; reject out-of-range counts up front rather than relying on the validation assert.
+        if (colorCount == 0 || colorCount + 1 > caps->limits.maxFBAttachments)
+        {
+            throw Napi::Error::New(info.Env(), "Invalid number of color attachments for multi render target frame buffer");
+        }
+
+        // BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS is 8, so 8 color + 1 depth fits in a fixed array.
+        std::array<bgfx::Attachment, 9> attachments{};
+        uint8_t numAttachments = 0;
+
+        for (uint32_t i = 0; i < colorCount; ++i)
+        {
+            const auto texture = colorTextures.Get(i).As<Napi::Pointer<Graphics::Texture>>().Get();
+            attachments[numAttachments++].init(texture->Handle(), bgfx::Access::Write, 0, 1, 0
+                , 0 != (caps->formats[texture->Format()] & BGFX_CAPS_FORMAT_TEXTURE_MIP_AUTOGEN) ? BGFX_RESOLVE_AUTO_GEN_MIPS : BGFX_RESOLVE_NONE
+                );
+        }
+
+        bgfx::TextureHandle depthStencilTextureHandle = BGFX_INVALID_HANDLE;
+        int8_t depthStencilAttachmentIndex = -1;
+        if (generateStencilBuffer || generateDepth)
+        {
+            auto flags = BGFX_TEXTURE_RT_WRITE_ONLY | RenderTargetSamplesToBgfxMsaaFlag(samples);
+#ifdef ANDROID
+            const auto depthStencilFormat{bgfx::TextureFormat::D24S8};
+#else
+            const auto depthStencilFormat{generateStencilBuffer ? bgfx::TextureFormat::D24S8 : bgfx::TextureFormat::D32};
+#endif
+            depthStencilTextureHandle = bgfx::createTexture2D(width, height, false, 1, depthStencilFormat, flags);
+            depthStencilAttachmentIndex = numAttachments;
+            attachments[numAttachments++].init(depthStencilTextureHandle, bgfx::Access::Write, 0, 1, 0, BGFX_RESOLVE_NONE);
+        }
+
+        bgfx::FrameBufferHandle frameBufferHandle = bgfx::createFrameBuffer(numAttachments, attachments.data());
+        if (!bgfx::isValid(frameBufferHandle))
+        {
+            if (bgfx::isValid(depthStencilTextureHandle))
+            {
+                bgfx::destroy(depthStencilTextureHandle);
+            }
+
+            throw Napi::Error::New(info.Env(), "Failed to create multi render target frame buffer");
         }
 
         Graphics::FrameBuffer* frameBuffer = new Graphics::FrameBuffer(m_deviceContext, frameBufferHandle, width, height, false, generateDepth, generateStencilBuffer, depthStencilAttachmentIndex);

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1894,9 +1894,11 @@ namespace Babylon
     {
         const bgfx::Caps* caps = bgfx::getCaps();
         const uint32_t colorCount = static_cast<uint32_t>(colorTextures.size());
-        // One slot per color attachment plus a single depth/stencil attachment. bgfx caps the total via
-        // maxFBAttachments; reject out-of-range counts up front rather than relying on the validation assert.
-        if (colorCount + 1 > caps->limits.maxFBAttachments)
+        // One slot per color attachment, plus a single depth/stencil attachment only when one is
+        // generated. bgfx caps the total via maxFBAttachments; reject out-of-range counts up front
+        // rather than relying on the validation assert.
+        const uint32_t depthStencilCount = (generateStencilBuffer || generateDepth) ? 1u : 0u;
+        if (colorCount + depthStencilCount > caps->limits.maxFBAttachments)
         {
             throw Napi::Error::New(env, "Invalid number of color attachments for frame buffer");
         }

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1858,12 +1858,55 @@ namespace Babylon
         const bool generateDepth = info[4].As<Napi::Boolean>();
         const uint32_t samples = info[5].IsUndefined() ? 1 : info[5].As<Napi::Number>().Uint32Value();
 
-        std::array<bgfx::Attachment, 2> attachments{};
+        // A single render target is just the zero-or-one color attachment case of the shared implementation.
+        Graphics::Texture* const colorTextures[]{texture};
+        const gsl::span<Graphics::Texture* const> colorAttachments{colorTextures, texture != nullptr ? 1u : 0u};
+
+        return CreateFrameBufferImpl(info.Env(), colorAttachments, width, height, generateStencilBuffer, generateDepth, samples);
+    }
+
+    Napi::Value NativeEngine::CreateMultiFrameBuffer(const Napi::CallbackInfo& info)
+    {
+        const auto colorTexturesArray = info[0].As<Napi::Array>();
+        const uint16_t width = static_cast<uint16_t>(info[1].As<Napi::Number>().Uint32Value());
+        const uint16_t height = static_cast<uint16_t>(info[2].As<Napi::Number>().Uint32Value());
+        const bool generateStencilBuffer = info[3].As<Napi::Boolean>();
+        const bool generateDepth = info[4].As<Napi::Boolean>();
+        const uint32_t samples = info[5].IsUndefined() ? 1 : info[5].As<Napi::Number>().Uint32Value();
+
+        const uint32_t colorCount = colorTexturesArray.Length();
+        // BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS is 8, so at most 8 color attachments fit alongside the depth attachment.
+        std::array<Graphics::Texture*, 8> colorTextures{};
+        if (colorCount > colorTextures.size())
+        {
+            throw Napi::Error::New(info.Env(), "Invalid number of color attachments for multi render target frame buffer");
+        }
+
+        for (uint32_t i = 0; i < colorCount; ++i)
+        {
+            colorTextures[i] = colorTexturesArray.Get(i).As<Napi::Pointer<Graphics::Texture>>().Get();
+        }
+
+        return CreateFrameBufferImpl(info.Env(), gsl::span<Graphics::Texture* const>{colorTextures.data(), colorCount}, width, height, generateStencilBuffer, generateDepth, samples);
+    }
+
+    Napi::Value NativeEngine::CreateFrameBufferImpl(Napi::Env env, gsl::span<Graphics::Texture* const> colorTextures, uint16_t width, uint16_t height, bool generateStencilBuffer, bool generateDepth, uint32_t samples)
+    {
+        const bgfx::Caps* caps = bgfx::getCaps();
+        const uint32_t colorCount = static_cast<uint32_t>(colorTextures.size());
+        // One slot per color attachment plus a single depth/stencil attachment. bgfx caps the total via
+        // maxFBAttachments; reject out-of-range counts up front rather than relying on the validation assert.
+        if (colorCount + 1 > caps->limits.maxFBAttachments)
+        {
+            throw Napi::Error::New(env, "Invalid number of color attachments for frame buffer");
+        }
+
+        // BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS is 8, so 8 color + 1 depth fits in a fixed array.
+        std::array<bgfx::Attachment, 9> attachments{};
         uint8_t numAttachments = 0;
 
-        if (texture != nullptr)
+        for (Graphics::Texture* texture : colorTextures)
         {
-            const bgfx::Caps* caps = bgfx::getCaps();
             // bgfx validation now asserts when trying to use BGFX_RESOLVE_AUTO_GEN_MIPS with a texture that doesn't have the BGFX_CAPS_FORMAT_TEXTURE_MIP_AUTOGEN flag,
             // but before it would just ignore the flag and not generate mips without any warning. This prevents validation assert, but rendering might be broken if autogen
             // mips were expected. Basically this change preserves previous behavior.
@@ -1878,7 +1921,7 @@ namespace Babylon
         {
             if (generateStencilBuffer && !generateDepth)
             {
-                JsConsoleLogger::LogWarn(info.Env(), "Stencil without depth is not supported, assuming depth and stencil");
+                JsConsoleLogger::LogWarn(env, "Stencil without depth is not supported, assuming depth and stencil");
             }
 
             auto flags = BGFX_TEXTURE_RT_WRITE_ONLY | RenderTargetSamplesToBgfxMsaaFlag(samples);
@@ -1910,71 +1953,11 @@ namespace Babylon
                 bgfx::destroy(depthStencilTextureHandle);
             }
 
-            throw Napi::Error::New(info.Env(), "Failed to create frame buffer");
+            throw Napi::Error::New(env, "Failed to create frame buffer");
         }
 
         Graphics::FrameBuffer* frameBuffer = new Graphics::FrameBuffer(m_deviceContext, frameBufferHandle, width, height, false, generateDepth, generateStencilBuffer, depthStencilAttachmentIndex);
-        return Napi::Pointer<Graphics::FrameBuffer>::Create(info.Env(), frameBuffer, Napi::NapiPointerDeleter(frameBuffer));
-    }
-
-    Napi::Value NativeEngine::CreateMultiFrameBuffer(const Napi::CallbackInfo& info)
-    {
-        const auto colorTextures = info[0].As<Napi::Array>();
-        const uint16_t width = static_cast<uint16_t>(info[1].As<Napi::Number>().Uint32Value());
-        const uint16_t height = static_cast<uint16_t>(info[2].As<Napi::Number>().Uint32Value());
-        const bool generateStencilBuffer = info[3].As<Napi::Boolean>();
-        const bool generateDepth = info[4].As<Napi::Boolean>();
-        const uint32_t samples = info[5].IsUndefined() ? 1 : info[5].As<Napi::Number>().Uint32Value();
-
-        const bgfx::Caps* caps = bgfx::getCaps();
-        const uint32_t colorCount = colorTextures.Length();
-        // One slot per color attachment plus a single depth/stencil attachment. bgfx caps the total via
-        // maxFBAttachments; reject out-of-range counts up front rather than relying on the validation assert.
-        if (colorCount == 0 || colorCount + 1 > caps->limits.maxFBAttachments)
-        {
-            throw Napi::Error::New(info.Env(), "Invalid number of color attachments for multi render target frame buffer");
-        }
-
-        // BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS is 8, so 8 color + 1 depth fits in a fixed array.
-        std::array<bgfx::Attachment, 9> attachments{};
-        uint8_t numAttachments = 0;
-
-        for (uint32_t i = 0; i < colorCount; ++i)
-        {
-            const auto texture = colorTextures.Get(i).As<Napi::Pointer<Graphics::Texture>>().Get();
-            attachments[numAttachments++].init(texture->Handle(), bgfx::Access::Write, 0, 1, 0
-                , 0 != (caps->formats[texture->Format()] & BGFX_CAPS_FORMAT_TEXTURE_MIP_AUTOGEN) ? BGFX_RESOLVE_AUTO_GEN_MIPS : BGFX_RESOLVE_NONE
-                );
-        }
-
-        bgfx::TextureHandle depthStencilTextureHandle = BGFX_INVALID_HANDLE;
-        int8_t depthStencilAttachmentIndex = -1;
-        if (generateStencilBuffer || generateDepth)
-        {
-            auto flags = BGFX_TEXTURE_RT_WRITE_ONLY | RenderTargetSamplesToBgfxMsaaFlag(samples);
-#ifdef ANDROID
-            const auto depthStencilFormat{bgfx::TextureFormat::D24S8};
-#else
-            const auto depthStencilFormat{generateStencilBuffer ? bgfx::TextureFormat::D24S8 : bgfx::TextureFormat::D32};
-#endif
-            depthStencilTextureHandle = bgfx::createTexture2D(width, height, false, 1, depthStencilFormat, flags);
-            depthStencilAttachmentIndex = numAttachments;
-            attachments[numAttachments++].init(depthStencilTextureHandle, bgfx::Access::Write, 0, 1, 0, BGFX_RESOLVE_NONE);
-        }
-
-        bgfx::FrameBufferHandle frameBufferHandle = bgfx::createFrameBuffer(numAttachments, attachments.data());
-        if (!bgfx::isValid(frameBufferHandle))
-        {
-            if (bgfx::isValid(depthStencilTextureHandle))
-            {
-                bgfx::destroy(depthStencilTextureHandle);
-            }
-
-            throw Napi::Error::New(info.Env(), "Failed to create multi render target frame buffer");
-        }
-
-        Graphics::FrameBuffer* frameBuffer = new Graphics::FrameBuffer(m_deviceContext, frameBufferHandle, width, height, false, generateDepth, generateStencilBuffer, depthStencilAttachmentIndex);
-        return Napi::Pointer<Graphics::FrameBuffer>::Create(info.Env(), frameBuffer, Napi::NapiPointerDeleter(frameBuffer));
+        return Napi::Pointer<Graphics::FrameBuffer>::Create(env, frameBuffer, Napi::NapiPointerDeleter(frameBuffer));
     }
 
     // TODO: This doesn't get called when an Engine instance is disposed.

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -33,6 +33,11 @@
 
 namespace Babylon
 {
+    namespace Graphics
+    {
+        class Texture;
+    }
+
     class NativeEngine final : public Napi::ObjectWrap<NativeEngine>
     {
         static constexpr auto JS_CLASS_NAME = "_NativeEngine";
@@ -116,6 +121,7 @@ namespace Babylon
         Napi::Value ReadTexture(const Napi::CallbackInfo& info);
         Napi::Value CreateFrameBuffer(const Napi::CallbackInfo& info);
         Napi::Value CreateMultiFrameBuffer(const Napi::CallbackInfo& info);
+        Napi::Value CreateFrameBufferImpl(Napi::Env env, gsl::span<Graphics::Texture* const> colorTextures, uint16_t width, uint16_t height, bool generateStencilBuffer, bool generateDepth, uint32_t samples);
         void DeleteFrameBuffer(NativeDataStream::Reader& data);
         void BindFrameBuffer(NativeDataStream::Reader& data);
         void UnbindFrameBuffer(NativeDataStream::Reader& data);

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -115,6 +115,7 @@ namespace Babylon
         void DeleteTexture(const Napi::CallbackInfo& info);
         Napi::Value ReadTexture(const Napi::CallbackInfo& info);
         Napi::Value CreateFrameBuffer(const Napi::CallbackInfo& info);
+        Napi::Value CreateMultiFrameBuffer(const Napi::CallbackInfo& info);
         void DeleteFrameBuffer(NativeDataStream::Reader& data);
         void BindFrameBuffer(NativeDataStream::Reader& data);
         void UnbindFrameBuffer(NativeDataStream::Reader& data);


### PR DESCRIPTION
Paired engine PR: BabylonJS/Babylon.js#18568

## What

Foundational native support for `MultiRenderTarget` (MRT) and the order-independent-transparency blend
modes, removing several "`engine._gl` is null" crash classes. It does **not** by itself turn the
MRT/OIT/FrameGraph validation tests green — those need further work (see Follow-ups).

## Changes

- **`Plugins/NativeEngine/Source/NativeEngine.cpp` / `.h`**
  - `CreateFrameBuffer` and `CreateMultiFrameBuffer` now share a private
    `CreateFrameBufferImpl(env, colorTextures, …)` helper that builds one bgfx framebuffer with N color
    attachments (+ an optional depth/stencil attachment), so a `MultiRenderTarget` renders to all
    targets at once (bgfx writes every attachment of the bound framebuffer — no `drawBuffers` needed).
    The two N-API methods are kept for protocol compatibility and only differ in how they parse
    `info[0]` (single nullable texture vs. array); the single-RT path is just the 0-or-1-color case.
    The shared helper validates the attachment count against `caps->limits.maxFBAttachments` and keeps
    the `"Stencil without depth…"` warning and the `isTextureValid` assert.
  - Add alpha blend modes `ALPHA_ONEONE_ONEONE` (11) and `ALPHA_LAYER_ACCUMULATE` (17) used by the
    depth-peeling OIT renderer.

## Paired engine PR

Pairs with the Babylon.js change (`createMultipleRenderTarget` + MRT helper overrides, `applyStates`
override, reverse-Z `clear`, alpha-mode mapping). That PR feature-detects both `createMultiFrameBuffer`
and the two alpha constants, so it degrades gracefully on native binaries that predate this PR.

## CI

The validation suite uses the published `babylonjs` npm, which doesn't yet contain the paired JS, so
no new tests are enabled here and CI stays in the usual "pending dep bump" state. Verified locally
against a `babylon.max.js` built from the paired branch, and the plugin compiles clean
(`cmake --build build/win32 --target NativeEngine --config RelWithDebInfo`).

## Follow-ups (separate work)

- OIT depth-peeling still faults inside the D3D11 driver on `submit` (multi-output / SRV↔RTV
  ping-pong); needs interactive GPU debugging (PIX / VS Graphics Debugger).
- Native does not yet apply the blend **equation** (`MAX`) — `setAlphaEquation` is a no-op — so OIT
  blending would still be incorrect after the crash is fixed.
- 2D-array / cube color attachments for MRT are approximated as 2D (test "MRT with different texture
  types").

---

## Related PRs & landing order

- **Babylon.js (engine / TS):** https://github.com/BabylonJS/Babylon.js/pull/18568
- **BabylonNative (C++ engine):** https://github.com/BabylonJS/BabylonNative/pull/1754

These two are co-dependent and land in this order:
1. **Babylon.js #18568 first** — it only adds native-engine TS overrides, changes no WebGL behavior,
   re-enables no validation tests on its own, and feature-detects this PR's additions, so it can merge
   independently.
2. A **`babylonjs` npm release** ships that TS change.
3. **BabylonNative #1754 last** — after bumping the bundled `babylonjs` to that release. (This
   foundational pair does not yet turn the MRT/OIT/FrameGraph tests green — that is separate follow-up
   work.)
