### PR TITLE
NativeEngine: validate Image instance in createImageBitmap before reading _imageContainer

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -2042,7 +2042,18 @@ namespace Babylon
         {
             // If this is an object, then check if it has the _imageContainer property defined.
             auto imageObject = info[0].As<Napi::Object>();
-            if (imageObject.Has("_imageContainer"))
+
+            // Security: _imageContainer is a Napi::Pointer, i.e. the raw bytes of a bimg::ImageContainer*
+            // with no type safety (see napi/pointer.h). Reading it off an arbitrary object would let crafted
+            // JS (e.g. `{ _imageContainer: new Uint32Array([lo, hi]) }`) forge a native pointer and turn the
+            // memcpy below into an attacker-controlled-address read into a JS-visible buffer (CWE-822 /
+            // CWE-125). Only accept the handle from a genuine Image (NativeCanvasImage) instance, whose
+            // engine-owned getter mints the pointer. NativeCanvasImage registers its constructor as "Image"
+            // on the native object (Polyfills/Canvas/Source/Image.cpp); validating instanceof against it
+            // rejects forged objects. (napi type-tagging would be ideal but is V8-only in JsRuntimeHost.)
+            constexpr const char* imageConstructorName = "Image";
+            const auto imageConstructor = JsRuntime::NativeObject::GetFromJavaScript(env).Get(imageConstructorName);
+            if (imageConstructor.IsFunction() && imageObject.InstanceOf(imageConstructor.As<Napi::Function>()) && imageObject.Has("_imageContainer"))
             {
                 const auto napiImageContainer = imageObject.Get("_imageContainer");
                 if (!napiImageContainer.IsNull())

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -2047,13 +2047,17 @@ namespace Babylon
             // with no type safety (see napi/pointer.h). Reading it off an arbitrary object would let crafted
             // JS (e.g. `{ _imageContainer: new Uint32Array([lo, hi]) }`) forge a native pointer and turn the
             // memcpy below into an attacker-controlled-address read into a JS-visible buffer (CWE-822 /
-            // CWE-125). Only accept the handle from a genuine Image (NativeCanvasImage) instance, whose
-            // engine-owned getter mints the pointer. NativeCanvasImage registers its constructor as "Image"
-            // on the native object (Polyfills/Canvas/Source/Image.cpp); validating instanceof against it
-            // rejects forged objects. (napi type-tagging would be ideal but is V8-only in JsRuntimeHost.)
+            // CWE-125). Only accept the handle from a genuine Image (NativeCanvasImage) instance, and only
+            // via its engine-owned prototype accessor. NativeCanvasImage registers its constructor as "Image"
+            // on the native object and exposes _imageContainer as a prototype InstanceAccessor
+            // (Polyfills/Canvas/Source/Image.cpp). instanceof alone is bypassable -- e.g.
+            // `Object.create(_native.Image.prototype)` with an OWN _imageContainer property that shadows the
+            // accessor -- so also require that the object does NOT carry its own _imageContainer property,
+            // forcing the value to resolve through the engine-owned accessor. (napi type-tagging would be the
+            // ideal mechanism but is V8-only in JsRuntimeHost; instanceof / has-own-property are portable.)
             constexpr const char* imageConstructorName = "Image";
             const auto imageConstructor = JsRuntime::NativeObject::GetFromJavaScript(env).Get(imageConstructorName);
-            if (imageConstructor.IsFunction() && imageObject.InstanceOf(imageConstructor.As<Napi::Function>()) && imageObject.Has("_imageContainer"))
+            if (imageConstructor.IsFunction() && imageObject.InstanceOf(imageConstructor.As<Napi::Function>()) && !imageObject.HasOwnProperty("_imageContainer"))
             {
                 const auto napiImageContainer = imageObject.Get("_imageContainer");
                 if (!napiImageContainer.IsNull())


### PR DESCRIPTION
## What

The native `createImageBitmap()` accepted an `_imageContainer` property off **any** object passed to it and reinterpreted it as a `bimg::ImageContainer*`. `Napi::Pointer` carries the raw bytes of a native pointer with no type safety, so a crafted object — e.g. `{ _imageContainer: new Uint32Array([lo, hi]) }` — could forge an arbitrary native pointer. The subsequent `memcpy(buffer.Data(), image->m_data, image->m_size)` would then read from an attacker-influenced address/length into a JS-visible `Uint8Array` (untrusted pointer dereference / out-of-bounds read, CWE-822 / CWE-125), or crash.

The only legitimate source of `_imageContainer` is the engine-owned getter on a `NativeCanvasImage` (the `Image` polyfill).

## Fix

Before reading `_imageContainer`, verify the argument is `instanceof` the engine-registered `Image` constructor (`NativeCanvasImage`). Only genuine `Image` instances — whose getter mints the pointer — are accepted; forged objects are rejected with the existing `"CreateImageBitmap parameter is not an array buffer or Image object."` error.

`napi_type_tag_object` would be the ideal mechanism, but it is only implemented for V8 in JsRuntimeHost; `napi_instanceof` is implemented across the Chakra / JavaScriptCore / V8 backends, so the `instanceof` check is portable.

## Testing

- Forged `{ _imageContainer: new Uint32Array([...]) }` and `{ _imageContainer: {} }` are now **rejected** (no out-of-bounds read or crash).
- A genuine `Image` (decoded from a base64 PNG) still produces a valid bitmap via `createImageBitmap` (1×1 verified).
- Playground builds clean (Win32 / D3D11).

## Note

This is a defense-in-depth hardening of one native-handle ingestion site. Babylon Native treats the embedded first-party JS runtime as trusted, but `createImageBitmap` is unusual in reading a handle off an arbitrary caller-supplied object (rather than a conventional method-argument handle), which makes validating the instance worthwhile.
