### PR TITLE
[NativeEngine] Add updateTextureDirectly texture-loader sink (#218)

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1528,10 +1528,13 @@ namespace Babylon
     // so the texture is created lazily on the first upload.
     void NativeEngine::UpdateTextureDirectly(const Napi::CallbackInfo& info)
     {
+#ifndef BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES
+        throw Napi::Error::New(info.Env(), "Image loading is disabled in this build (BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES=OFF).");
+#else
         const auto texture{info[0].As<Napi::Pointer<Graphics::Texture>>().Get()};
         const auto data{info[1].As<Napi::TypedArray>()};
-        const auto faceIndex{static_cast<uint8_t>(info[2].As<Napi::Number>().Uint32Value())};
-        const auto lod{static_cast<uint8_t>(info[3].As<Napi::Number>().Uint32Value())};
+        const auto faceIndexValue{info[2].As<Napi::Number>().Uint32Value()};
+        const auto lodValue{info[3].As<Napi::Number>().Uint32Value()};
         const auto baseWidth{info[4].As<Napi::Number>().Uint32Value()};
         const auto baseHeight{info[5].As<Napi::Number>().Uint32Value()};
         const auto mipWidth{info[6].As<Napi::Number>().Uint32Value()};
@@ -1549,6 +1552,41 @@ namespace Babylon
             mipWidth > maxTextureSize || mipHeight > maxTextureSize)
         {
             throw Napi::Error::New(Env(), "Invalid base or mip dimensions for the texture.");
+        }
+
+        // Cube textures must be square and address one of the six faces; 2D textures have a single
+        // face. Validate the JS-provided face index before narrowing it to uint8_t.
+        if (isCube)
+        {
+            if (baseWidth != baseHeight || mipWidth != mipHeight)
+            {
+                throw Napi::Error::New(Env(), "Cube texture dimensions must be square.");
+            }
+            if (faceIndexValue >= 6)
+            {
+                throw Napi::Error::New(Env(), "Cube face index must be in the range [0, 5].");
+            }
+        }
+        else if (faceIndexValue != 0)
+        {
+            throw Napi::Error::New(Env(), "Face index must be 0 for a 2D texture.");
+        }
+
+        // The lod must address a real mip level: level 0 only when the texture has no mipmaps,
+        // otherwise within the mip chain implied by the base dimensions.
+        uint32_t numMips{1};
+        if (hasMips)
+        {
+            uint32_t levelDim{baseWidth > baseHeight ? baseWidth : baseHeight};
+            while (levelDim > 1)
+            {
+                levelDim >>= 1;
+                ++numMips;
+            }
+        }
+        if (lodValue >= numMips)
+        {
+            throw Napi::Error::New(Env(), "Lod exceeds the texture's mip level count.");
         }
 
         if (!texture->IsValid())
@@ -1569,6 +1607,12 @@ namespace Babylon
             throw Napi::Error::New(Env(), "The data size does not match mip dimensions and format.");
         }
 
+        // bgfx::copy takes a 32-bit size; reject anything that would truncate.
+        if (expectedSize > 0xFFFFFFFFull)
+        {
+            throw Napi::Error::New(Env(), "Texture upload size exceeds the maximum supported size.");
+        }
+
         const auto bytes{static_cast<uint8_t*>(data.ArrayBuffer().Data()) + data.ByteOffset()};
         // bgfx must own the upload buffer (released asynchronously after the GPU consumes it).
         const bgfx::Memory* mem{bgfx::copy(bytes, static_cast<uint32_t>(data.ByteLength()))};
@@ -1584,12 +1628,13 @@ namespace Babylon
 
         if (isCube)
         {
-            texture->UpdateCube(0, faceIndex, lod, 0, 0, static_cast<uint16_t>(mipWidth), static_cast<uint16_t>(mipHeight), mem);
+            texture->UpdateCube(0, static_cast<uint8_t>(faceIndexValue), static_cast<uint8_t>(lodValue), 0, 0, static_cast<uint16_t>(mipWidth), static_cast<uint16_t>(mipHeight), mem);
         }
         else
         {
-            texture->Update2D(0, lod, 0, 0, static_cast<uint16_t>(mipWidth), static_cast<uint16_t>(mipHeight), mem);
+            texture->Update2D(0, static_cast<uint8_t>(lodValue), 0, 0, static_cast<uint16_t>(mipWidth), static_cast<uint16_t>(mipHeight), mem);
         }
+#endif
     }
 
     void NativeEngine::LoadCubeTexture(const Napi::CallbackInfo& info)

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -715,6 +715,7 @@ namespace Babylon
                 InstanceMethod("loadTexture", &NativeEngine::LoadTexture),
                 InstanceMethod("loadRawTexture", &NativeEngine::LoadRawTexture),
                 InstanceMethod("loadRawTexture2DArray", &NativeEngine::LoadRawTexture2DArray),
+                InstanceMethod("updateTextureDirectly", &NativeEngine::UpdateTextureDirectly),
                 InstanceMethod("loadCubeTexture", &NativeEngine::LoadCubeTexture),
                 InstanceMethod("loadCubeTextureWithMips", &NativeEngine::LoadCubeTextureWithMips),
                 InstanceMethod("getTextureWidth", &NativeEngine::GetTextureWidth),
@@ -1518,6 +1519,77 @@ namespace Babylon
             }
         }
 #endif
+    }
+
+    // Implements the shared JS texture-loader sink (Babylon's _uploadDataToTextureDirectly /
+    // _uploadCompressedDataToTextureDirectly), letting DDS/KTX/KTX2/Basis/IES/HDR/EXR/TGA load
+    // through the same loaders WebGL/WebGPU use. The loaders upload one (face, mip) at a time,
+    // WebGL texImage2D-style; bgfx instead needs the whole texture allocated before any update,
+    // so the texture is created lazily on the first upload.
+    void NativeEngine::UpdateTextureDirectly(const Napi::CallbackInfo& info)
+    {
+        const auto texture{info[0].As<Napi::Pointer<Graphics::Texture>>().Get()};
+        const auto data{info[1].As<Napi::TypedArray>()};
+        const auto faceIndex{static_cast<uint8_t>(info[2].As<Napi::Number>().Uint32Value())};
+        const auto lod{static_cast<uint8_t>(info[3].As<Napi::Number>().Uint32Value())};
+        const auto baseWidth{info[4].As<Napi::Number>().Uint32Value()};
+        const auto baseHeight{info[5].As<Napi::Number>().Uint32Value()};
+        const auto mipWidth{info[6].As<Napi::Number>().Uint32Value()};
+        const auto mipHeight{info[7].As<Napi::Number>().Uint32Value()};
+        const auto format{static_cast<bimg::TextureFormat::Enum>(info[8].As<Napi::Number>().Uint32Value())};
+        const auto isCube{info[9].As<Napi::Boolean>().Value()};
+        const auto hasMips{info[10].As<Napi::Boolean>().Value()};
+        const auto invertY{info[11].As<Napi::Boolean>().Value()};
+
+        // Validate the JS-provided dimensions against GPU limits before narrowing to uint16_t,
+        // so an out-of-range value can't wrap into an in-range one and drive an OOB read/upload.
+        const auto maxTextureSize = bgfx::getCaps()->limits.maxTextureSize;
+        if (baseWidth == 0 || baseHeight == 0 || mipWidth == 0 || mipHeight == 0 ||
+            baseWidth > maxTextureSize || baseHeight > maxTextureSize ||
+            mipWidth > maxTextureSize || mipHeight > maxTextureSize)
+        {
+            throw Napi::Error::New(Env(), "Invalid base or mip dimensions for the texture.");
+        }
+
+        if (!texture->IsValid())
+        {
+            if (isCube)
+            {
+                texture->CreateCube(static_cast<uint16_t>(baseWidth), hasMips, 1, Cast(format), BGFX_TEXTURE_NONE);
+            }
+            else
+            {
+                texture->Create2D(static_cast<uint16_t>(baseWidth), static_cast<uint16_t>(baseHeight), hasMips, 1, Cast(format), BGFX_TEXTURE_NONE);
+            }
+        }
+
+        const uint64_t expectedSize{bimg::imageGetSize(nullptr, static_cast<uint16_t>(mipWidth), static_cast<uint16_t>(mipHeight), 1, false, false, 1, format)};
+        if (expectedSize == 0 || static_cast<uint64_t>(data.ByteLength()) != expectedSize)
+        {
+            throw Napi::Error::New(Env(), "The data size does not match mip dimensions and format.");
+        }
+
+        const auto bytes{static_cast<uint8_t*>(data.ArrayBuffer().Data()) + data.ByteOffset()};
+        // bgfx must own the upload buffer (released asynchronously after the GPU consumes it).
+        const bgfx::Memory* mem{bgfx::copy(bytes, static_cast<uint32_t>(data.ByteLength()))};
+
+        // Match the existing loader flip conventions: cube faces flip only on origin-bottom-left
+        // (OpenGL), like LoadCubeTextureFromImages; 2D follows the raw/loadTexture convention.
+        // Compressed block data cannot be row-flipped.
+        const bool flip{isCube ? bgfx::getCaps()->originBottomLeft : (bgfx::getCaps()->originBottomLeft ? invertY : !invertY)};
+        if (flip && !bimg::isCompressed(format))
+        {
+            FlipImage({mem->data, mem->size}, static_cast<uint32_t>(mipHeight));
+        }
+
+        if (isCube)
+        {
+            texture->UpdateCube(0, faceIndex, lod, 0, 0, static_cast<uint16_t>(mipWidth), static_cast<uint16_t>(mipHeight), mem);
+        }
+        else
+        {
+            texture->Update2D(0, lod, 0, 0, static_cast<uint16_t>(mipWidth), static_cast<uint16_t>(mipHeight), mem);
+        }
     }
 
     void NativeEngine::LoadCubeTexture(const Napi::CallbackInfo& info)

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1539,7 +1539,7 @@ namespace Babylon
         const auto baseHeight{info[5].As<Napi::Number>().Uint32Value()};
         const auto mipWidth{info[6].As<Napi::Number>().Uint32Value()};
         const auto mipHeight{info[7].As<Napi::Number>().Uint32Value()};
-        const auto format{static_cast<bimg::TextureFormat::Enum>(info[8].As<Napi::Number>().Uint32Value())};
+        const auto formatValue{info[8].As<Napi::Number>().Uint32Value()};
         const auto isCube{info[9].As<Napi::Boolean>().Value()};
         const auto hasMips{info[10].As<Napi::Boolean>().Value()};
         const auto invertY{info[11].As<Napi::Boolean>().Value()};
@@ -1553,6 +1553,14 @@ namespace Babylon
         {
             throw Napi::Error::New(Env(), "Invalid base or mip dimensions for the texture.");
         }
+
+        // The format is a raw JS enum value; validate it before narrowing so an out-of-range value
+        // can't index past bimg/bgfx's format tables in Create*/imageGetSize (OOB read).
+        if (formatValue >= bimg::TextureFormat::Count)
+        {
+            throw Napi::Error::New(Env(), "Invalid texture format.");
+        }
+        const auto format{static_cast<bimg::TextureFormat::Enum>(formatValue)};
 
         // Cube textures must be square and address one of the six faces; 2D textures have a single
         // face. Validate the JS-provided face index before narrowing it to uint8_t.

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1589,6 +1589,17 @@ namespace Babylon
             throw Napi::Error::New(Env(), "Lod exceeds the texture's mip level count.");
         }
 
+        // The mip dimensions must match the level implied by (base >> lod); otherwise bgfx would
+        // update a region that doesn't match the allocated mip level (asserts / UB on some backends).
+        const uint32_t shiftedWidth{baseWidth >> lodValue};
+        const uint32_t shiftedHeight{baseHeight >> lodValue};
+        const uint32_t expectedMipWidth{shiftedWidth > 1 ? shiftedWidth : 1};
+        const uint32_t expectedMipHeight{shiftedHeight > 1 ? shiftedHeight : 1};
+        if (mipWidth != expectedMipWidth || mipHeight != expectedMipHeight)
+        {
+            throw Napi::Error::New(Env(), "Mip dimensions do not match the base dimensions and lod.");
+        }
+
         if (!texture->IsValid())
         {
             if (isCube)

--- a/Plugins/NativeEngine/Source/NativeEngine.h
+++ b/Plugins/NativeEngine/Source/NativeEngine.h
@@ -102,6 +102,7 @@ namespace Babylon
         void CopyTexture(NativeDataStream::Reader& data);
         void LoadRawTexture(const Napi::CallbackInfo& info);
         void LoadRawTexture2DArray(const Napi::CallbackInfo& info);
+        void UpdateTextureDirectly(const Napi::CallbackInfo& info);
         void LoadCubeTexture(const Napi::CallbackInfo& info);
         void LoadCubeTextureWithMips(const Napi::CallbackInfo& info);
         Napi::Value GetTextureWidth(const Napi::CallbackInfo& info);


### PR DESCRIPTION
## What

Adds a single new N-API method, `updateTextureDirectly`, to `NativeEngine` — the native half of #218 (single-file `.dds`/`.ktx`/`.ktx2` cubemap loading).

It implements the sink for Babylon's shared JS texture-loader path (`_uploadDataToTextureDirectly` / `_uploadCompressedDataToTextureDirectly`), so `NativeEngine` can reuse the exact same stock loaders that WebGL/WebGPU use (DDS/KTX/KTX2/Basis/IES/HDR/EXR/TGA), rather than needing a bespoke native path per container format.

The loaders upload one `(face, mip)` at a time, WebGL `texImage2D`-style. bgfx instead needs the whole texture allocated before any update, so the texture is created lazily on the first upload and subsequent `(face, mip)` calls update into it.

## Why draft / paired change

This is a **dormant** sink: nothing in the current published `babylonjs` calls `updateTextureDirectly`, so this PR is a no-op at runtime until the paired Babylon.js JS change ships. It compiles cleanly and is safe to merge independently.

- Paired JS half (the loader wiring + diffuse-IBL spherical-harmonics computation): draft at bkaradzic-microsoft/Babylon.js#1, to be re-targeted at `BabylonJS/Babylon.js` when ready.
- A follow-up BabylonNative PR will re-enable the 7 PBR/IBL validation tests in `Apps/Playground/Scripts/config.json` that this feature fixes — held until the JS half is published to npm (`Apps/package.json` pins `babylonjs: "^9.3.4"`, which will auto-resolve), so the test re-enable doesn't turn CI red before the runtime dependency exists.

## Implementation notes

All inputs to this binding come from JS, so every scalar is validated **before** it is narrowed or used to index a table:

- **Build guard:** the body is wrapped in `BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES` (matching `LoadRawTexture`/`LoadCubeTexture`) and throws when image loading is disabled, so the plugin still compiles with `LOAD_IMAGES=OFF` (the `bimg` headers are gated on that flag).
- **Dimensions:** base/mip dimensions are checked against `bgfx::getCaps()->limits.maxTextureSize` (and non-zero) before narrowing to `uint16_t`, so an out-of-range value can't wrap into an in-range one and drive an OOB read/upload.
- **Face index & lod:** read as `uint32` and validated before narrowing to `uint8_t` — cube face `< 6`, 2D face `== 0`, and `lod` within the mip chain implied by the base dimensions (so `hasMips == false` restricts lod to 0).
- **Cube shape & mip consistency:** cube uploads must be square, and `mipWidth`/`mipHeight` must equal `max(1, base >> lod)`, so an inconsistent update region can't reach `bgfx::updateTexture*` and assert / hit backend UB.
- **Format:** read as `uint32` and rejected when `>= bimg::TextureFormat::Count` before the enum cast, so an out-of-range value can't index past bimg/bgfx's format tables in `Create*`/`imageGetSize`.
- **Size check + overflow guard:** `data.ByteLength()` is validated against `bimg::imageGetSize(...)` for the given mip dimensions and format, and the size is rejected if it would exceed `bgfx::copy`'s 32-bit length.
- **Async-safe upload:** uses `bgfx::copy` so bgfx owns the buffer and releases it after the GPU consumes it.
- **Flip conventions** match the existing loaders: cube faces flip only on origin-bottom-left (OpenGL), like `LoadCubeTextureFromImages`; 2D follows the raw/`loadTexture` convention. Compressed block data is never row-flipped.

## Testing

Validated locally against the paired JS build via the Playground headless validation harness — the 7 PBR/IBL tests that previously exceeded the pixel-diff budget (because prefiltered-cube SH wasn't loading) now pass well within budget (all << 240,000-px budget):

| Test | Pixel diff |
|---|---|
| NME glTF | 461 |
| Anisotropic | 311 |
| Clear Coat | 473 |
| PBRMetallicRoughnessMaterial | 308 |
| PBRSpecularGlossinessMaterial | 363 |
| PBR | 266 |
| PBR in mirror | 676 |

The config.json re-enable of these tests is held for the follow-up PR (see above).

## Review

Addressed multiple rounds of Copilot review: the `LOAD_IMAGES` build guard, the pre-narrow validation of face index / lod / format, the cube-square and mip-dimension-consistency checks, and the `bgfx::copy` overflow guard were all added in response. One suggestion (re-deriving and comparing an already-valid texture's dimensions/format on every update) was intentionally declined as redundant — the loader is the sole caller and always drives consistent parameters.
