### PR TITLE
Playground: clearer pixel-diff failure diagnostics

### DIFF
--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -56,16 +56,13 @@
     function logFailureDiagnostics(test) {
         const outDir = TestUtils.getOutputDirectory();
         if (test.referenceImage) {
-            console.log("  Rendered result: " + outDir + "/Results/" + test.referenceImage);
-            console.log("  Diff overlay:    " + outDir + "/Errors/" + test.referenceImage);
+            console.log(`  Rendered result: ${outDir}/Results/${test.referenceImage}`);
+            console.log(`  Diff overlay:    ${outDir}/Errors/${test.referenceImage}`);
         }
         if (test.playgroundId) {
-            console.log("  Note: this test loads playgroundId " + test.playgroundId +
-                " from the snippet server and pulls GUI/assets/fonts over the network," +
-                " so a pixel diff is often a transient async asset/font-load timing flake.");
+            console.log(`  Note: this test loads playgroundId ${test.playgroundId} from the snippet server and pulls GUI/assets/fonts over the network, so a pixel diff is often a transient async asset/font-load timing flake.`);
             console.log("  Re-run in isolation to confirm a real regression:");
-            console.log("    Playground --headless --once --test \"" + (test.title || "") +
-                "\" app:///Scripts/validation_native.js");
+            console.log(`    Playground --headless --once --test "${test.title || ""}" app:///Scripts/validation_native.js`);
         }
     }
 
@@ -178,8 +175,7 @@
         if (differencesCount) {
             const pixelCount = size / 4;
             const diffRatio = (differencesCount * 100) / pixelCount;
-            console.log("Pixel difference: " + differencesCount + " / " + pixelCount + " pixels (" +
-                diffRatio.toFixed(3) + "%, per-channel threshold " + threshold + "); allowed errorRatio " + errorRatio + "%.");
+            console.log(`Pixel difference: ${differencesCount} / ${pixelCount} pixels (${diffRatio.toFixed(3)}%, per-channel threshold ${threshold}); allowed errorRatio ${errorRatio}%.`);
         } else {
             console.log("No pixel difference!");
         }

--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -165,7 +165,7 @@
 
             if (differencesCount === 0) {
                 const pixel = index / 4;
-                const width = testWidth / engine.getHardwareScalingLevel();
+                const width = Math.round(testWidth / engine.getHardwareScalingLevel());
                 console.log(`First pixel off at ${index} (pixel ${pixel} @ x=${pixel % width}, y=${Math.floor(pixel / width)}): Value: (${renderData[index]}, ${renderData[index + 1]}, ${renderData[index + 2]}) - Expected: (${referenceData[index]}, ${referenceData[index + 1]}, ${referenceData[index + 2]}) `);
             }
 

--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -45,6 +45,30 @@
         done(false);
     }
 
+    // Emitted after a pixel-comparison failure to make triage faster. Prints the
+    // rendered/diff PNG paths and, for scenes fetched from the Babylon snippet
+    // server, a transient-flake hint: those tests pull the GUI library, textures
+    // and web fonts over the network/CDN, so their output depends on async
+    // asset/font-load timing. A pixel diff there is frequently a transient flake
+    // rather than a real regression -- the 'Parse GUI json with unicode' snippet
+    // test is the canonical example (its GUI text renders with the fallback font
+    // until 'droidsans' finishes loading, shifting thousands of glyph pixels).
+    function logFailureDiagnostics(test) {
+        const outDir = TestUtils.getOutputDirectory();
+        if (test.referenceImage) {
+            console.log("  Rendered result: " + outDir + "/Results/" + test.referenceImage);
+            console.log("  Diff overlay:    " + outDir + "/Errors/" + test.referenceImage);
+        }
+        if (test.playgroundId) {
+            console.log("  Note: this test loads playgroundId " + test.playgroundId +
+                " from the snippet server and pulls GUI/assets/fonts over the network," +
+                " so a pixel diff is often a transient async asset/font-load timing flake.");
+            console.log("  Re-run in isolation to confirm a real regression:");
+            console.log("    Playground --headless --once --test \"" + (test.title || "") +
+                "\" app:///Scripts/validation_native.js");
+        }
+    }
+
     // Per-run counters surfaced as a final summary line on exit.
     let ranCount = 0;
     let passedCount = 0;
@@ -140,7 +164,9 @@
             }
 
             if (differencesCount === 0) {
-                console.log(`First pixel off at ${index}: Value: (${renderData[index]}, ${renderData[index + 1]}, ${renderData[index] + 2}) - Expected: (${referenceData[index]}, ${referenceData[index + 1]}, ${referenceData[index + 2]}) `);
+                const pixel = index / 4;
+                const width = testWidth / engine.getHardwareScalingLevel();
+                console.log(`First pixel off at ${index} (pixel ${pixel} @ x=${pixel % width}, y=${Math.floor(pixel / width)}): Value: (${renderData[index]}, ${renderData[index + 1]}, ${renderData[index + 2]}) - Expected: (${referenceData[index]}, ${referenceData[index + 1]}, ${referenceData[index + 2]}) `);
             }
 
             referenceData[index] = 255;
@@ -150,7 +176,10 @@
         }
 
         if (differencesCount) {
-            console.log("Pixel difference: " + differencesCount + " pixels.");
+            const pixelCount = size / 4;
+            const diffRatio = (differencesCount * 100) / pixelCount;
+            console.log("Pixel difference: " + differencesCount + " / " + pixelCount + " pixels (" +
+                diffRatio.toFixed(3) + "%, per-channel threshold " + threshold + "); allowed errorRatio " + errorRatio + "%.");
         } else {
             console.log("No pixel difference!");
         }
@@ -185,7 +214,8 @@
 
             if (compareFunction(test, screenshot, referenceImage, test.threshold || 25, test.errorRatio || defaultErrorRatio)) {
                 testRes = false;
-                console.log("Test '" + (test.title || "(unnamed)") + "' failed");
+                console.log("Test '" + (test.title || "(unnamed)") + "' failed (pixel comparison)");
+                logFailureDiagnostics(test);
             } else {
                 testRes = true;
                 console.log("Test '" + (test.title || "(unnamed)") + "' validated");


### PR DESCRIPTION
## Summary

Makes the Playground validation runner's pixel-comparison failures faster to triage, and flags the common transient network/font-load flake (e.g. `Parse GUI json with unicode`), which is a `playgroundId` snippet test whose GUI text renders with the fallback font until `droidsans.ttf` finishes loading over the network.

## Changes (`Apps/Playground/Scripts/validation_native.js`)

- **Fix a bug in the "First pixel off" line.** It printed the blue channel as `renderData[index] + 2` (red + 2) instead of `renderData[index + 2]`, so the reported "Value" blue was wrong. It now prints the true value and the offending pixel's `x,y` coordinates.
- **Report the diff ratio vs. the allowance.** `Pixel difference:` now shows `N / total pixels (X.XXX%, per-channel threshold T); allowed errorRatio R%`, so it's immediately clear how close a diff is to the pass line.
- **Actionable failure diagnostics.** On a pixel-comparison failure the runner prints the rendered/diff PNG paths, and **for `playgroundId` (snippet) tests only** a note that the scene + its GUI/assets/fonts load over the network (so the diff is often a transient async font/asset-load flake) plus the exact isolation re-run command. Local scene-file tests get only the PNG paths — a diff there is a real regression, not a flake.

## Example output

Passing snippet test (new ratio line + fixed blue channel + coords):
```
First pixel off at 277192 (pixel 69298 @ x=298, y=115): Value: (81, 81, 100) - Expected: (51, 51, 76)
Pixel difference: 2031 / 240000 pixels (0.846%, per-channel threshold 25); allowed errorRatio 2.5%.
Test 'Parse GUI json with unicode' validated
```

Failing snippet test (new hint):
```
Test 'Parse GUI json with unicode' failed (pixel comparison)
  Rendered result: .../Results/parseGuiJsonWithUnicode.png
  Diff overlay:    .../Errors/parseGuiJsonWithUnicode.png
  Note: this test loads playgroundId #ERVGT5#0 from the snippet server and pulls GUI/assets/fonts over the network, so a pixel diff is often a transient async asset/font-load timing flake.
  Re-run in isolation to confirm a real regression:
    Playground --headless --once --test "Parse GUI json with unicode" app:///Scripts/validation_native.js
```

## Validation

- `node --check` passes.
- Ran `Parse GUI json with unicode` in isolation — new output verified, test still passes (`ran=1 passed=1`).
- Diagnostics-only change; no effect on pass/fail logic.