### PR TITLE
Fix NativeEngine build breaks on Windows x86/ARM64 and Clang x86_64

### DIFF
--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -115,13 +115,14 @@ if(NOT BABYLON_NATIVE_PLUGIN_NATIVEENGINE_WEBP AND TARGET bimg_decode)
     target_compile_definitions(bimg_decode PRIVATE BIMG_CONFIG_PARSE_WEBP=0)
 endif()
 
-if(UNIX AND NOT APPLE AND NOT ANDROID AND CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64|AMD64)")
+if(NOT APPLE AND NOT ANDROID AND CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64|AMD64)" AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     # The new bx requires SSE4.2 on x86_64 (see bx scripts/toolchain.lua and
     # include/bx/inline/simd128_sse.inl which uses _mm_round_ps / _mm_blendv_ps
     # under "SSE4.1 - always available with SSE4.2 minspec"). bgfx.cmake does
-    # not propagate this flag, so add it explicitly on Linux x86_64 where
-    # GCC/Clang don't enable SSE4.x by default. MSVC and Apple Silicon are
-    # unaffected.
+    # not propagate this flag, so add it explicitly for any GCC/Clang frontend on
+    # x86_64 (e.g. Linux, or Clang targeting Windows), none of which enable SSE4.x
+    # by default. MSVC (cl.exe) allows the intrinsics regardless and Apple Silicon
+    # is unaffected.
     foreach(_bx_target IN ITEMS bx bgfx bimg bimg_decode bimg_encode)
         if(TARGET ${_bx_target})
             target_compile_options(${_bx_target} PRIVATE -msse4.2)

--- a/Plugins/NativeEngine/CMakeLists.txt
+++ b/Plugins/NativeEngine/CMakeLists.txt
@@ -67,6 +67,17 @@ endif()
 if(WIN32)
     target_compile_definitions(NativeEngine
         PRIVATE NOMINMAX)
+
+    # arcana's Windows trace_region.h (pulled in by NativeEngine.cpp and Program.cpp)
+    # emits ETW TraceLogging events. The EventRegister/EventUnregister/EventWriteTransfer
+    # declarations it relies on (via <evntprov.h>) are only visible when
+    # _WIN32_WINNT >= _WIN32_WINNT_VISTA (0x0600). bx/platform.h only sets _WIN32_WINNT
+    # when it is still undefined, and then to 0x0601 for 64-bit but 0x0502 (pre-Vista)
+    # for 32-bit; its 64-bit check also misses MSVC's _M_ARM64, so Windows ARM64 is
+    # treated as 32-bit. Both cases leave _WIN32_WINNT below Vista and break the compile
+    # (error C3861). Pin a modern Windows API baseline so it is set before any header.
+    target_compile_definitions(NativeEngine
+        PRIVATE _WIN32_WINNT=0x0A00 WINVER=0x0A00)
 endif()
 
 # Required by VertexBuffer::BuildInstanceDataBuffer. Remove once we have a better solution for that method.

--- a/Plugins/NativeEngine/Source/ShaderProvider.cpp
+++ b/Plugins/NativeEngine/Source/ShaderProvider.cpp
@@ -35,7 +35,9 @@ namespace Babylon
     {
         // The shader cache is keyed only by source, so it must be bypassed when routing instanced
         // attributes (otherwise a variant would collide with the base program's cached shader).
-        const bool useCache = instancedAttributes.empty();
+        // Only referenced inside the SHADER_CACHE blocks below, so mark it maybe_unused for builds
+        // that compile with the ShaderCache plugin disabled.
+        [[maybe_unused]] const bool useCache = instancedAttributes.empty();
 
 #ifdef SHADER_CACHE
         if (useCache && Plugins::ShaderCache::IsEnabled())


### PR DESCRIPTION
## Summary

Three independent build breaks when building Babylon Native in configurations outside the x64/MSVC + Linux path:

### 1. NativeEngine fails to compile on Windows x86 (Win32) and ARM64 — `error C3861`

`arcana`'s Windows `trace_region.h` now emits ETW TraceLogging events, and it is pulled in by `NativeEngine.cpp` and `Program.cpp`. The `EventRegister` / `EventUnregister` / `EventWriteTransfer` functions it uses (declared in `<evntprov.h>`) are only visible when `_WIN32_WINNT >= _WIN32_WINNT_VISTA` (`0x0600`):

```
TraceLoggingProvider.h(2850): error C3861: 'EventUnregister': identifier not found
TraceLoggingProvider.h(2887): error C3861: 'EventRegister': identifier not found
TraceLoggingProvider.h(3103): error C3861: 'EventWriteTransfer': identifier not found
```

`bx/platform.h` only sets `_WIN32_WINNT` when it is still undefined, and then to `0x0601` for 64-bit but `0x0502` (pre-Vista) for 32-bit. Its 64-bit detection checks `__aarch64__` but not MSVC's `_M_ARM64`, so Windows ARM64 is treated as 32-bit and also gets `0x0502`. Both leave the macro below Vista and break the compile. x64 gets `0x0601` and builds fine, which is why the x64 CI stays green.

**Fix:** pin a modern Windows API baseline (`_WIN32_WINNT=0x0A00` / `WINVER=0x0A00`) on the NativeEngine target so it is established before any header is included. `bx` honors the value through its own `#ifndef` guard.

### 2. `ShaderProvider.cpp` — unused variable when ShaderCache is disabled

`useCache` is only referenced inside `#ifdef SHADER_CACHE` blocks, so with the ShaderCache plugin disabled it is unused and trips `-Wunused-variable` (fatal under `-Werror`) on Clang and `C4189` on MSVC. Marked `[[maybe_unused]]`.

### 3. Building bx/bimg with a Clang toolchain on x86_64 misses SSE4.x

The new `bx` SIMD path (`bx/inline/simd128_sse.inl`) uses `_mm_round_ps` / `_mm_blendv_ps`, which require SSE4.1:

```
simd128_sse.inl: error: '__builtin_ia32_roundps' needs target feature sse4.1
```

`Dependencies/CMakeLists.txt` only added `-msse4.2` under `if(UNIX ...)`, so a Clang frontend targeting Windows x86_64 does not get it. Broadened the guard to any GCC/Clang frontend on x86_64 (MSVC allows the intrinsics regardless; Apple Silicon is unaffected).

## Testing

- Reproduced the `C3861` failure with the 10.0.26100 Windows SDK and confirmed the `_WIN32_WINNT`/`WINVER` baseline resolves it at the exact failing lines.
- Confirmed `[[maybe_unused]]` clears `-Werror,-Wunused-variable` on Clang.
- Verified the CMake guard now evaluates true for a Clang / x86_64 Windows toolchain.
