### PR TITLE
Update bgfx.cmake to converged bgfx (539e1feb); drop platform.h include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ FetchContent_Declare(base-n
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(bgfx.cmake
     GIT_REPOSITORY https://github.com/BabylonJS/bgfx.cmake.git
-    GIT_TAG 68762dde81848256bd785880b00309832b1cad27
+    GIT_TAG 9c64597523a4edb3c54ef66f7ad1c7c3fa806ceb
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(CMakeExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/CMakeExtensions.git

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/BgfxCallback.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/BgfxCallback.h
@@ -4,7 +4,6 @@
 #include <functional>
 
 #include <bgfx/bgfx.h>
-#include <bgfx/platform.h>
 
 namespace Babylon::Graphics
 {

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
@@ -9,7 +9,6 @@
 #include <napi/env.h>
 
 #include <bgfx/bgfx.h>
-#include <bgfx/platform.h>
 
 #include <mutex>
 #include <unordered_map>

--- a/Core/Graphics/Source/DeviceImpl.h
+++ b/Core/Graphics/Source/DeviceImpl.h
@@ -13,7 +13,6 @@
 #include <napi/env.h>
 
 #include <bgfx/bgfx.h>
-#include <bgfx/platform.h>
 
 #include <atomic>
 #include <condition_variable>

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -67,6 +67,12 @@ target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_MAX_FRAME_BUFFERS=${BGFX_CON
 # Temporary disable uniform debug.
 target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_DEBUG_UNIFORM=0)
 
+# Disable video decoding support (not used by Babylon Native).
+target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_VIDEO=0)
+
+# Disable the C99 API (Babylon Native uses the C++ API only); saves binary size.
+target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_C99_API=0)
+
 if(GRAPHICS_API STREQUAL "D3D11")
     target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_RENDERER_DIRECT3D11=1)
 elseif(GRAPHICS_API STREQUAL "D3D12")

--- a/Plugins/NativeCamera/Source/Android/CameraDevice.cpp
+++ b/Plugins/NativeCamera/Source/Android/CameraDevice.cpp
@@ -9,7 +9,6 @@
 #include <media/NdkImageReader.h>
 #include <android/log.h>
 #include <bgfx/bgfx.h>
-#include <bgfx/platform.h>
 #include <arcana/threading/dispatcher.h>
 #include <Babylon/JsRuntimeScheduler.h>
 #include <Babylon/Graphics/DeviceContext.h>

--- a/Plugins/NativeCamera/Source/Apple/CameraDevice.mm
+++ b/Plugins/NativeCamera/Source/Apple/CameraDevice.mm
@@ -5,7 +5,6 @@
 #import <MetalKit/MetalKit.h>
 #include <napi/napi.h>
 #include <bgfx/bgfx.h>
-#include <bgfx/platform.h>
 #include <arcana/macros.h>
 #include <arcana/threading/task.h>
 #include <arcana/threading/dispatcher.h>

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -16,7 +16,6 @@
 #include <napi/napi.h>
 
 #include <bgfx/bgfx.h>
-#include <bgfx/platform.h>
 #ifdef BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES
 #include <bimg/bimg.h>
 #include <bx/allocator.h>

--- a/Plugins/TestUtils/Source/TestUtils.cpp
+++ b/Plugins/TestUtils/Source/TestUtils.cpp
@@ -2,7 +2,6 @@
 #include <Babylon/Plugins/TestUtils.h>
 
 #include <bgfx/bgfx.h>
-#include <bgfx/platform.h>
 #ifdef BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES
 #include <bimg/decode.h>
 #include <bimg/encode.h>


### PR DESCRIPTION
## Summary

Bumps the `bgfx.cmake` pin to [`9c64597`](https://github.com/BabylonJS/bgfx.cmake/commit/9c64597523a4edb3c54ef66f7ad1c7c3fa806ceb), which vendors the converged **BabylonJS/bgfx @ `539e1feb`** and carries the CMake fixes that bring bimg's CMake build in line with its GENie build:

- `image_decode_wic.cpp` is now globbed (WIC decoder),
- the ETC2 encoder dir was renamed to `etcpak`,
- AVIF decode (dav1d codec) is wired up.

Because the converged bgfx drops `include/bgfx/platform.h` (upstream [#3761](https://github.com/bkaradzic/bgfx/pull/3761) — its declarations now live in the generated `bgfx.h`), this removes the now-redundant `#include <bgfx/platform.h>` from the seven BN consumers that carried it (each already includes `<bgfx/bgfx.h>` directly above). That in turn removes the need for the `BGFX_IDL_CPP` compile shim.

Also disables two unused bgfx config features to save binary size:

- `BGFX_CONFIG_VIDEO=0` — video decoding is unused by Babylon Native.
- `BGFX_CONFIG_C99_API=0` — BN uses the C++ API only.

## Changes

- `CMakeLists.txt`: `bgfx.cmake` pin `68762dd` → `9c64597`
- `Dependencies/CMakeLists.txt`: add `BGFX_CONFIG_VIDEO=0` and `BGFX_CONFIG_C99_API=0`
- Remove `#include <bgfx/platform.h>` from 7 files (BgfxCallback.h, DeviceContext.h, DeviceImpl.h, NativeEngine.h, TestUtils.cpp, NativeCamera Apple/Android CameraDevice)

## Validation

- Playground Release builds clean (Win32 D3D11).
- Full headless validation suite: **`ran=295 passed=295 failed=0 missingRef=0`**, exit 0.