### PR TITLE
Resolve #1786 review follow-ups: drop BN workarounds, bump bgfx.cmake, guard useCache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ FetchContent_Declare(base-n
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(bgfx.cmake
     GIT_REPOSITORY https://github.com/BabylonJS/bgfx.cmake.git
-    GIT_TAG 3b67f0c0c5505a22f6e88640519b5b473c938ad9
+    GIT_TAG 8f7e4455933085fc719913138c78ef61242709e3
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(CMakeExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/CMakeExtensions.git

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -115,21 +115,6 @@ if(NOT BABYLON_NATIVE_PLUGIN_NATIVEENGINE_WEBP AND TARGET bimg_decode)
     target_compile_definitions(bimg_decode PRIVATE BIMG_CONFIG_PARSE_WEBP=0)
 endif()
 
-if(NOT APPLE AND NOT ANDROID AND CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64|AMD64)" AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    # The new bx requires SSE4.2 on x86_64 (see bx scripts/toolchain.lua and
-    # include/bx/inline/simd128_sse.inl which uses _mm_round_ps / _mm_blendv_ps
-    # under "SSE4.1 - always available with SSE4.2 minspec"). bgfx.cmake does
-    # not propagate this flag, so add it explicitly for any GCC/Clang frontend on
-    # x86_64 (e.g. Linux, or Clang targeting Windows), none of which enable SSE4.x
-    # by default. MSVC (cl.exe) allows the intrinsics regardless and Apple Silicon
-    # is unaffected.
-    foreach(_bx_target IN ITEMS bx bgfx bimg bimg_decode bimg_encode)
-        if(TARGET ${_bx_target})
-            target_compile_options(${_bx_target} PRIVATE -msse4.2)
-        endif()
-    endforeach()
-endif()
-
 if(UNIX AND NOT APPLE AND NOT ANDROID)
     # Use GLVND libraries for EGL support in bgfx
     set(OpenGL_GL_PREFERENCE GLVND)

--- a/Plugins/NativeEngine/CMakeLists.txt
+++ b/Plugins/NativeEngine/CMakeLists.txt
@@ -67,17 +67,6 @@ endif()
 if(WIN32)
     target_compile_definitions(NativeEngine
         PRIVATE NOMINMAX)
-
-    # arcana's Windows trace_region.h (pulled in by NativeEngine.cpp and Program.cpp)
-    # emits ETW TraceLogging events. The EventRegister/EventUnregister/EventWriteTransfer
-    # declarations it relies on (via <evntprov.h>) are only visible when
-    # _WIN32_WINNT >= _WIN32_WINNT_VISTA (0x0600). bx/platform.h only sets _WIN32_WINNT
-    # when it is still undefined, and then to 0x0601 for 64-bit but 0x0502 (pre-Vista)
-    # for 32-bit; its 64-bit check also misses MSVC's _M_ARM64, so Windows ARM64 is
-    # treated as 32-bit. Both cases leave _WIN32_WINNT below Vista and break the compile
-    # (error C3861). Pin a modern Windows API baseline so it is set before any header.
-    target_compile_definitions(NativeEngine
-        PRIVATE _WIN32_WINNT=0x0A00 WINVER=0x0A00)
 endif()
 
 # Required by VertexBuffer::BuildInstanceDataBuffer. Remove once we have a better solution for that method.

--- a/Plugins/NativeEngine/Source/ShaderProvider.cpp
+++ b/Plugins/NativeEngine/Source/ShaderProvider.cpp
@@ -35,11 +35,11 @@ namespace Babylon
     {
         // The shader cache is keyed only by source, so it must be bypassed when routing instanced
         // attributes (otherwise a variant would collide with the base program's cached shader).
-        // Only referenced inside the SHADER_CACHE blocks below, so mark it maybe_unused for builds
-        // that compile with the ShaderCache plugin disabled.
-        [[maybe_unused]] const bool useCache = instancedAttributes.empty();
-
+        // Declared and used only inside the SHADER_CACHE blocks, so it is compiled out entirely when
+        // the ShaderCache plugin is disabled.
 #ifdef SHADER_CACHE
+        const bool useCache = instancedAttributes.empty();
+
         if (useCache && Plugins::ShaderCache::IsEnabled())
         {
             const auto shaderInfo = Plugins::ShaderCache::GetShader(vertexSource, fragmentSource);


### PR DESCRIPTION
## Summary

Addresses the three review follow-ups from #1786 ([bghgary's notes](https://github.com/BabylonJS/BabylonNative/pull/1786)), moving each fix to its proper home so BN no longer carries the workarounds.

### 1. Drop the manual `-msse4.2` flag (`Dependencies/CMakeLists.txt`)

The SSE4.2 minspec that bx's x86_64 SIMD path requires now lives in **bgfx.cmake** (BabylonJS/bgfx.cmake#130), applied `PUBLIC` on the `bx` target — including the `-Xarch_x86_64` scoping needed for Apple universal (arm64;x86_64) builds. BN no longer needs to re-add it.

### 2. Drop the per-plugin `_WIN32_WINNT` / `WINVER` pin (`Plugins/NativeEngine/CMakeLists.txt`)

The root cause was fixed in **bx** (bkaradzic/bx#409): `platform.h` now detects MSVC ARM64 as 64-bit and defaults every 32-bit Windows target to `0x0601` instead of the pre-Vista `0x0502`. With that, arcana's ETW `trace_region.h` compiles on Windows x86/ARM64 without pinning an API baseline on the NativeEngine target.

### 3. Guard `useCache` with `#ifdef SHADER_CACHE` (`Plugins/NativeEngine/Source/ShaderProvider.cpp`)

`useCache` is referenced only inside the `#ifdef SHADER_CACHE` blocks, so its declaration moves into that guard (rather than `[[maybe_unused]]`): the variable — and `instancedAttributes.empty()` — is compiled out entirely when the ShaderCache plugin is disabled.

To consume 1 and 2, this bumps the `bgfx.cmake` pin to `8f7e4455` (which carries the SSE minspec on the bx target and advances bx to `cd6720ce` with the platform.h fixes).

## Testing

- Built NativeEngine for **Win32** against the bumped pin with the `_WIN32_WINNT` workaround removed — `NativeEngine.cpp` / `Program.cpp` / `ShaderProvider.cpp` compile and `NativeEngine.lib` links (previously this arch failed with `error C3861` in `TraceLoggingProvider.h`).
- The SSE minspec on the bx target was verified in bgfx.cmake#130 (compiles the `_mm_round_ps` SSE4.1 intrinsic on Clang/x86_64, `-Xarch_x86_64`-scoped on Apple).
- `ShaderProvider` compiles clean under Clang `-Werror -Wunused-variable` with ShaderCache enabled and disabled.
