### PR TITLE
ShaderCompiler: preserve original sampler names colliding with HLSL/MSL keywords

### DIFF
--- a/Plugins/ShaderCache/Source/ShaderCacheImpl.cpp
+++ b/Plugins/ShaderCache/Source/ShaderCacheImpl.cpp
@@ -35,7 +35,10 @@ namespace
 
 namespace Babylon::Plugins::ShaderCache
 {
-    static const uint32_t CACHE_VERSION = 2;
+    // 3: sampler uniforms are stored under their original GLSL name rather than the
+    //    SPIRV-Cross-renamed identifier, which changes both the bgfx uniform table in
+    //    Vertex/FragmentBytes and the keys of UniformStages.
+    static const uint32_t CACHE_VERSION = 3;
 
     void ShaderCacheImpl::Clear()
     {

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerCommon.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerCommon.cpp
@@ -90,12 +90,21 @@ namespace Babylon::ShaderCompilerCommon
         }
     }
 
-    void AppendSamplers(std::vector<uint8_t>& bytes, const spirv_cross::Compiler& compiler, const spirv_cross::SmallVector<spirv_cross::Resource>& samplers, std::map<std::string, uint8_t>& stages)
+    void AppendSamplers(std::vector<uint8_t>& bytes, const spirv_cross::Compiler& compiler, const spirv_cross::ParsedIR& originalIr, const spirv_cross::SmallVector<spirv_cross::Resource>& samplers, std::map<std::string, uint8_t>& stages)
     {
         for (const spirv_cross::Resource& sampler : samplers)
         {
-            AppendBytes(bytes, static_cast<uint8_t>(sampler.name.size()));
-            AppendBytes(bytes, sampler.name);
+            // SPIRV-Cross's HLSL/MSL backends rename resources whose name collides with a reserved
+            // keyword of the target language (e.g. a GLSL sampler named "Texture2D" or "Texture2DArray"
+            // becomes "_Texture2D" because those are HLSL built-in object types). bgfx's uniform table
+            // and Babylon.js look samplers up by their original GLSL name, so the renamed identifier would
+            // never bind (the sampler silently samples nothing). Recover the pre-transpile name from the
+            // parser's ParsedIR (the Compiler transpiles a private copy, leaving the parser's names intact).
+            const std::string& originalName = originalIr.get_name(sampler.id);
+            const std::string& name = originalName.empty() ? sampler.name : originalName;
+
+            AppendBytes(bytes, static_cast<uint8_t>(name.size()));
+            AppendBytes(bytes, name);
             AppendBytes(bytes, static_cast<uint8_t>(bgfx::UniformType::Sampler | BGFX_UNIFORM_SAMPLERBIT));
 
             // TODO : These values (num, regIndex, regCount) are only used by Vulkan and should be set for that API
@@ -113,13 +122,14 @@ namespace Babylon::ShaderCompilerCommon
             // That produced multiple sampler2D uniforms and a samplerCube all pointing at one unit,
             // which GLES/ANGLE rejects at draw time with GL_INVALID_OPERATION (D3D11/Metal don't
             // validate this, so the bug was GL-only). Each sampler now gets its own distinct unit,
-            // mirroring WebGL's Effect._bindSamplerUniformToChannel.
-            if (stages.find(sampler.name) == stages.end())
+            // mirroring WebGL's Effect._bindSamplerUniformToChannel. Keyed on the recovered
+            // pre-transpile name (see above) so both stages agree on the same identifier.
+            if (stages.find(name) == stages.end())
             {
-                stages[sampler.name] = static_cast<uint8_t>(stages.size());
+                stages[name] = static_cast<uint8_t>(stages.size());
             }
 #else
-            stages[sampler.name] = static_cast<uint8_t>(compiler.get_decoration(sampler.id, spv::DecorationBinding));
+            stages[name] = static_cast<uint8_t>(compiler.get_decoration(sampler.id, spv::DecorationBinding));
 #endif
         }
     }
@@ -298,7 +308,7 @@ namespace Babylon::ShaderCompilerCommon
 
             AppendBytes(vertexBytes, static_cast<uint16_t>(numUniforms));
             AppendUniformBuffer(vertexBytes, uniformsInfo, false);
-            AppendSamplers(vertexBytes, compiler, samplers, bgfxShaderInfo.UniformStages);
+            AppendSamplers(vertexBytes, compiler, vertexShaderInfo.Parser->get_parsed_ir(), samplers, bgfxShaderInfo.UniformStages);
 
             AppendBytes(vertexBytes, static_cast<uint32_t>(vertexShaderInfo.Bytes.size()));
             AppendBytes(vertexBytes, vertexShaderInfo.Bytes);
@@ -359,7 +369,7 @@ namespace Babylon::ShaderCompilerCommon
 
             AppendBytes(fragmentBytes, static_cast<uint16_t>(numUniforms));
             AppendUniformBuffer(fragmentBytes, uniformsInfo, true);
-            AppendSamplers(fragmentBytes, compiler, samplers, bgfxShaderInfo.UniformStages);
+            AppendSamplers(fragmentBytes, compiler, fragmentShaderInfo.Parser->get_parsed_ir(), samplers, bgfxShaderInfo.UniformStages);
 
             AppendBytes(fragmentBytes, static_cast<uint32_t>(fragmentShaderInfo.Bytes.size()));
             AppendBytes(fragmentBytes, fragmentShaderInfo.Bytes);

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerCommon.h
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerCommon.h
@@ -61,7 +61,7 @@ namespace Babylon::ShaderCompilerCommon
     };
 
     void AppendUniformBuffer(std::vector<uint8_t>& bytes, const NonSamplerUniformsInfo& uniformBuffer, bool isFragment);
-    void AppendSamplers(std::vector<uint8_t>& bytes, const spirv_cross::Compiler& compiler, const spirv_cross::SmallVector<spirv_cross::Resource>& samplers, std::map<std::string, uint8_t>& stages);
+    void AppendSamplers(std::vector<uint8_t>& bytes, const spirv_cross::Compiler& compiler, const spirv_cross::ParsedIR& originalIr, const spirv_cross::SmallVector<spirv_cross::Resource>& samplers, std::map<std::string, uint8_t>& stages);
     NonSamplerUniformsInfo CollectNonSamplerUniforms(spirv_cross::Parser& parser, const spirv_cross::Compiler& compiler);
 
     /// Assigns unique descriptor bindings to every uniform buffer in the shader so that


### PR DESCRIPTION
### Problem

SPIRV-Cross's HLSL and MSL backends rename any shader resource whose name collides with a reserved keyword of the target language, prepending an underscore. Babylon.js generates GLSL samplers named `Texture2D` and `Texture2DArray`, which are HLSL built-in object types, so they are emitted into the bgfx uniform table as `_Texture2D` / `_Texture2DArray`.

Both bgfx and Babylon.js look samplers up by their **original GLSL name**, so the renamed uniform never binds. There is no error — the stage just silently samples nothing and renders transparent.

### Fix

`AppendSamplers` recovers the pre-transpile name from the parser's `ParsedIR` via `get_name(id)`. The `Compiler` transpiles a *private copy* of the IR, so the parser still holds the original names. That name is emitted into the bgfx uniform table and the stage map.

- The texture register (`DecorationBinding`) is untouched — only the app-facing name changes.
- Non-colliding samplers resolve to the identical string, so they are bit-for-bit unaffected.
- The existing OpenGL stage-assignment guard is now keyed on the recovered name so the vertex and fragment passes agree on the same identifier.

### Validation

Built `x64 / Release / D3D11` against this branch and ran the full Playground validation suite:

```
Run complete. ran=300 passed=300 failed=0 missingRef=0 skipped=420
```

No regressions. Because every non-colliding sampler keeps its current name, the change is a no-op for all 300 currently-enabled tests.

### Scope

This is intentionally code-only — no `config.json` changes. The test this unblocks (`MultiRenderTarget with different texture types`, `#XSNYAU#22`) also needs a matching Babylon.js-side fix for the mixed-type MRT write path, so its un-exclusion is deliberately left for a later change once both halves are in. Verified: with only this fix applied, that test still fails, so enabling it here would red the build.
