### PR TITLE
Re-enable blur-cube-with-the-effect-renderer validation test

### DIFF
--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -2575,8 +2575,6 @@
             "title": "blur-cube-with-the-effect-renderer",
             "playgroundId": "#4C900K#2",
             "renderCount": 20,
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel comparison fails (more than 20% pixels differ)",
             "referenceImage": "blur-cube-with-the-effect-renderer.png"
         },
         {

--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -11,13 +11,13 @@
         "UnitTests/JavaScript"
       ],
       "dependencies": {
-        "babylonjs": "^9.3.4",
-        "babylonjs-addons": "^9.3.4",
-        "babylonjs-gltf2interface": "^9.3.4",
-        "babylonjs-gui": "^9.3.4",
-        "babylonjs-loaders": "^9.3.4",
-        "babylonjs-materials": "^9.3.4",
-        "babylonjs-serializers": "^9.3.4",
+        "babylonjs": "^9.15.0",
+        "babylonjs-addons": "^9.15.0",
+        "babylonjs-gltf2interface": "^9.15.0",
+        "babylonjs-gui": "^9.15.0",
+        "babylonjs-loaders": "^9.15.0",
+        "babylonjs-materials": "^9.15.0",
+        "babylonjs-serializers": "^9.15.0",
         "jsc-android": "^241213.1.0",
         "v8-android": "^7.8.2"
       }
@@ -2596,63 +2596,63 @@
       }
     },
     "node_modules/babylonjs": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-9.9.1.tgz",
-      "integrity": "sha512-zMH8r0l/il9PJhy2+uS+/EyeLBy/ElZg0lKLj2d+ZrUarOanjMISaACw0HUx7C1EgYoXUFSMQLYcpXguleh8GA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-9.15.0.tgz",
+      "integrity": "sha512-IJQhrxsxxj4KCg4aSsB5chLidzAfbghr8rnzo6sRLFin6ipfeayCxg7MevjaMzqdVmc/BOMU6sj49nSNrBq+yQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-addons": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-addons/-/babylonjs-addons-9.9.1.tgz",
-      "integrity": "sha512-Hi9QZqeanqG+4VAAmJmHJh7JKf1bc/Y5Ml+wuv+W+3f/dKltZpy/pii/QN4vhYRyrU0n+S8OJc+kVeaUUFjHEg==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-addons/-/babylonjs-addons-9.15.0.tgz",
+      "integrity": "sha512-7vxm0ffFXWHCZWDlYYleifb6mg1iSH7nNo+sA9706z7QIfpNnLS9+9cTYadWobvhURwaD/DHAKnm7Z8ckq9YAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1"
+        "babylonjs": "9.15.0"
       }
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.9.1.tgz",
-      "integrity": "sha512-qHE7pASEWbRORU+NEPSSL9fyVh6gBNqC1ugV94YL9Dz0HnLcH8YNcxdi6Pf+oXgFHRrXWZiJATn37HynsF7/0g==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.15.0.tgz",
+      "integrity": "sha512-Yr/WvOvnsZFN2LoyNU/ZZbT+lXMdNA9OiZzE4RibI1tnYxQjpPKT6X1cxQ/ACJPVzKwudxzJxQ/f/Tdba4TLDg==",
       "license": "Apache-2.0"
     },
     "node_modules/babylonjs-gui": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-9.9.1.tgz",
-      "integrity": "sha512-w6HSvuHSqLYUOuxvko+gkjAQMvatf7gnOPufLRslm+P4tC+5KMEd0hyC+1vHCJuQmZXXkoc/GnozzFeaqllHZw==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gui/-/babylonjs-gui-9.15.0.tgz",
+      "integrity": "sha512-klF2ywhA040JMQ3Z5XaGkN4S0GIOshtnvtUd8kbYqlLYEu5i6/y/zvB8V3O4geslzV0kWcBe2mIthlr7M7p4og==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1"
+        "babylonjs": "9.15.0"
       }
     },
     "node_modules/babylonjs-loaders": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-9.9.1.tgz",
-      "integrity": "sha512-bFSe4TQTi7aA7RsWmuZHQLX4mBMoza5D+AFRD2tVrizGyGCfQJALKnKze7Z3OetFyeo72838GXJAXmyiOWcxAA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-loaders/-/babylonjs-loaders-9.15.0.tgz",
+      "integrity": "sha512-k5Kg9wmuy0n4ZAWu9woFk3C1yEwSvQHRv0Ct2GOQtuRvIHUIyRcW4KEKOsW0GOiApSjXh9nQcabdJTnUo8IBNw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1",
-        "babylonjs-gltf2interface": "9.9.1"
+        "babylonjs": "9.15.0",
+        "babylonjs-gltf2interface": "9.15.0"
       }
     },
     "node_modules/babylonjs-materials": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-9.9.1.tgz",
-      "integrity": "sha512-2ai5hk59dzHRUN28/5/Nijknn+IungSuoBsrHrNZE2T/yIT+/T/IrU0ebm53nRYliv6NG0IaxSCfnh6euZUj7A==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-materials/-/babylonjs-materials-9.15.0.tgz",
+      "integrity": "sha512-E9C5EB0nZJrGvT7Mb38gypAnzi1q8vr/Gi+fTeqRQilIU8mdk+YzD5unfKOROEv8arRFCXGWrtBqkIN8k2PFxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1"
+        "babylonjs": "9.15.0"
       }
     },
     "node_modules/babylonjs-serializers": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.9.1.tgz",
-      "integrity": "sha512-nZJPplzHprwJhp4JVLgB3dEpJR2HvEElPIDvOoAFf1IcaKwcDja2tZTGXIbARdWlTX547pN0qN/vEd6dYLrnDA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.15.0.tgz",
+      "integrity": "sha512-iLYwPzZrUr2SnwHcsXjHJHYdJIVC+boW6z/olE0mE5GvqmfKXTtqFr9wRGrsq85BarhHQkfVlfQdFwhFq/JG4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "babylonjs": "9.9.1",
-        "babylonjs-gltf2interface": "9.9.1"
+        "babylonjs": "9.15.0",
+        "babylonjs-gltf2interface": "9.15.0"
       }
     },
     "node_modules/balanced-match": {

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -9,13 +9,13 @@
     "getNightly": "node scripts/getNightly.js"
   },
   "dependencies": {
-    "babylonjs": "^9.3.4",
-    "babylonjs-addons": "^9.3.4",
-    "babylonjs-gltf2interface": "^9.3.4",
-    "babylonjs-gui": "^9.3.4",
-    "babylonjs-loaders": "^9.3.4",
-    "babylonjs-materials": "^9.3.4",
-    "babylonjs-serializers": "^9.3.4",
+    "babylonjs": "^9.15.0",
+    "babylonjs-addons": "^9.15.0",
+    "babylonjs-gltf2interface": "^9.15.0",
+    "babylonjs-gui": "^9.15.0",
+    "babylonjs-loaders": "^9.15.0",
+    "babylonjs-materials": "^9.15.0",
+    "babylonjs-serializers": "^9.15.0",
     "jsc-android": "^241213.1.0",
     "v8-android": "^7.8.2"
   }


### PR DESCRIPTION
## What

Re-enables the `blur-cube-with-the-effect-renderer` Playground validation test (`#4C900K#2`) by
dropping its `excludeFromAutomaticTesting` entry in `config.json`, and bumps the bundled `babylonjs`
to **9.15.0** (which contains the paired engine fix) so the test actually passes in CI.

Two commits:
1. Re-enable `blur-cube-with-the-effect-renderer` in `Apps/Playground/Scripts/config.json`.
2. Bump `babylonjs` to 9.15.0 in `Apps/package.json` + `Apps/package-lock.json`.

Broken out of https://github.com/BabylonJS/BabylonNative/pull/1748 so it can merge independently:
#1748 re-enables this same test alongside six single-file-`.dds` cube tests, but those six are still
gated on an unmerged cube-loading TS change (BabylonJS/Babylon.js#18567), whereas this test only
needs the already-merged depth-test fix. (#1748 currently still carries a duplicate `blur-cube`
re-enable; that entry should be dropped there once this lands.)

## Why it passes now

The test previously failed pixel comparison because the native engine ignored
`depthCullingState.depthTest`, so an `EffectRenderer` fullscreen pass produced an all-black frame.
That is fixed by https://github.com/BabylonJS/Babylon.js/pull/18558 ("[Native] Honor
depthCullingState.depthTest on the native engine"), **merged 2026-06-16 and shipped in `babylonjs`
9.15.0** — the version this PR now pins. With that fix present in the bundled engine the pass renders
correctly and the test matches its reference image.

## Status

- **Pin bump included; the earlier gate is resolved.** The bump to 9.15.0 (which contains #18558) is
  part of this PR, so the re-enable no longer depends on a separate future `babylonjs` bump.
- **CI is fully green**, including every Win32 D3D11 and Ubuntu desktop job that runs the validation
  suite — `blur-cube-with-the-effect-renderer` validates. Ready to merge (pending review).
