### PR TITLE
NativeEngine: fix use-after-free in texture upload mip loop (regression of #1628)

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -318,7 +318,7 @@ namespace Babylon
                 texture->Create2D(static_cast<uint16_t>(image->m_width), static_cast<uint16_t>(image->m_height), (image->m_numMips > 1), 1, Cast(image->m_format), flags);
             }
 
-            for (uint8_t mip = 0; mip < image->m_numMips; ++mip)
+            for (uint8_t mip = 0, numMips = image->m_numMips; mip < numMips; ++mip)
             {
                 bimg::ImageMip imageMip{};
                 if (bimg::imageGetRawData(*image, 0, mip, image->m_data, image->m_size, imageMip))
@@ -387,7 +387,7 @@ namespace Babylon
                 for (uint8_t side = 0; side < 6; ++side)
                 {
                     bimg::ImageContainer* image{images[side]};
-                    for (uint8_t mip = 0; mip < image->m_numMips; ++mip)
+                    for (uint8_t mip = 0, numMips = image->m_numMips; mip < numMips; ++mip)
                     {
                         bimg::ImageMip imageMip{};
                         if (bimg::imageGetRawData(*image, 0, mip, image->m_data, image->m_size, imageMip))


### PR DESCRIPTION
## Problem

`NativeEngine::LoadTextureFromImage` (and the single-mip-per-face branch of
`LoadCubeTextureFromImages`) drove the mip-upload loop with
`for (uint8_t mip = 0; mip < image->m_numMips; ++mip)`, re-reading
`image->m_numMips` for the exit condition on every iteration.

On the **last** iteration the mip is submitted to bgfx via
`bgfx::makeRef(imageMip.m_data, imageMip.m_size, releaseFn, image)`, where
`releaseFn` calls `bimg::imageFree(image)`. bgfx invokes that release once it
has consumed the memory — which happens on the render thread inside
`bgfx::frame()`, potentially **immediately** after `Update2D`/`UpdateCube`
submits the command. The loop then evaluates `mip < image->m_numMips` by
dereferencing `image` *after it may already have been freed*. If the stale
`m_numMips` read happens to be greater than `mip`, the loop re-enters
`bimg::imageGetRawData(*image, ...)` on the freed container; its garbage
`m_format` indexes `s_imageBlockInfo` out of bounds → an intermittent access
violation.

This is a **use-after-free (CWE-416)**, reproduced as a rare, timing-dependent
(~8%, ~1-in-12) crash on texture-loading validation tests (e.g. an NME particle
test that loads a ramp texture while the render loop is active).

### Not a bgfx threading bug
bgfx resource creation/update **are** mutex-guarded (`m_resourceApiLock`, which
`bgfx::frame()` also holds), so calling them from the decode worker thread is
safe and supported. The defect is purely that BabylonNative keeps
dereferencing `image` after handing its ownership to bgfx's asynchronous
release queue.

## Fix

Cache `image->m_numMips` in the loop initializer
(`for (uint8_t mip = 0, numMips = image->m_numMips; mip < numMips; ++mip)`) so
the loop bound is no longer re-read from `image` after the freeing submit.

This restores **verbatim** the change made in
[`e8ee5f7`](https://github.com/BabylonJS/BabylonNative/commit/e8ee5f74baf2472eafe260ffecd36b7301d77ca4)
(#1628) — see Regression history below.

## Regression history

This is a **re-fix of a previously-fixed bug**. The exact same race was fixed
in April by commit
[`e8ee5f7`](https://github.com/BabylonJS/BabylonNative/commit/e8ee5f74baf2472eafe260ffecd36b7301d77ca4)
("Fixed race condition when passing data to bgfx. Issue #1398", #1628), which
changed both loops to `for (uint8_t mip = 0, numMips = image->m_numMips; ...)`.

That fix was inadvertently reverted by commit
[`6bb8014`](https://github.com/BabylonJS/BabylonNative/commit/6bb8014121bb5fb9d46fe7b02b3670522c3bb288)
("Reworked threading model.", #1652), which restored the original
`for (uint8_t mip = 0; mip < image->m_numMips; ++mip)` form in both
`LoadTextureFromImage` and `LoadCubeTextureFromImages`, reintroducing the
use-after-free. This PR re-applies the original fix unchanged.

## Validation

- Stress-tested an affected texture-loading validation test **3000× headless**
  (30 × 100, 5-way concurrent for extra scheduler pressure): **0 crashes**
  (baseline crashes ~8% / ~1-in-12). At that baseline rate P(0 in 3000) is
  effectively zero, so the use-after-free is eliminated.
- Particle validation subset: no regressions.
