### PR TITLE
Downlevel the Babylon.js core bundle to ES5 in the nightly script fetch

### DIFF
--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -20,6 +20,9 @@
         "babylonjs-serializers": "^9.15.0",
         "jsc-android": "^241213.1.0",
         "v8-android": "^7.8.2"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@babel/cli": {

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -6,7 +6,11 @@
     "UnitTests/JavaScript"
   ],
   "scripts": {
-    "getNightly": "node scripts/getNightly.js"
+    "getNightly": "node scripts/getNightly.js && npm run downlevel:native-scripts -- node_modules/babylonjs/babylon.max.js",
+    "downlevel:native-scripts": "node scripts/downlevelNativeScripts.mjs"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "babylonjs": "^9.15.0",

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -6,7 +6,7 @@
     "UnitTests/JavaScript"
   ],
   "scripts": {
-    "getNightly": "node scripts/getNightly.js && npm run downlevel:native-scripts -- node_modules/babylonjs/babylon.max.js node_modules/babylonjs-addons/babylonjs.addons.js",
+    "getNightly": "node scripts/getNightly.js && npm run downlevel:native-scripts -- node_modules/babylonjs/babylon.max.js",
     "downlevel:native-scripts": "node scripts/downlevelNativeScripts.mjs"
   },
   "devDependencies": {

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -6,7 +6,7 @@
     "UnitTests/JavaScript"
   ],
   "scripts": {
-    "getNightly": "node scripts/getNightly.js && npm run downlevel:native-scripts -- node_modules/babylonjs/babylon.max.js",
+    "getNightly": "node scripts/getNightly.js && npm run downlevel:native-scripts -- node_modules/babylonjs/babylon.max.js node_modules/babylonjs-addons/babylonjs.addons.js",
     "downlevel:native-scripts": "node scripts/downlevelNativeScripts.mjs"
   },
   "devDependencies": {

--- a/Apps/scripts/downlevelNativeScripts.mjs
+++ b/Apps/scripts/downlevelNativeScripts.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "fs/promises";
+import { resolve } from "path";
+import ts from "typescript";
+
+const targets = process.argv.slice(2);
+
+if (targets.length === 0) {
+    process.stderr.write("Usage: node scripts/downlevelNativeScripts.mjs <file> [...]\n");
+    process.exit(1);
+}
+
+// Babylon.js emits its UMD bundles at an ES2015 target: the TC39 decorator migration relies on the
+// `accessor` keyword, which cannot be expressed in ES5, and esbuild cannot emit ES5 classes. Babylon
+// Native runs those bundles on Chakra, which consumes ES5-level script, so the core bundle must be
+// down-leveled before it is executed. Babylon.js does the same thing to the artifacts this repo
+// publishes (see `downlevel:native-scripts` in the Babylon.js monorepo pipeline); without it the
+// bundle still parses and most of the engine works, so the breakage is silent - e.g. GlowLayer never
+// reports ready and any scene using it hangs in Scene.executeWhenReady.
+//
+// TypeScript is used for the transform rather than Babel. Babel's ES5 class lowering emits
+// `Reflect.construct` / `_wrapNativeSuper` machinery for classes that extend native built-ins such as
+// `Error`, and that machinery runs at class-definition time and hard-crashes Chakra while the bundle
+// loads. TypeScript lowers classes with its `__extends` helper - plain prototype assignment, no
+// `Reflect.construct` - which is the emit Babylon Native consumed for years when the bundles were
+// built at an ES5 target directly. `ts.transpileModule` is a purely syntactic single-file transform,
+// so it handles the multi-megabyte bundle without type checking and inlines its own helpers.
+const compilerOptions = {
+    target: ts.ScriptTarget.ES5,
+    // The bundles are UMD/IIFE scripts with no top-level module syntax; leave module output untouched.
+    module: ts.ModuleKind.None,
+    // Lower `for..of`, spread and other iterator protocols correctly for ES5.
+    downlevelIteration: true,
+    // Inline the emit helpers so the bundle stays self-contained on Chakra.
+    importHelpers: false,
+    newLine: ts.NewLineKind.LineFeed,
+    sourceMap: false,
+    ignoreDeprecations: "6.0",
+};
+
+let count = 0;
+
+for (const target of targets) {
+    const filePath = resolve(target);
+    const source = await readFile(filePath, "utf8");
+    const { outputText } = ts.transpileModule(source, { compilerOptions, fileName: filePath });
+    await writeFile(filePath, outputText, "utf8");
+    process.stdout.write(`Downleveled ${filePath}\n`);
+    ++count;
+}
+
+process.stdout.write(`Downleveled ${count} Babylon Native script file(s).\n`);

--- a/Apps/scripts/downlevelNativeScripts.mjs
+++ b/Apps/scripts/downlevelNativeScripts.mjs
@@ -1,53 +1,107 @@
 #!/usr/bin/env node
 
-import { readFile, writeFile } from "fs/promises";
-import { resolve } from "path";
+// Kept byte-identical to scripts/downlevelNativeScripts.mjs in the Babylon.js repo, which applies the
+// same transform to the artifacts this repo publishes. Diff the two before changing either.
+
+import { readdir, readFile, stat, writeFile } from "fs/promises";
+import { basename, join, resolve } from "path";
 import ts from "typescript";
 
 const targets = process.argv.slice(2);
 
 if (targets.length === 0) {
-    process.stderr.write("Usage: node scripts/downlevelNativeScripts.mjs <file> [...]\n");
+    process.stderr.write("Usage: node scripts/downlevelNativeScripts.mjs <file-or-directory> [...]\n");
     process.exit(1);
 }
 
-// Babylon.js emits its UMD bundles at an ES2015 target: the TC39 decorator migration relies on the
-// `accessor` keyword, which cannot be expressed in ES5, and esbuild cannot emit ES5 classes. Babylon
-// Native runs those bundles on Chakra, which consumes ES5-level script, so the core bundle must be
-// down-leveled before it is executed. Babylon.js does the same thing to the artifacts this repo
-// publishes (see `downlevel:native-scripts` in the Babylon.js monorepo pipeline); without it the
-// bundle still parses and most of the engine works, so the breakage is silent - e.g. GlowLayer never
-// reports ready and any scene using it hangs in Scene.executeWhenReady.
+// The TC39 decorator migration forces the Native UMD bundle to be emitted at an ES2015 target (the
+// `accessor` keyword requires ES2015+, and esbuild cannot emit ES5 classes). Babylon Native's Chakra
+// engine consumes ES5-level script, so the bundle must be down-leveled before it runs.
 //
-// TypeScript is used for the transform rather than Babel. Babel's ES5 class lowering emits
-// `Reflect.construct` / `_wrapNativeSuper` machinery for classes that extend native built-ins such as
-// `Error`, and that machinery runs at class-definition time and hard-crashes Chakra while the bundle
-// loads. TypeScript lowers classes with its `__extends` helper - plain prototype assignment, no
-// `Reflect.construct` - which is the emit Babylon Native consumed for years when the bundles were
-// built at an ES5 target directly. `ts.transpileModule` is a purely syntactic single-file transform,
-// so it handles the multi-megabyte bundle without type checking and inlines its own helpers.
+// We use the TypeScript transpiler (not Babel) for this. Babel's ES5 class transform emits
+// `Reflect.construct`/`_wrapNativeSuper` machinery for classes that extend native built-ins (e.g.
+// `Error`, `Array`); that machinery executes at class-definition time and hard-crashes Chakra when
+// the bundle loads. TypeScript instead lowers classes with its `__extends` helper (plain prototype
+// assignment, no `Reflect.construct`) - the exact emit Babylon Native ran successfully for years when
+// the UMD bundles were built directly at an ES5 target. `ts.transpileModule` performs a purely
+// syntactic, single-file transform (no type checking), so it does not choke on the multi-megabyte
+// bundle, and it inlines self-contained helpers (no external `tslib`/`regeneratorRuntime` required).
 const compilerOptions = {
     target: ts.ScriptTarget.ES5,
     // The bundles are UMD/IIFE scripts with no top-level module syntax; leave module output untouched.
     module: ts.ModuleKind.None,
     // Lower `for..of`, spread and other iterator protocols correctly for ES5.
     downlevelIteration: true,
-    // Inline the emit helpers so the bundle stays self-contained on Chakra.
+    // Inline the emit helpers into each file so the bundle stays self-contained on Chakra.
     importHelpers: false,
     newLine: ts.NewLineKind.LineFeed,
     sourceMap: false,
+    // The ES5/`module: none`/`downlevelIteration` combination emits TS 7.0 deprecation notices; they
+    // are informational and do not affect the emitted output.
     ignoreDeprecations: "6.0",
 };
 
-let count = 0;
-
-for (const target of targets) {
-    const filePath = resolve(target);
-    const source = await readFile(filePath, "utf8");
-    const { outputText } = ts.transpileModule(source, { compilerOptions, fileName: filePath });
-    await writeFile(filePath, outputText, "utf8");
-    process.stdout.write(`Downleveled ${filePath}\n`);
-    ++count;
+function isNativeScriptFile(filePath) {
+    return /^babylon.*\.js$/i.test(basename(filePath));
 }
 
-process.stdout.write(`Downleveled ${count} Babylon Native script file(s).\n`);
+async function collectFiles(target) {
+    const resolvedTarget = resolve(target);
+    const targetStat = await stat(resolvedTarget);
+
+    if (targetStat.isFile()) {
+        return isNativeScriptFile(resolvedTarget) ? [resolvedTarget] : [];
+    }
+
+    if (!targetStat.isDirectory()) {
+        return [];
+    }
+
+    const entries = await readdir(resolvedTarget, { withFileTypes: true });
+    const files = [];
+
+    for (const entry of entries) {
+        const entryPath = join(resolvedTarget, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...(await collectFiles(entryPath)));
+        } else if (entry.isFile() && isNativeScriptFile(entryPath)) {
+            files.push(entryPath);
+        }
+    }
+
+    return files;
+}
+
+const files = [...new Set((await Promise.all(targets.map(collectFiles))).flat())];
+
+if (files.length === 0) {
+    process.stdout.write("No Babylon Native scripts found to downlevel.\n");
+    process.exit(0);
+}
+
+for (const file of files) {
+    const code = await readFile(file, "utf8");
+    const result = ts.transpileModule(code, { compilerOptions, fileName: file, reportDiagnostics: true });
+
+    // `transpileModule` only surfaces syntactic and command-line/config diagnostics (it has no type
+    // information). Command-line/config diagnostics (code >= 5000) are informational for our
+    // transpile-only use; a real problem shows up as a syntactic error (code < 5000).
+    const fatalDiagnostics = (result.diagnostics || []).filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error && diagnostic.code < 5000);
+    if (fatalDiagnostics.length > 0) {
+        const formatted = ts.formatDiagnostics(fatalDiagnostics, {
+            getCanonicalFileName: (fileName) => fileName,
+            getCurrentDirectory: () => process.cwd(),
+            getNewLine: () => "\n",
+        });
+        throw new Error(`TypeScript reported errors while down-leveling ${file}:\n${formatted}`);
+    }
+
+    if (!result.outputText) {
+        throw new Error(`TypeScript did not produce output for ${file}`);
+    }
+
+    await writeFile(file, result.outputText, "utf8");
+    process.stdout.write(`Downleveled ${file}\n`);
+}
+
+process.stdout.write(`Downleveled ${files.length} Babylon Native script file(s).\n`);

--- a/Apps/scripts/getNightly.js
+++ b/Apps/scripts/getNightly.js
@@ -2,20 +2,41 @@ var https = require('https');
 var fs = require('fs');
 
 function download(filename, url) {
-  var file = fs.createWriteStream(filename);
-  var request = https.get(url, function(response) {
-    response.pipe(file);
+  return new Promise(function (resolve, reject) {
+    https.get(url, function (response) {
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error('GET ' + url + ' failed with status ' + response.statusCode));
+        return;
+      }
+      var file = fs.createWriteStream(filename);
+      file.on('error', reject);
+      file.on('finish', resolve);
+      response.pipe(file);
+    }).on('error', reject);
   });
 }
 
+var files = [
+  ['node_modules/babylonjs/babylon.max.js', 'https://preview.babylonjs.com/babylon.max.js'],
+  ['node_modules/babylonjs/babylon.max.js.map', 'https://preview.babylonjs.com/babylon.max.js.map'],
+  ['node_modules/babylonjs-materials/babylonjs.materials.js', 'https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js'],
+  ['node_modules/babylonjs-materials/babylonjs.materials.js.map', 'https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js.map'],
+  ['node_modules/babylonjs-loaders/babylonjs.loaders.js', 'https://preview.babylonjs.com/loaders/babylonjs.loaders.js'],
+  ['node_modules/babylonjs-loaders/babylonjs.loaders.js.map', 'https://preview.babylonjs.com/loaders/babylonjs.loaders.js.map'],
+  ['node_modules/babylonjs-gui/babylon.gui.js', 'https://preview.babylonjs.com/gui/babylon.gui.js'],
+  ['node_modules/babylonjs-gui/babylon.gui.js.map', 'https://preview.babylonjs.com/gui/babylon.gui.js.map'],
+  ['node_modules/babylonjs-serializers/babylonjs.serializers.js', 'https://preview.babylonjs.com/serializers/babylonjs.serializers.js'],
+  ['node_modules/babylonjs-serializers/babylonjs.serializers.js.map', 'https://preview.babylonjs.com/serializers/babylonjs.serializers.js.map'],
+];
+
 console.log('Downloading babylon.js nightly');
-download('node_modules/babylonjs/babylon.max.js', 'https://preview.babylonjs.com/babylon.max.js');
-download('node_modules/babylonjs/babylon.max.js.map', 'https://preview.babylonjs.com/babylon.max.js.map');
-download('node_modules/babylonjs-materials/babylonjs.materials.js', 'https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js');
-download('node_modules/babylonjs-materials/babylonjs.materials.js.map', 'https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js.map');
-download('node_modules/babylonjs-loaders/babylonjs.loaders.js', 'https://preview.babylonjs.com/loaders/babylonjs.loaders.js');
-download('node_modules/babylonjs-loaders/babylonjs.loaders.js.map', 'https://preview.babylonjs.com/loaders/babylonjs.loaders.js.map');
-download('node_modules/babylonjs-gui/babylon.gui.js', 'https://preview.babylonjs.com/gui/babylon.gui.js');
-download('node_modules/babylonjs-gui/babylon.gui.js.map', 'https://preview.babylonjs.com/gui/babylon.gui.js.map');
-download('node_modules/babylonjs-serializers/babylonjs.serializers.js', 'https://preview.babylonjs.com/serializers/babylonjs.serializers.js');
-download('node_modules/babylonjs-serializers/babylonjs.serializers.js.map', 'https://preview.babylonjs.com/serializers/babylonjs.serializers.js.map');
+
+// Awaited so a failed or partial download fails the script instead of silently leaving the previous
+// file in place, and so the down-level step that runs next cannot race an incomplete write.
+Promise.all(files.map(function (f) { return download(f[0], f[1]); })).then(function () {
+  console.log('Downloaded ' + files.length + ' file(s)');
+}, function (err) {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/Apps/scripts/getNightly.js
+++ b/Apps/scripts/getNightly.js
@@ -20,6 +20,8 @@ function download(filename, url) {
 var files = [
   ['node_modules/babylonjs/babylon.max.js', 'https://preview.babylonjs.com/babylon.max.js'],
   ['node_modules/babylonjs/babylon.max.js.map', 'https://preview.babylonjs.com/babylon.max.js.map'],
+  ['node_modules/babylonjs-addons/babylonjs.addons.js', 'https://preview.babylonjs.com/addons/babylonjs.addons.js'],
+  ['node_modules/babylonjs-addons/babylonjs.addons.js.map', 'https://preview.babylonjs.com/addons/babylonjs.addons.js.map'],
   ['node_modules/babylonjs-materials/babylonjs.materials.js', 'https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js'],
   ['node_modules/babylonjs-materials/babylonjs.materials.js.map', 'https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js.map'],
   ['node_modules/babylonjs-loaders/babylonjs.loaders.js', 'https://preview.babylonjs.com/loaders/babylonjs.loaders.js'],

--- a/Apps/scripts/getNightly.js
+++ b/Apps/scripts/getNightly.js
@@ -3,17 +3,47 @@ var fs = require('fs');
 
 function download(filename, url) {
   return new Promise(function (resolve, reject) {
-    https.get(url, function (response) {
-      if (response.statusCode !== 200) {
-        response.resume();
-        reject(new Error('GET ' + url + ' failed with status ' + response.statusCode));
+    var file = fs.createWriteStream(filename);
+    var settled = false;
+
+    function fail(err) {
+      if (settled) {
         return;
       }
-      var file = fs.createWriteStream(filename);
-      file.on('error', reject);
-      file.on('finish', resolve);
+      settled = true;
+      file.destroy();
+      reject(err);
+    }
+
+    file.on('error', fail);
+    // 'close', not 'finish': 'finish' fires once the data is flushed but before the descriptor is
+    // released, and the down-level step runs against these files immediately afterwards.
+    file.on('close', function () {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    });
+
+    var request = https.get(url, function (response) {
+      if (response.statusCode !== 200) {
+        response.resume();
+        fail(new Error('GET ' + url + ' failed with status ' + response.statusCode));
+        return;
+      }
+      response.on('error', fail);
+      // A server-side abort emits neither 'finish' nor 'error' on the file, so without this the
+      // promise would never settle.
+      response.on('aborted', function () {
+        fail(new Error('GET ' + url + ' aborted by the server'));
+      });
       response.pipe(file);
-    }).on('error', reject);
+    });
+
+    request.on('error', fail);
+    request.setTimeout(120000, function () {
+      request.destroy(new Error('GET ' + url + ' timed out'));
+    });
   });
 }
 


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

## Context
The [nightly](https://dev.azure.com/babylonjs/ContinousIntegration/_build/latest?definitionId=36&branchName=master) has failed every run since 2026-07-07. `Glow layer and LODs` never satisfies `Scene.executeWhenReady`, burns the 600s budget and aborts the run at test 24; a green run executes 294.

Babylon.js emits its UMD bundles at an ES2015 target since [#18647](https://github.com/BabylonJS/Babylon.js/pull/18647) — the TC39 decorator migration needs the `accessor` keyword. Babylon Native runs them on Chakra, which consumes ES5. Babylon.js added a downlevel step for this in [#18630](https://github.com/BabylonJS/Babylon.js/pull/18630) and applies it to `babylon.max.js` before launching our `Playground.exe` / `UnitTests.exe` in its monorepo pipeline, which is why the Babylon.js side of this same test stays green. `getNightly` never got the equivalent.

Nothing errors: the bundle loads, and meshes, textures, the glow render target and all four blur post-processes all report ready. `GlowLayer.isLayerReady()` just stays `false`. Any scene with a `GlowLayer` is affected — the LOD in the failing test is incidental, and it surfaces through this test alone because every other glow scene is already `excludeFromAutomaticTesting`.

## Change
`getNightly` downlevels `node_modules/babylonjs/babylon.max.js` after fetching. Playground and UnitTests both copy that file, so one transform covers both. Only the core bundle needs it: Chakra parses ES2015 classes and arrows fine, and it is the Stage 3 decorator emit that breaks it — the `accessor` keyword appears twice in preview core and not at all in preview addons. Babylon.js downlevels the same single file.

`getNightly` also now fetches `babylonjs-addons`, which it had been skipping. The Playground loads addons immediately after the core bundle, so a preview core was running against an npm-pinned addons build.

`downlevelNativeScripts.mjs` is a verbatim copy of the Babylon.js script apart from a provenance header, so the two stay diffable.

Downloads are now awaited and status-checked — they were fire-and-forget, so the downlevel could race a partial write.

## Verification
Win32 x64 D3D11 against the current preview: the full suite goes from aborting at test 24 to `ran=296 passed=296 failed=0`, both with addons pinned and with addons fetched from preview.

Swapping only `babylon.max.js` in one unchanged build:

| babylonjs | Result |
|---|---|
| 9.15.0 | passes |
| 9.16.0 – 9.18.0 | never ready |
| 9.16.0, downleveled | passes |

Unaffected in Chromium on all of those versions, so this is the script target rather than a Babylon.js regression.
