### PR TITLE
Fix one-frame latency when a canvas texture feeds a same-frame consumer

### DIFF
--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -2275,7 +2275,6 @@
         {
             "title": "Load GUI snippet with unicode",
             "playgroundId": "#YS93KY#1",
-            "renderCount": 50,
             "referenceImage": "loadGuiSnippetWithUnicode.png"
         },
         {

--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -2275,6 +2275,7 @@
         {
             "title": "Load GUI snippet with unicode",
             "playgroundId": "#YS93KY#1",
+            "renderCount": 50,
             "referenceImage": "loadGuiSnippetWithUnicode.png"
         },
         {

--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -2274,14 +2274,12 @@
         },
         {
             "title": "Load GUI snippet with unicode",
-            "playgroundId": "#YS93KY#0",
-            "renderCount": 50,
+            "playgroundId": "#YS93KY#1",
             "referenceImage": "loadGuiSnippetWithUnicode.png"
         },
         {
             "title": "Parse GUI json with unicode",
-            "playgroundId": "#ERVGT5#0",
-            "renderCount": 50,
+            "playgroundId": "#ERVGT5#1",
             "referenceImage": "parseGuiJsonWithUnicode.png"
         },
         {

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
@@ -44,6 +44,11 @@ namespace Babylon::Graphics
         uint16_t ViewNumLayers() const;
         void ViewNumLayers(uint16_t);
 
+        // View id reserved (by the Canvas polyfill) for the canvas->texture blit that fills
+        // this texture. UINT16_MAX means "unset"; consumers fall back to a freshly peeked view.
+        bgfx::ViewId BlitViewId() const { return m_blitViewId; }
+        void BlitViewId(bgfx::ViewId viewId) { m_blitViewId = viewId; }
+
     private:
         bgfx::TextureHandle m_handle{bgfx::kInvalidHandle};
         bool m_ownsHandle{false};
@@ -56,6 +61,7 @@ namespace Babylon::Graphics
         uint32_t m_samplerFlags{BGFX_SAMPLER_NONE};
         uint16_t m_viewFirstLayer{0};
         uint16_t m_viewNumLayers{0};
+        bgfx::ViewId m_blitViewId{UINT16_MAX};
         uintptr_t m_deviceID;
         DeviceContext& m_deviceContext;
     };

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1409,10 +1409,18 @@ namespace Babylon
         const auto textureSource = data.ReadPointer<Graphics::Texture>();
         const auto textureDestination = data.ReadPointer<Graphics::Texture>();
 
-        // Use a view id greater than every view used so far so the blit runs after
-        // all canvas Flushes that may have produced the source content (bgfx
-        // processes blits in numeric view-id order). See #1683.
-        const bgfx::ViewId blitView = m_deviceContext.PeekNextViewId();
+        // The canvas->texture blit must run AFTER the canvas Flush that produced the source
+        // (bgfx processes blits in numeric view-id order) yet BEFORE the scene/backbuffer view
+        // that samples the destination, otherwise the consumer (e.g. a fullscreen GUI ADT layer)
+        // samples the previous frame's content — a one-frame latency. Context::Flush reserves a
+        // view id immediately after the canvas draws (before the scene render is recorded) and
+        // hands it to the source texture; use it here. Non-canvas sources have no reserved id, so
+        // fall back to PeekNextViewId() (a view greater than every view used so far). See #1683.
+        bgfx::ViewId blitView = textureSource->BlitViewId();
+        if (blitView == UINT16_MAX)
+        {
+            blitView = m_deviceContext.PeekNextViewId();
+        }
         encoder->blit(blitView, textureDestination->Handle(), 0, 0, textureSource->Handle());
     }
 

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -215,6 +215,9 @@ namespace Babylon::Polyfills::Internal
         }
 
         m_texture->Attach(bgfx::getTexture(m_frameBuffer->Handle()), false, m_width, m_height, false, 1, bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT);
+        // Hand the blit view id reserved during the preceding Context::Flush to the texture so
+        // NativeEngine::CopyTexture blits on a view ordered before the consuming layer.
+        m_texture->BlitViewId(m_blitViewId);
         return Napi::Pointer<Graphics::Texture>::Create(info.Env(), m_texture.get());
     }
 

--- a/Polyfills/Canvas/Source/Canvas.h
+++ b/Polyfills/Canvas/Source/Canvas.h
@@ -71,6 +71,10 @@ namespace Babylon::Polyfills::Internal
         Babylon::Graphics::FrameBuffer& GetFrameBuffer() { return *m_frameBuffer; }
         FrameBufferPool m_frameBufferPool;
 
+        // View id reserved by Context::Flush (right after this canvas' draws) for the
+        // canvas->texture blit issued from NativeEngine::CopyTexture. See Context::Flush.
+        void SetBlitViewId(bgfx::ViewId viewId) { m_blitViewId = viewId; }
+
         Graphics::DeviceContext& GetGraphicsContext()
         {
             return m_graphicsContext;
@@ -99,6 +103,7 @@ namespace Babylon::Polyfills::Internal
 
         std::unique_ptr<Graphics::FrameBuffer> m_frameBuffer;
         std::unique_ptr<Graphics::Texture> m_texture{};
+        bgfx::ViewId m_blitViewId{UINT16_MAX};
         bool m_dirty{};
         bool m_clear{};
 

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -728,6 +728,15 @@ namespace Babylon::Polyfills::Internal
             nvgEndFrame(*m_nvg);
             frameBuffer.Unbind();
 
+            // Reserve the view id for the eventual canvas->texture blit NOW, while we are
+            // sequenced immediately after this canvas' draws but before the scene/backbuffer
+            // render is recorded. bgfx processes blits in numeric view-id order, so the copy
+            // must land AFTER the canvas Flush (source ready) yet BEFORE the fullscreen ADT
+            // layer samples the destination texture. Deferring to CopyTexture's
+            // PeekNextViewId() would place the blit after the backbuffer view, so the layer
+            // would sample the previous frame's content (a one-frame GUI latency).
+            m_canvas->SetBlitViewId(m_graphicsContext.AcquireNewViewId());
+
             for (auto& buffer : m_canvas->m_frameBufferPool.GetPoolBuffers())
             {
                 // sanity check no unreleased buffers


### PR DESCRIPTION
## Context

The two GUI unicode viz tests were pinned to old playground revisions with `renderCount: 50` settle frames. [BabylonJS/Babylon.js#18506](https://github.com/BabylonJS/Babylon.js/pull/18506) re-saved them as awaiting `#1` revisions and dropped the settle frames on the Babylon.js side. Adopting the `#1` revisions on Native isn't enough to drop `renderCount` — the settle frames masked a Native rendering bug, independent of #18506.

## Root cause

`updateDynamicTexture` flushes a GUI `AdvancedDynamicTexture`'s `NativeCanvas` (nanovg), then copies the canvas render target into the ADT texture via `NativeEngine::CopyTexture` (a `bgfx::blit`). The fullscreen ADT layer samples that texture during the scene/backbuffer render.

`CopyTexture` scheduled the blit on `PeekNextViewId()`, which — once the backbuffer view was already acquired — placed the blit on a view id *after* the view that samples the destination. bgfx runs blits in numeric view-id order, so the layer sampled the previous frame's canvas: a one-frame latency (blank first frame; for `Parse`, red buttons + broken emoji). `renderCount: 50` just rendered past it.

Trace of one ADT frame, before: canvas `view 0-7`, backbuffer + layer `view 8`, blit `view 9` — blit runs after the layer.

## Fix

`Context::Flush` reserves the blit's view id right after the canvas draws (before the scene render is recorded) and hands it to the source texture; `CopyTexture` uses it. Non-canvas copies keep the `PeekNextViewId()` fallback (preserves #1683).

After: canvas `view 0-7`, blit `view 8`, backbuffer + layer `view 9` — same-frame. General to Native GUI, not just these two tests.

## Changes

- `NativeEngine.cpp`, `Context.cpp`, `Canvas.{h,cpp}`, `Texture.h`: reserve and thread the blit view id.
- `config.json`: adopt `#YS93KY#1` / `#ERVGT5#1`, drop `renderCount` from both.

Both tests pass at the default `renderCount: 1` on Win32 D3D11, including the ASAN sanitizer viz run.

[Created by Copilot on behalf of @bghgary]
