### PR TITLE
Fix Metal/GL instanced-variant attribute location mismatch (particles/instances)

### DIFF
--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -677,8 +677,6 @@
         },
         {
             "title": "Attractors",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#DEZ79M#57",
             "referenceImage": "attractors.png"
         },
@@ -1568,8 +1566,6 @@
         },
         {
             "title": "Particles",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#G3ZYFU#7",
             "renderCount": 100,
             "referenceImage": "particles.png"
@@ -1843,8 +1839,6 @@
         },
         {
             "title": "Instances with color buffer",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#YPABS1#91",
             "referenceImage": "instancecolors.png"
         },
@@ -2674,8 +2668,6 @@
         },
         {
             "title": "halo-particle-system",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#2441BU#1",
             "renderCount": 20,
             "referenceImage": "halo-particle-system.png"
@@ -2690,8 +2682,6 @@
         },
         {
             "title": "particle-system-with-custom-nme-shader",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#DMLLV2",
             "renderCount": 5,
             "referenceImage": "particle-system-with-custom-nme-shader.png"
@@ -4076,288 +4066,216 @@
         },
         {
             "title": "Particles - Basic Properties - Size",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3780",
             "renderCount": 120,
             "referenceImage": "particles-basic-size.png"
         },
         {
             "title": "Particles - Basic Properties - Scale",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3782",
             "renderCount": 120,
             "referenceImage": "particles-basic-scale.png"
         },
         {
             "title": "Particles - Basic Properties - Color",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3786",
             "renderCount": 120,
             "referenceImage": "particles-basic-color.png"
         },
         {
             "title": "Particles - Basic Properties - Speed",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3791",
             "renderCount": 120,
             "referenceImage": "particles-basic-speed.png"
         },
         {
             "title": "Particles - Basic Properties - Angular Speed",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3796",
             "renderCount": 120,
             "referenceImage": "particles-basic-angular-speed.png"
         },
         {
             "title": "Particles - Basic Properties - Angular Speed - Rotation",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3806",
             "renderCount": 120,
             "referenceImage": "particles-basic-angular-speed-rotation.png"
         },
         {
             "title": "Particles - Basic Properties - Translation Pivot",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3808",
             "renderCount": 120,
             "referenceImage": "particles-basic-translation-pivot.png"
         },
         {
             "title": "Particles - Basic Properties - Direction",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3814",
             "renderCount": 120,
             "referenceImage": "particles-basic-direction.png"
         },
         {
             "title": "Particles - Basic Properties - Direction - Gravity",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3816",
             "renderCount": 120,
             "referenceImage": "particles-basic-direction-gravity.png"
         },
         {
             "title": "Particles - Basic Properties - Emit Rate - Slow",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3821",
             "renderCount": 120,
             "referenceImage": "particles-basic-emit-rate-slow.png"
         },
         {
             "title": "Particles - Basic Properties - Emit Rate - Fast",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3823",
             "renderCount": 120,
             "referenceImage": "particles-basic-emit-rate-fast.png"
         },
         {
             "title": "Particles - Basic Properties - Emission Limits",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3825",
             "renderCount": 120,
             "referenceImage": "particles-basic-emission-limits.png"
         },
         {
             "title": "Particles - Basic Properties - Lifetime - Short",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3829",
             "renderCount": 120,
             "referenceImage": "particles-basic-lifetime-short.png"
         },
         {
             "title": "Particles - Basic Properties - Lifetime - Long",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3834",
             "renderCount": 120,
             "referenceImage": "particles-basic-lifetime-long.png"
         },
         {
             "title": "Particles - Change - Size",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3841",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-size.png"
         },
         {
             "title": "Particles - Change - Size 2",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3844",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-size-2.png"
         },
         {
             "title": "Particles - Change - Color",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3847",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-color.png"
         },
         {
             "title": "Particles - Change - Color 2",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3851",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-color-2.png"
         },
         {
             "title": "Particles - Change - Speed",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3853",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-speed.png"
         },
         {
             "title": "Particles - Change - Speed 2",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3855",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-speed-2.png"
         },
         {
             "title": "Particles - Change - Speed Limit",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3859",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-speed-limit.png"
         },
         {
             "title": "Particles - Change - Angular Speed",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3862",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-angular-speed.png"
         },
         {
             "title": "Particles - Change - Angular Speed 2",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3865",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-angular-speed-2.png"
         },
         {
             "title": "Particles - Change - Drag",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3868",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-drag.png"
         },
         {
             "title": "Particles - Change - Drag 2",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3872",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-drag-2.png"
         },
         {
             "title": "Particles - Change - Emit Rate",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3875",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-emit-rate.png"
         },
         {
             "title": "Particles - Change - Emit Rate 2",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3879",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-emit-rate-2.png"
         },
         {
             "title": "Particles - Change - Lifetime",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3885",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-lifetime.png"
         },
         {
             "title": "Particles - Change - Lifetime 2",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3890",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-lifetime-2.png"
         },
         {
             "title": "Particles - Change - Start Size",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#0K3AQ2#3897",
             "renderCount": 120,
             "referenceImage": "particles-basic-change-start-size.png"
         },
         {
             "title": "Particles - Emitters - Point",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#WLX2I2#7",
             "renderCount": 120,
             "referenceImage": "particles-emitters-point.png"
         },
         {
             "title": "Particles - Emitters - Box",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#WLX2I2#8",
             "renderCount": 120,
             "referenceImage": "particles-emitters-box.png"
         },
         {
             "title": "Particles - Emitters - Sphere",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#WLX2I2#9",
             "renderCount": 120,
             "referenceImage": "particles-emitters-sphere.png"
         },
         {
             "title": "Particles - Emitters - Directed Sphere",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#WLX2I2#10",
             "renderCount": 120,
             "referenceImage": "particles-emitters-directed-sphere.png"
         },
         {
             "title": "Particles - Emitters - Hemisphere",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#WLX2I2#11",
             "renderCount": 120,
             "referenceImage": "particles-emitters-hemisphere.png"
         },
         {
             "title": "Particles - Emitters - Cylinder",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#WLX2I2#12",
             "renderCount": 120,
             "errorRatio": 4,
@@ -4373,72 +4291,54 @@
         },
         {
             "title": "Particles - Emitters - Cone",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#WLX2I2#16",
             "renderCount": 120,
             "referenceImage": "particles-emitters-cone.png"
         },
         {
             "title": "Particles - Emitters - Directed Cone",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#WLX2I2#17",
             "renderCount": 120,
             "referenceImage": "particles-emitters-directed-cone.png"
         },
         {
             "title": "Particles - Emitters - Mesh",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#WLX2I2#20",
             "renderCount": 120,
             "referenceImage": "particles-emitters-mesh.png"
         },
         {
             "title": "Particles - Emitters - Custom",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#WLX2I2#22",
             "renderCount": 120,
             "referenceImage": "particles-emitters-custom.png"
         },
         {
             "title": "Particles - Animations",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#2MI0A1#7",
             "renderCount": 120,
             "referenceImage": "particles-animations.png"
         },
         {
             "title": "Particles - Animations 2",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#2MI0A1#8",
             "renderCount": 120,
             "referenceImage": "particles-animations-2.png"
         },
         {
             "title": "Particles - Ramp Gradient",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#I2D9MM#15",
             "renderCount": 120,
             "referenceImage": "particles-ramp-gradient.png"
         },
         {
             "title": "Particles - Ramp Gradient Remap",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#E3VU3R",
             "renderCount": 120,
             "referenceImage": "particles-ramp-gradient-remap.png"
         },
         {
             "title": "Particles - Ramp Gradient Remap Alpha",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#I2D9MM#16",
             "renderCount": 120,
             "referenceImage": "particles-ramp-gradient-remap-alpha.png"
@@ -4477,16 +4377,12 @@
         },
         {
             "title": "Particles - Effects",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#1ASENS#424",
             "renderCount": 120,
             "referenceImage": "particles-effects.png"
         },
         {
             "title": "Particles - Helper - Sun",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#A97UQ6#5",
             "renderCount": 120,
             "referenceImage": "particles-helper-sun.png",
@@ -4510,8 +4406,6 @@
         },
         {
             "title": "Particles - Attractors",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#DEZ79M#73",
             "renderCount": 240,
             "referenceImage": "particles-attractors.png"
@@ -4541,8 +4435,6 @@
         },
         {
             "title": "Selection outline layer with instances and LOD",
-            "excludedGraphicsApis": ["Metal"],
-            "reason": "Metal: crashes with MTLVertexDescriptor assertion (attribute references a buffer with no stride) in the particle/instance rendering path on macOS.",
             "playgroundId": "#8I487I#0",
             "referenceImage": "Selection-outline-layer-with-instances-and-LOD.png"
         },

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
@@ -684,7 +684,9 @@ namespace Babylon::ShaderCompilerTraversers
                 // To work around this issue, instead of mapping our attributes to the most similar bgfx::attribute, instead replace
                 // the first attribute encountered with the symbol bgfx uses for attribute 0 and increment for each subsequent attribute encountered.
                 // This will cause our shader to have nonsensical naming, but will allow us to efficiently "pack" the attributes.
-                m_genericAttributesRunningCount++;
+                const unsigned int stableLocation = GetStableLocation(name);
+                if (stableLocation >= static_cast<unsigned int>(bgfx::Attrib::Count))
+                    throw std::runtime_error("Cannot support more than 18 vertex attributes.");
                 if (IsGenericInstance(name))
                 {
                     // Consumer-declared instanced attribute: route to the explicit bgfx i_data
@@ -694,18 +696,15 @@ namespace Babylon::ShaderCompilerTraversers
                     const unsigned int slot = static_cast<unsigned int>(bgfx::Attrib::TexCoord7) - location;
                     if (slot >= BX_COUNTOF(s_attribInstanceName))
                         throw std::runtime_error(std::string{"Instanced attribute '"} + name + "' has location " + std::to_string(location) + " which does not map to a valid bgfx i_data slot (computed slot " + std::to_string(slot) + ").");
-                    return {GetStableLocation(name), s_attribInstanceName[slot]};
+                    return {stableLocation, s_attribInstanceName[slot]};
                 }
                 if (IsInstance(name))
                 {
                     // Reverse: bgfx maps i_data0 to the highest semantic (TEXCOORD7),
                     // so the first instance attribute gets the highest i_data index.
-                    return {GetStableLocation(name), s_attribInstanceName[--m_instanceAttributeCount]};
+                    return {stableLocation, s_attribInstanceName[--m_instanceAttributeCount]};
                 }
-                if (m_genericAttributesRunningCount >= static_cast<unsigned int>(bgfx::Attrib::Count))
-                    throw std::runtime_error("Cannot support more than 18 vertex attributes.");
-
-                return {GetStableLocation(name), s_attribName[GetStableLocation(name)]};
+                return {stableLocation, s_attribName[stableLocation]};
             }
             unsigned int m_instanceAttributeCount{0};
         };
@@ -770,7 +769,9 @@ namespace Babylon::ShaderCompilerTraversers
                 // the first attribute encountered with the symbol bgfx uses for attribute 0 and increment for each subsequent attribute encountered.
                 // This will cause our shader to have nonsensical naming, but will allow us to efficiently "pack" the attributes.
 
-                m_genericAttributesRunningCount++;
+                const unsigned int stableLocation = GetStableLocation(name);
+                if (stableLocation >= static_cast<unsigned int>(bgfx::Attrib::Count))
+                    throw std::runtime_error("Cannot support more than 18 vertex attributes.");
                 if (IsGenericInstance(name))
                 {
                     // Consumer-declared instanced attribute: route to the explicit bgfx i_data
@@ -780,16 +781,13 @@ namespace Babylon::ShaderCompilerTraversers
                     const unsigned int slot = static_cast<unsigned int>(bgfx::Attrib::TexCoord7) - location;
                     if (slot >= BX_COUNTOF(s_attribInstanceName))
                         throw std::runtime_error(std::string{"Instanced attribute '"} + name + "' has location " + std::to_string(location) + " which does not map to a valid bgfx i_data slot (computed slot " + std::to_string(slot) + ").");
-                    return {GetStableLocation(name), s_attribInstanceName[slot]};
+                    return {stableLocation, s_attribInstanceName[slot]};
                 }
                 if (IsInstance(name))
                 {
-                    return {GetStableLocation(name), s_attribInstanceName[--m_instanceAttributeCount]};
+                    return {stableLocation, s_attribInstanceName[--m_instanceAttributeCount]};
                 }
-                if (m_genericAttributesRunningCount >= static_cast<unsigned int>(bgfx::Attrib::Count))
-                    throw std::runtime_error("Cannot support more than 18 vertex attributes.");
-
-                return {GetStableLocation(name), s_attribName[GetStableLocation(name)]};
+                return {stableLocation, s_attribName[stableLocation]};
             }
             unsigned int m_instanceAttributeCount{0};
         };

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
@@ -589,6 +589,28 @@ namespace Babylon::ShaderCompilerTraversers
                        strcmp(name, "splatIndex3") != 0;
             }
 
+            // The shader attribute location assigned to a varying must be stable regardless
+            // of how many attributes are instanced -- i.e. identical between the base program
+            // compile and any instanced variant. Vertex buffers are bound using the base
+            // program's attribute locations (VertexAttributeLocations), so if a variant
+            // reassigns a per-vertex attribute to a different location (as the instance/
+            // non-instance 2-pass ordering would), that buffer's data no longer reaches the
+            // shader and reads zero. The attribute's ordinal position in the name-sorted
+            // varying map is independent of the 2-pass ordering and therefore stable.
+            unsigned int GetStableLocation(const char* name) const
+            {
+                unsigned int index = 0;
+                for (const auto& entry : m_varyingNameToSymbol)
+                {
+                    if (entry.first == name)
+                    {
+                        break;
+                    }
+                    ++index;
+                }
+                return index;
+            }
+
             unsigned int m_genericAttributesRunningCount{0};
             const std::map<std::string, uint32_t>* m_instancedAttributes{nullptr};
             std::map<std::string, TIntermSymbol*> m_varyingNameToSymbol{};
@@ -672,18 +694,18 @@ namespace Babylon::ShaderCompilerTraversers
                     const unsigned int slot = static_cast<unsigned int>(bgfx::Attrib::TexCoord7) - location;
                     if (slot >= BX_COUNTOF(s_attribInstanceName))
                         throw std::runtime_error(std::string{"Instanced attribute '"} + name + "' has location " + std::to_string(location) + " which does not map to a valid bgfx i_data slot (computed slot " + std::to_string(slot) + ").");
-                    return {static_cast<unsigned int>(m_genericAttributesRunningCount - 1), s_attribInstanceName[slot]};
+                    return {GetStableLocation(name), s_attribInstanceName[slot]};
                 }
                 if (IsInstance(name))
                 {
                     // Reverse: bgfx maps i_data0 to the highest semantic (TEXCOORD7),
                     // so the first instance attribute gets the highest i_data index.
-                    return {static_cast<unsigned int>(m_genericAttributesRunningCount - 1), s_attribInstanceName[--m_instanceAttributeCount]};
+                    return {GetStableLocation(name), s_attribInstanceName[--m_instanceAttributeCount]};
                 }
                 if (m_genericAttributesRunningCount >= static_cast<unsigned int>(bgfx::Attrib::Count))
                     throw std::runtime_error("Cannot support more than 18 vertex attributes.");
 
-                return {static_cast<unsigned int>(m_genericAttributesRunningCount - 1), s_attribName[static_cast<unsigned int>(m_genericAttributesRunningCount - 1)]};
+                return {GetStableLocation(name), s_attribName[GetStableLocation(name)]};
             }
             unsigned int m_instanceAttributeCount{0};
         };
@@ -758,16 +780,16 @@ namespace Babylon::ShaderCompilerTraversers
                     const unsigned int slot = static_cast<unsigned int>(bgfx::Attrib::TexCoord7) - location;
                     if (slot >= BX_COUNTOF(s_attribInstanceName))
                         throw std::runtime_error(std::string{"Instanced attribute '"} + name + "' has location " + std::to_string(location) + " which does not map to a valid bgfx i_data slot (computed slot " + std::to_string(slot) + ").");
-                    return {static_cast<unsigned int>(m_genericAttributesRunningCount - 1), s_attribInstanceName[slot]};
+                    return {GetStableLocation(name), s_attribInstanceName[slot]};
                 }
                 if (IsInstance(name))
                 {
-                    return {static_cast<unsigned int>(m_genericAttributesRunningCount - 1), s_attribInstanceName[--m_instanceAttributeCount]};
+                    return {GetStableLocation(name), s_attribInstanceName[--m_instanceAttributeCount]};
                 }
                 if (m_genericAttributesRunningCount >= static_cast<unsigned int>(bgfx::Attrib::Count))
                     throw std::runtime_error("Cannot support more than 18 vertex attributes.");
 
-                return {static_cast<unsigned int>(m_genericAttributesRunningCount - 1), s_attribName[static_cast<unsigned int>(m_genericAttributesRunningCount - 1)]};
+                return {GetStableLocation(name), s_attribName[GetStableLocation(name)]};
             }
             unsigned int m_instanceAttributeCount{0};
         };


### PR DESCRIPTION
## Problem

On **Metal** (and OpenGL), particle systems and instanced meshes with a custom per-instance attribute buffer rendered **collapsed geometry** — particles shrank to invisible points, instanced cubes disappeared. 54 Playground visualization tests were disabled on Metal via `excludedGraphicsApis` in #1772 because of this (they previously crashed with an `MTLVertexDescriptor` assertion; that crash was separately addressed in bgfx, after which they rendered blank/collapsed).

Reference vs. result before this fix (`Instances with color buffer`): two colored cubes → empty frame; particles → tiny dots at the emitter origin.

## Root cause

NativeEngine compiles a separate **instanced shader variant** (`Program::GetOrCreateInstancedVariant`) but binds vertex buffers using the **base** program's `VertexAttributeLocations`.

The Metal/GL shader-compiler traverser assigned per-vertex attribute locations from a running count driven by its instance/non-instance **2-pass ordering**. So a per-vertex attribute got a *different* location in the variant than in the base program. Verified with instrumentation on a particle draw:

```
base    (0 instanced attrs): offset -> a_tangent,  loc=2   <- vertex buffer bound here
variant (4 instanced attrs): offset -> a_position, loc=0   <- shader reads here
```

The bound buffer no longer matched the shader input, so the per-vertex attribute (the billboard `offset`) **read zero** → all quad corners/instances collapsed to a single point. D3D11 is unaffected because it maps attributes by fixed semantic, keeping base and variant consistent.

## Fix

Assign each varying's shader location from its **stable ordinal position in the name-sorted varying map** (new `GetStableLocation` helper), independent of the 2-pass ordering. This keeps per-vertex attribute locations identical between the base program and its instanced variant, so buffers bound at base-program locations reach the shader. The `i_data*` instance-name assignment is unchanged.

- No bgfx changes.
- Base-program / non-instanced compiles are unchanged (their locations already equalled the stable ordinal).
- Applied to both the Metal and OpenGL traversers.

## Re-enables 54 tests

Removes the `excludedGraphicsApis: ["Metal"]` + crash reason from the 54 now-passing tests in `config.json`. The **3** remaining Metal exclusions are unrelated pixel-comparison issues (Convolution Post Process; two OpenPBR Fuzz tests).

## Verification (macOS / Metal, Apple Silicon)

- All **54** previously-excluded tests pass individually and **render correctly** — e.g. `Instances with color buffer` now shows the expected red + green cubes; particle billboards expand and are colored.
- **Full validation suite passes with the 54 enabled** (exit 0, 0 error diffs), no regressions to the ~20 existing instancing tests (Thin Instances, motion-blur, shadows-with-instances, etc.).
- Before → after on the 54: `54 crash` → (post bgfx stride fix) `37 pass / 17 pixel-fail` → **`54 pass`**.
