### PR TITLE
Bump JsRuntimeHost pin (napi string-getter underflow fix + 3 others)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ FetchContent_Declare(ios-cmake
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(JsRuntimeHost
     GIT_REPOSITORY https://github.com/BabylonJS/JsRuntimeHost.git
-    GIT_TAG 99457c03625782c3eeac6609f632538c7c9445d0)
+    GIT_TAG 272f6a9f3de78f7c4cd8a838ae9655c81fc4881a)
 FetchContent_Declare(metal-cpp
     GIT_REPOSITORY https://github.com/bkaradzic/metal-cpp.git
     GIT_TAG metal-cpp_26


### PR DESCRIPTION
## What

Bump the `JsRuntimeHost` FetchContent pin to JRH `main` HEAD `272f6a9f`.

This brings in a security fix in JsRuntimeHost — an integer underflow in the Chakra `napi_get_value_string_*` getters when a caller passes a non-null buffer with `bufsize == 0` (`bufsize - 1` underflows to `SIZE_MAX`, causing an out-of-bounds write):

- https://github.com/BabylonJS/JsRuntimeHost/pull/197

It is a single-commit fast-forward over the pin currently on `master` (`99457c03`, JRH #181).

## Verification

- CMake reconfigure fetches JsRuntimeHost at `272f6a9f`; the `#197` fix is present in `js_native_api_chakra.cc`.
- Playground (D3D11, Debug) configures and builds clean against JsRuntimeHost `272f6a9f` (`napi`, `JsRuntime`, `AppRuntime`, and the polyfills relink; `Playground.exe` is produced).
