### PR TITLE
Restore layerIndex parameter on deprecated ExternalTexture::AddToContextAsync

### DIFF
--- a/Apps/UnitTests/Source/Tests.ExternalTexture.cpp
+++ b/Apps/UnitTests/Source/Tests.ExternalTexture.cpp
@@ -218,7 +218,7 @@ TEST(ExternalTexture, AddToContextAsyncWithLayerIndex)
     // Close the frame in which the deprecated shim's synchronous CreateForJavaScript ran.
     device.FinishRenderingCurrentFrame();
 
-    // Wait for promise to resolve.
-    promiseResolved.get_future().wait();
+    // get() (not wait()) so a rejected promise rethrows and fails the test.
+    EXPECT_NO_THROW(promiseResolved.get_future().get());
 #endif
 }

--- a/Apps/UnitTests/Source/Tests.ExternalTexture.cpp
+++ b/Apps/UnitTests/Source/Tests.ExternalTexture.cpp
@@ -166,3 +166,59 @@ TEST(ExternalTexture, AddToContextAsyncAndUpdate)
     device.FinishRenderingCurrentFrame();
 #endif
 }
+
+TEST(ExternalTexture, AddToContextAsyncWithLayerIndex)
+{
+#ifdef SKIP_EXTERNAL_TEXTURE_TESTS
+    GTEST_SKIP();
+#else
+    Babylon::Graphics::Device device{g_deviceConfig};
+
+    device.StartRenderingCurrentFrame();
+
+    // Array texture (3 layers) so a non-zero layer index is valid.
+    auto nativeTexture = Helpers::CreateTexture(device.GetPlatformInfo().Device, 256, 256, 3);
+    Babylon::Plugins::ExternalTexture externalTexture{nativeTexture};
+    Helpers::DestroyTexture(nativeTexture);
+
+    std::promise<void> addToContext{};
+    std::promise<void> promiseResolved{};
+
+    Babylon::AppRuntime runtime{};
+    runtime.Dispatch([&device, &addToContext, &promiseResolved, externalTexture](Napi::Env env) {
+        device.AddToJavaScript(env);
+
+        Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
+            std::cout << message << std::endl;
+        });
+
+        Babylon::Polyfills::Window::Initialize(env);
+
+        Babylon::Plugins::NativeEngine::Initialize(env);
+
+        // Backwards-compat: the deprecated AddToContextAsync must still accept a layer
+        // index and forward it to CreateForJavaScript (views only that array slice).
+        auto jsPromise = externalTexture.AddToContextAsync(env, 1);
+        addToContext.set_value();
+
+        auto jsOnFulfilled = Napi::Function::New(env, [&promiseResolved](const Napi::CallbackInfo& info) {
+            promiseResolved.set_value();
+        });
+
+        auto jsOnRejected = Napi::Function::New(env, [&promiseResolved](const Napi::CallbackInfo& info) {
+            promiseResolved.set_exception(std::make_exception_ptr(info[0].As<Napi::Error>()));
+        });
+
+        jsPromise.Get("then").As<Napi::Function>().Call(jsPromise, {jsOnFulfilled, jsOnRejected});
+    });
+
+    // Wait for AddToContextAsync to be called.
+    addToContext.get_future().wait();
+
+    // Close the frame in which the deprecated shim's synchronous CreateForJavaScript ran.
+    device.FinishRenderingCurrentFrame();
+
+    // Wait for promise to resolve.
+    promiseResolved.get_future().wait();
+#endif
+}

--- a/Plugins/ExternalTexture/Include/Babylon/Plugins/ExternalTexture.h
+++ b/Plugins/ExternalTexture/Include/Babylon/Plugins/ExternalTexture.h
@@ -40,8 +40,9 @@ namespace Babylon::Plugins
 
         // Deprecated: use CreateForJavaScript instead. Retained as a shim for existing consumers.
         // Returns a Promise that is already resolved with the value from CreateForJavaScript.
+        // If layerIndex is set, the JavaScript texture views only that array layer (single-slice).
         [[deprecated("Use CreateForJavaScript instead.")]]
-        Napi::Promise AddToContextAsync(Napi::Env) const;
+        Napi::Promise AddToContextAsync(Napi::Env, std::optional<uint16_t> layerIndex = {}) const;
 
         // Updates to a new texture. If layerIndex is set, views only that array layer (single-slice).
         void Update(Graphics::TextureT, std::optional<Graphics::TextureFormatT> = {}, std::optional<uint16_t> layerIndex = {});

--- a/Plugins/ExternalTexture/Source/ExternalTexture_Shared.h
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Shared.h
@@ -136,10 +136,10 @@ namespace Babylon::Plugins
         m_impl->Update(ptr, overrideFormat, layerIndex);
     }
 
-    Napi::Promise ExternalTexture::AddToContextAsync(Napi::Env env) const
+    Napi::Promise ExternalTexture::AddToContextAsync(Napi::Env env, std::optional<uint16_t> layerIndex) const
     {
         auto deferred = Napi::Promise::Deferred::New(env);
-        deferred.Resolve(CreateForJavaScript(env));
+        deferred.Resolve(CreateForJavaScript(env, layerIndex));
         return deferred.Promise();
     }
 }


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

#1646 kept `AddToContextAsync` as a deprecated shim but dropped its optional `layerIndex` parameter:

- Before: `Napi::Promise AddToContextAsync(Napi::Env, std::optional<uint16_t> layerIndex = {}) const;`
- After: `Napi::Promise AddToContextAsync(Napi::Env) const;`

So callers passing a layer index (e.g. `AddToContextAsync(env, 1)`) no longer compile. This restores the parameter and forwards it to `CreateForJavaScript` (keeping `[[deprecated]]`), plus a test (`AddToContextAsyncWithLayerIndex`) covering the two-argument form on a 3-layer array texture.
