### PR TITLE
Use a coherent system SDK for Apple builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,18 @@ elseif(IOS)
     set(DEPLOYMENT_TARGET "13" CACHE STRING "")
 endif()
 
+if(CMAKE_HOST_APPLE
+   AND CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR
+   AND NOT CMAKE_TOOLCHAIN_FILE
+   AND NOT IOS
+   AND NOT VISIONOS
+   AND NOT CMAKE_OSX_SYSROOT)
+    # Use one coherent Xcode SDK for headers and frameworks. Leaving this empty
+    # can mix Command Line Tools headers with frameworks from the selected
+    # Xcode, which turns SDK-only diagnostics into warnings-as-errors.
+    set(CMAKE_OSX_SYSROOT macosx CACHE STRING "macOS SDK" FORCE)
+endif()
+
 project(BabylonNative)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -191,6 +191,16 @@ endif()
 # --------------------------------------------------
 FetchContent_MakeAvailable_With_Message(JsRuntimeHost)
 
+if(APPLE AND NAPI_JAVASCRIPT_ENGINE STREQUAL "JavaScriptCore" AND TARGET napi)
+    # find_library adds the SDK framework directory with -F, which does not
+    # classify framework headers as system headers. JsRuntimeHost uses
+    # -pedantic -Werror, so make that classification explicit for napi and all
+    # consumers while preserving warnings-as-errors for project sources.
+    get_filename_component(_JAVASCRIPTCORE_FRAMEWORKS_DIR "${JAVASCRIPTCORE_LIBRARY}" DIRECTORY)
+    target_compile_options(napi PUBLIC "SHELL:-iframework ${_JAVASCRIPTCORE_FRAMEWORKS_DIR}")
+    unset(_JAVASCRIPTCORE_FRAMEWORKS_DIR)
+endif()
+
 # --------------------------------------------------
 # metal-cpp
 # --------------------------------------------------


### PR DESCRIPTION
## Summary

- default top-level macOS builds to the selected Xcode `macosx` SDK when no toolchain or sysroot was supplied
- classify JavaScriptCore framework headers as system headers for `napi` and its consumers
- normalize both JavaScriptCore framework-bundle and framework-binary paths
- preserve explicit toolchains, explicit sysroots, and Apple mobile configurations

## Why

An empty macOS sysroot can mix Command Line Tools headers with frameworks from the selected Xcode installation. Diagnostics from that mixed SDK surface become errors under JsRuntimeHost warnings-as-errors builds.

Using one SDK for headers and frameworks fixes the mismatch. Marking the JavaScriptCore framework directory as a system framework keeps SDK implementation diagnostics out of project warning policy without suppressing warnings in BabylonNative or JsRuntimeHost sources.

## Validation

- rebased onto current BabylonNative `master`
- fresh RelWithDebInfo/Ninja configure with JavaScriptCore
- built `napi` and `AppRuntime`
- verified compile commands use the same selected SDK for `-isysroot` and `-iframework`
- tested both `.../JavaScriptCore.framework` and `.../JavaScriptCore.framework/JavaScriptCore` discovery forms under a framework directory containing spaces
- `git diff --check`
