### PR TITLE
Canvas: implement getImageData and fix drawImage crash on plain ImageBitmap

### DIFF
--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -920,6 +920,15 @@ namespace Babylon::Polyfills::Internal
                 throw Napi::Error::New(info.Env(), "drawImage: ImageBitmap dimensions are too large.");
             }
 
+            // imageGetSize takes uint16_t extents, so anything above 65535 would be truncated and
+            // produce a size for a much smaller image. A 65537x1 RGBA8 bitmap would come back as
+            // 1x1 (4 bytes), a 4-byte buffer would pass the check below, and the RGBA8 memcpy
+            // would then read width*height*4 bytes from it. Reject what bimg cannot describe.
+            if (width > std::numeric_limits<uint16_t>::max() || height > std::numeric_limits<uint16_t>::max())
+            {
+                throw Napi::Error::New(info.Env(), "drawImage: ImageBitmap dimensions exceed the maximum supported size.");
+            }
+
             // Ask bimg for the size rather than computing width*height*bpp/8: block-compressed
             // formats round up to whole blocks and have a minimum block count, so a 1x1 BC1 image
             // still occupies one 8-byte block. The naive bits-per-pixel math would accept a
@@ -1078,10 +1087,44 @@ namespace Babylon::Polyfills::Internal
             throw Napi::Error::New(info.Env(), "Context2D.getImageData: invalid number of parameters");
         }
 
-        const auto sx = info[0].As<Napi::Number>().Int32Value();
-        const auto sy = info[1].As<Napi::Number>().Int32Value();
-        const auto sw = info[2].As<Napi::Number>().Uint32Value();
-        const auto sh = info[3].As<Napi::Number>().Uint32Value();
+        auto sx = info[0].As<Napi::Number>().Int32Value();
+        auto sy = info[1].As<Napi::Number>().Int32Value();
+        const auto swInt = info[2].As<Napi::Number>().Int32Value();
+        const auto shInt = info[3].As<Napi::Number>().Int32Value();
+
+        // Parse the extents as signed. Read via Uint32Value, a width of -1 wraps to 4294967295,
+        // and the size_t guard below does not catch it on 64-bit because 4294967295 * 1 is far
+        // below SIZE_MAX/4, so ImageData would go on to allocate roughly 17 GB.
+        //
+        // A negative extent is legal: the browser treats it as a rectangle running in the
+        // opposite direction and returns the normalized region, so fold the sign into the
+        // origin rather than rejecting it. INT32_MIN has no positive counterpart, so it is
+        // rejected outright instead of being negated into itself.
+        if (swInt == std::numeric_limits<int32_t>::min() || shInt == std::numeric_limits<int32_t>::min())
+        {
+            throw Napi::RangeError::New(info.Env(), "Context2D.getImageData: requested region is too large.");
+        }
+
+        uint32_t sw, sh;
+        if (swInt < 0)
+        {
+            sw = static_cast<uint32_t>(-swInt);
+            sx -= static_cast<int32_t>(sw);
+        }
+        else
+        {
+            sw = static_cast<uint32_t>(swInt);
+        }
+
+        if (shInt < 0)
+        {
+            sh = static_cast<uint32_t>(-shInt);
+            sy -= static_cast<int32_t>(sh);
+        }
+        else
+        {
+            sh = static_cast<uint32_t>(shInt);
+        }
 
         // The region is caller-supplied and backs a width*height*4 allocation, so reject sizes
         // that would overflow size_t before ImageData tries to allocate them.

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <limits>
 #include <optional>
 #include <regex>
 
@@ -778,18 +779,22 @@ namespace Babylon::Polyfills::Internal
         {
             m_cpuWidth = width;
             m_cpuHeight = height;
-            m_cpuPixels.assign(static_cast<size_t>(width) * height * 4, 0);
-        }
-    }
 
-    void Context::BlitImageToCpu(const NativeCanvasImage& image, int32_t sx, int32_t sy, uint32_t sw, uint32_t sh, int32_t dx, int32_t dy, uint32_t dw, uint32_t dh)
-    {
-        BlitPixelsToCpu(image.GetPixels(), image.GetWidth(), image.GetHeight(), sx, sy, sw, sh, dx, dy, dw, dh);
+            const uint64_t pixelCount = static_cast<uint64_t>(width) * height;
+            if (pixelCount > std::numeric_limits<size_t>::max() / 4)
+            {
+                // Leave the mirror empty; drawImage and getImageData both no-op safely on it.
+                m_cpuPixels.clear();
+                return;
+            }
+
+            m_cpuPixels.assign(static_cast<size_t>(pixelCount) * 4, 0);
+        }
     }
 
     void Context::BlitPixelsToCpu(const uint8_t* src, uint32_t srcWidth, uint32_t srcHeight, int32_t sx, int32_t sy, uint32_t sw, uint32_t sh, int32_t dx, int32_t dy, uint32_t dw, uint32_t dh)
     {
-        if (src == nullptr || dw == 0 || dh == 0)
+        if (src == nullptr || dw == 0 || dh == 0 || sw == 0 || sh == 0 || srcWidth == 0 || srcHeight == 0)
         {
             return;
         }
@@ -800,39 +805,37 @@ namespace Babylon::Polyfills::Internal
             return;
         }
 
-        for (uint32_t j = 0; j < dh; ++j)
+        // Clamp the iteration range to the destination rect's intersection with the canvas up
+        // front. The destination size is caller-controlled (and reaches us as an unsigned value,
+        // so a negative width wraps to ~4e9), and iterating the full rect just to reject every
+        // pixel would stall the JS thread. int64_t keeps dx/dy + dw/dh from overflowing.
+        const int64_t iBegin = std::max<int64_t>(0, -static_cast<int64_t>(dx));
+        const int64_t iEnd = std::min<int64_t>(dw, static_cast<int64_t>(m_cpuWidth) - dx);
+        const int64_t jBegin = std::max<int64_t>(0, -static_cast<int64_t>(dy));
+        const int64_t jEnd = std::min<int64_t>(dh, static_cast<int64_t>(m_cpuHeight) - dy);
+
+        for (int64_t j = jBegin; j < jEnd; ++j)
         {
-            const int32_t destY = dy + static_cast<int32_t>(j);
-            if (destY < 0 || destY >= static_cast<int32_t>(m_cpuHeight))
-            {
-                continue;
-            }
-
             // Nearest-neighbor sample of the source row (exact when dh == sh).
-            const int32_t srcYRel = static_cast<int32_t>(static_cast<uint64_t>(j) * sh / dh);
-            const int32_t srcY = sy + srcYRel;
-            if (srcY < 0 || srcY >= static_cast<int32_t>(srcHeight))
+            const int64_t srcY = sy + static_cast<int64_t>(j) * sh / dh;
+            if (srcY < 0 || srcY >= static_cast<int64_t>(srcHeight))
             {
                 continue;
             }
 
-            for (uint32_t i = 0; i < dw; ++i)
+            const size_t destRow = static_cast<size_t>(dy + j) * m_cpuWidth;
+            const size_t srcRow = static_cast<size_t>(srcY) * srcWidth;
+
+            for (int64_t i = iBegin; i < iEnd; ++i)
             {
-                const int32_t destX = dx + static_cast<int32_t>(i);
-                if (destX < 0 || destX >= static_cast<int32_t>(m_cpuWidth))
+                const int64_t srcX = sx + static_cast<int64_t>(i) * sw / dw;
+                if (srcX < 0 || srcX >= static_cast<int64_t>(srcWidth))
                 {
                     continue;
                 }
 
-                const int32_t srcXRel = static_cast<int32_t>(static_cast<uint64_t>(i) * sw / dw);
-                const int32_t srcX = sx + srcXRel;
-                if (srcX < 0 || srcX >= static_cast<int32_t>(srcWidth))
-                {
-                    continue;
-                }
-
-                const size_t srcIndex = (static_cast<size_t>(srcY) * srcWidth + srcX) * 4;
-                const size_t destIndex = (static_cast<size_t>(destY) * m_cpuWidth + destX) * 4;
+                const size_t srcIndex = (srcRow + static_cast<size_t>(srcX)) * 4;
+                const size_t destIndex = (destRow + static_cast<size_t>(dx + i)) * 4;
                 m_cpuPixels[destIndex + 0] = src[srcIndex + 0];
                 m_cpuPixels[destIndex + 1] = src[srcIndex + 1];
                 m_cpuPixels[destIndex + 2] = src[srcIndex + 2];
@@ -898,11 +901,32 @@ namespace Babylon::Polyfills::Internal
                 return;
             }
 
+            // Everything below is caller-supplied. bimg::imageConvert reads width*height*bpp bits
+            // from the source and writes width*height*4 bytes to the destination without knowing
+            // either buffer's real length, so validate both before handing it any pointers.
+            if (format >= bimg::TextureFormat::Count)
+            {
+                throw Napi::Error::New(info.Env(), "drawImage: ImageBitmap has an out-of-range pixel format.");
+            }
+
+            const uint64_t pixelCount = static_cast<uint64_t>(width) * height;
+            if (pixelCount > std::numeric_limits<size_t>::max() / 4)
+            {
+                throw Napi::Error::New(info.Env(), "drawImage: ImageBitmap dimensions are too large.");
+            }
+
+            const uint64_t requiredBits = static_cast<uint64_t>(data.ByteLength()) * 8;
+            const uint8_t bitsPerPixel = bimg::getBitsPerPixel(format);
+            if (bitsPerPixel == 0 || pixelCount > requiredBits / bitsPerPixel)
+            {
+                throw Napi::Error::New(info.Env(), "drawImage: ImageBitmap data is smaller than width*height for its format.");
+            }
+
             const uint8_t* srcBytes = data.Data();
-            std::vector<uint8_t> rgba(static_cast<size_t>(width) * height * 4);
+            std::vector<uint8_t> rgba(static_cast<size_t>(pixelCount) * 4);
             if (format == bimg::TextureFormat::RGBA8)
             {
-                std::memcpy(rgba.data(), srcBytes, std::min<size_t>(rgba.size(), data.ByteLength()));
+                std::memcpy(rgba.data(), srcBytes, rgba.size());
             }
             else if (!bimg::imageConvert(&Graphics::DeviceContext::GetDefaultAllocator(), rgba.data(), bimg::TextureFormat::RGBA8, srcBytes, format, width, height, 1))
             {
@@ -1017,10 +1041,22 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value Context::GetImageData(const Napi::CallbackInfo& info)
     {
+        if (info.Length() < 4)
+        {
+            throw Napi::Error::New(info.Env(), "Context2D.getImageData: invalid number of parameters");
+        }
+
         const auto sx = info[0].As<Napi::Number>().Int32Value();
         const auto sy = info[1].As<Napi::Number>().Int32Value();
         const auto sw = info[2].As<Napi::Number>().Uint32Value();
         const auto sh = info[3].As<Napi::Number>().Uint32Value();
+
+        // The region is caller-supplied and backs a width*height*4 allocation, so reject sizes
+        // that would overflow size_t before ImageData tries to allocate them.
+        if (static_cast<uint64_t>(sw) * sh > std::numeric_limits<size_t>::max() / 4)
+        {
+            throw Napi::RangeError::New(info.Env(), "Context2D.getImageData: requested region is too large.");
+        }
 
         return ImageData::CreateInstance(info.Env(), this, sx, sy, sw, sh);
     }

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -32,6 +32,10 @@
 #include "LineCaps.h"
 #include "Gradient.h"
 
+#ifdef BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES
+#include <bimg/bimg.h>
+#endif
+
 namespace Babylon::Polyfills::Internal
 {
     static constexpr auto JS_CONTEXT_CONSTRUCTOR_NAME = "Context";
@@ -780,7 +784,11 @@ namespace Babylon::Polyfills::Internal
 
     void Context::BlitImageToCpu(const NativeCanvasImage& image, int32_t sx, int32_t sy, uint32_t sw, uint32_t sh, int32_t dx, int32_t dy, uint32_t dw, uint32_t dh)
     {
-        const uint8_t* src = image.GetPixels();
+        BlitPixelsToCpu(image.GetPixels(), image.GetWidth(), image.GetHeight(), sx, sy, sw, sh, dx, dy, dw, dh);
+    }
+
+    void Context::BlitPixelsToCpu(const uint8_t* src, uint32_t srcWidth, uint32_t srcHeight, int32_t sx, int32_t sy, uint32_t sw, uint32_t sh, int32_t dx, int32_t dy, uint32_t dw, uint32_t dh)
+    {
         if (src == nullptr || dw == 0 || dh == 0)
         {
             return;
@@ -791,9 +799,6 @@ namespace Babylon::Polyfills::Internal
         {
             return;
         }
-
-        const uint32_t srcWidth = image.GetWidth();
-        const uint32_t srcHeight = image.GetHeight();
 
         for (uint32_t j = 0; j < dh; ++j)
         {
@@ -873,7 +878,47 @@ namespace Babylon::Polyfills::Internal
 
     void Context::DrawImage(const Napi::CallbackInfo& info)
     {
-        const NativeCanvasImage* canvasImage = NativeCanvasImage::Unwrap(info[0].As<Napi::Object>());
+        Napi::Object imageObj = info[0].As<Napi::Object>();
+
+        // NativeEngine.createImageBitmap() returns a plain object carrying the raw decoded pixels
+        // ({data, width, height, format}) rather than a wrapped NativeCanvasImage. Because Babylon
+        // Native sets forceBitmapOverHTMLImageElement, LoadImage delivers these bitmaps to drawImage
+        // (e.g. Mesh.applyDisplacementMap, height/flow maps). Unwrapping such a plain object as a
+        // NativeCanvasImage would dereference garbage and crash, so handle it explicitly by
+        // converting the pixels to RGBA8 and drawing/blitting them directly.
+        if (imageObj.Has("data") && imageObj.Get("data").IsTypedArray())
+        {
+#ifdef BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES
+            const auto data = imageObj.Get("data").As<Napi::Uint8Array>();
+            const uint32_t width = imageObj.Get("width").As<Napi::Number>().Uint32Value();
+            const uint32_t height = imageObj.Get("height").As<Napi::Number>().Uint32Value();
+            const auto format = static_cast<bimg::TextureFormat::Enum>(imageObj.Get("format").As<Napi::Number>().Uint32Value());
+            if (width == 0 || height == 0)
+            {
+                return;
+            }
+
+            const uint8_t* srcBytes = data.Data();
+            std::vector<uint8_t> rgba(static_cast<size_t>(width) * height * 4);
+            if (format == bimg::TextureFormat::RGBA8)
+            {
+                std::memcpy(rgba.data(), srcBytes, std::min<size_t>(rgba.size(), data.ByteLength()));
+            }
+            else if (!bimg::imageConvert(&Graphics::DeviceContext::GetDefaultAllocator(), rgba.data(), bimg::TextureFormat::RGBA8, srcBytes, format, width, height, 1))
+            {
+                throw Napi::Error::New(info.Env(), "drawImage: unsupported ImageBitmap pixel format.");
+            }
+
+            const int imageIndex = nvgCreateImageRGBA(*m_nvg, static_cast<int>(width), static_cast<int>(height), 0, rgba.data());
+            DrawImageCommon(info, imageIndex, rgba.data(), width, height);
+            nvgDeleteImage(*m_nvg, imageIndex);
+            return;
+#else
+            throw Napi::Error::New(info.Env(), "drawImage: image loading disabled in this build.");
+#endif
+        }
+
+        const NativeCanvasImage* canvasImage = NativeCanvasImage::Unwrap(imageObj);
 
         int imageIndex{-1};
         const auto nvgImageIter = m_nvgImageIndices.find(canvasImage);
@@ -888,27 +933,33 @@ namespace Babylon::Polyfills::Internal
         }
         assert(imageIndex != -1);
 
+        DrawImageCommon(info, imageIndex, canvasImage->GetPixels(), canvasImage->GetWidth(), canvasImage->GetHeight());
+    }
+
+    void Context::DrawImageCommon(const Napi::CallbackInfo& info, int imageIndex, const uint8_t* srcPixels, uint32_t srcWidth, uint32_t srcHeight)
+    {
+        const auto imgWidth = static_cast<float>(srcWidth);
+        const auto imgHeight = static_cast<float>(srcHeight);
+
         if (info.Length() == 3)
         {
             const auto dx = static_cast<float>(info[1].As<Napi::Number>().Int32Value());
             const auto dy = static_cast<float>(info[2].As<Napi::Number>().Int32Value());
-            const auto width = static_cast<float>(canvasImage->GetWidth());
-            const auto height = static_cast<float>(canvasImage->GetHeight());
 
-            NVGpaint imagePaint = nvgImagePattern(*m_nvg, 0.f, 0.f, width, height, 0.f, imageIndex, 1.f);
+            NVGpaint imagePaint = nvgImagePattern(*m_nvg, 0.f, 0.f, imgWidth, imgHeight, 0.f, imageIndex, 1.f);
 
             if (!m_isClipped)
             {
                 nvgBeginPath(*m_nvg);
             }
 
-            nvgRect(*m_nvg, dx, dy, width, height);
+            nvgRect(*m_nvg, dx, dy, imgWidth, imgHeight);
             nvgFillPaint(*m_nvg, imagePaint);
             SetFilterStack();
             nvgFill(*m_nvg);
 
-            BlitImageToCpu(*canvasImage, 0, 0, canvasImage->GetWidth(), canvasImage->GetHeight(),
-                static_cast<int32_t>(dx), static_cast<int32_t>(dy), canvasImage->GetWidth(), canvasImage->GetHeight());
+            BlitPixelsToCpu(srcPixels, srcWidth, srcHeight, 0, 0, srcWidth, srcHeight,
+                static_cast<int32_t>(dx), static_cast<int32_t>(dy), srcWidth, srcHeight);
         }
         else if (info.Length() == 5)
         {
@@ -929,7 +980,7 @@ namespace Babylon::Polyfills::Internal
             SetFilterStack();
             nvgFill(*m_nvg);
 
-            BlitImageToCpu(*canvasImage, 0, 0, canvasImage->GetWidth(), canvasImage->GetHeight(),
+            BlitPixelsToCpu(srcPixels, srcWidth, srcHeight, 0, 0, srcWidth, srcHeight,
                 static_cast<int32_t>(dx), static_cast<int32_t>(dy), static_cast<uint32_t>(dWidth), static_cast<uint32_t>(dHeight));
         }
         else if (info.Length() == 9)
@@ -942,8 +993,6 @@ namespace Babylon::Polyfills::Internal
             const auto dy = static_cast<float>(info[6].As<Napi::Number>().Int32Value());
             const auto dWidth = static_cast<float>(info[7].As<Napi::Number>().Uint32Value());
             const auto dHeight = static_cast<float>(info[8].As<Napi::Number>().Uint32Value());
-            const auto width = static_cast<float>(canvasImage->GetWidth());
-            const auto height = static_cast<float>(canvasImage->GetHeight());
 
             NVGpaint imagePaint = nvgImagePattern(*m_nvg, dx, dy, dWidth, dHeight, 0.f, imageIndex, 1.f);
 
@@ -957,7 +1006,7 @@ namespace Babylon::Polyfills::Internal
             SetFilterStack();
             nvgFill(*m_nvg);
 
-            BlitImageToCpu(*canvasImage, sx, sy, sWidth, sHeight,
+            BlitPixelsToCpu(srcPixels, srcWidth, srcHeight, sx, sy, sWidth, sHeight,
                 static_cast<int32_t>(dx), static_cast<int32_t>(dy), static_cast<uint32_t>(dWidth), static_cast<uint32_t>(dHeight));
         }
         else

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -844,10 +844,15 @@ namespace Babylon::Polyfills::Internal
         }
     }
 
-    void Context::ReadPixels(int32_t sx, int32_t sy, uint32_t w, uint32_t h, uint8_t* dst) const
+    void Context::ReadPixels(int32_t sx, int32_t sy, uint32_t w, uint32_t h, uint8_t* dst)
     {
         const size_t total = static_cast<size_t>(w) * h * 4;
         std::memset(dst, 0, total);
+
+        // Resync the mirror to the canvas first. Without this, a canvas resize followed by
+        // getImageData with no intervening drawImage would read the old buffer using the old
+        // dimensions and hand back stale pixels; EnsureCpuBuffer reallocates and zero-fills.
+        EnsureCpuBuffer();
         if (m_cpuPixels.empty())
         {
             return;
@@ -901,9 +906,9 @@ namespace Babylon::Polyfills::Internal
                 return;
             }
 
-            // Everything below is caller-supplied. bimg::imageConvert reads width*height*bpp bits
-            // from the source and writes width*height*4 bytes to the destination without knowing
-            // either buffer's real length, so validate both before handing it any pointers.
+            // Everything below is caller-supplied. bimg::imageConvert reads the source and writes
+            // width*height*4 bytes to the destination without knowing either buffer's real length,
+            // so validate both before handing it any pointers.
             if (format >= bimg::TextureFormat::Count)
             {
                 throw Napi::Error::New(info.Env(), "drawImage: ImageBitmap has an out-of-range pixel format.");
@@ -915,9 +920,12 @@ namespace Babylon::Polyfills::Internal
                 throw Napi::Error::New(info.Env(), "drawImage: ImageBitmap dimensions are too large.");
             }
 
-            const uint64_t requiredBits = static_cast<uint64_t>(data.ByteLength()) * 8;
-            const uint8_t bitsPerPixel = bimg::getBitsPerPixel(format);
-            if (bitsPerPixel == 0 || pixelCount > requiredBits / bitsPerPixel)
+            // Ask bimg for the size rather than computing width*height*bpp/8: block-compressed
+            // formats round up to whole blocks and have a minimum block count, so a 1x1 BC1 image
+            // still occupies one 8-byte block. The naive bits-per-pixel math would accept a
+            // 1-byte buffer for it and imageConvert would then read past the end.
+            const uint64_t requiredBytes = bimg::imageGetSize(nullptr, static_cast<uint16_t>(width), static_cast<uint16_t>(height), 1, false, false, 1, format);
+            if (requiredBytes == 0 || data.ByteLength() < requiredBytes)
             {
                 throw Napi::Error::New(info.Env(), "drawImage: ImageBitmap data is smaller than width*height for its format.");
             }
@@ -987,10 +995,22 @@ namespace Babylon::Polyfills::Internal
         }
         else if (info.Length() == 5)
         {
-            const auto dx = static_cast<float>(info[1].As<Napi::Number>().Int32Value());
-            const auto dy = static_cast<float>(info[2].As<Napi::Number>().Int32Value());
-            const auto dWidth = static_cast<float>(info[3].As<Napi::Number>().Uint32Value());
-            const auto dHeight = static_cast<float>(info[4].As<Napi::Number>().Uint32Value());
+            const auto dxInt = info[1].As<Napi::Number>().Int32Value();
+            const auto dyInt = info[2].As<Napi::Number>().Int32Value();
+            const auto dWidthInt = info[3].As<Napi::Number>().Int32Value();
+            const auto dHeightInt = info[4].As<Napi::Number>().Int32Value();
+
+            // Parse the extents as signed: read via Uint32Value, a negative width wraps to ~4e9,
+            // which would queue an enormous nvgRect. A non-positive extent draws nothing.
+            if (dWidthInt <= 0 || dHeightInt <= 0)
+            {
+                return;
+            }
+
+            const auto dx = static_cast<float>(dxInt);
+            const auto dy = static_cast<float>(dyInt);
+            const auto dWidth = static_cast<float>(dWidthInt);
+            const auto dHeight = static_cast<float>(dHeightInt);
 
             NVGpaint imagePaint = nvgImagePattern(*m_nvg, dx, dy, dWidth, dHeight, 0.f, imageIndex, 1.f);
 
@@ -1005,18 +1025,30 @@ namespace Babylon::Polyfills::Internal
             nvgFill(*m_nvg);
 
             BlitPixelsToCpu(srcPixels, srcWidth, srcHeight, 0, 0, srcWidth, srcHeight,
-                static_cast<int32_t>(dx), static_cast<int32_t>(dy), static_cast<uint32_t>(dWidth), static_cast<uint32_t>(dHeight));
+                dxInt, dyInt, static_cast<uint32_t>(dWidthInt), static_cast<uint32_t>(dHeightInt));
         }
         else if (info.Length() == 9)
         {
             const auto sx = info[1].As<Napi::Number>().Int32Value();
             const auto sy = info[2].As<Napi::Number>().Int32Value();
-            const auto sWidth = info[3].As<Napi::Number>().Uint32Value();
-            const auto sHeight = info[4].As<Napi::Number>().Uint32Value();
-            const auto dx = static_cast<float>(info[5].As<Napi::Number>().Int32Value());
-            const auto dy = static_cast<float>(info[6].As<Napi::Number>().Int32Value());
-            const auto dWidth = static_cast<float>(info[7].As<Napi::Number>().Uint32Value());
-            const auto dHeight = static_cast<float>(info[8].As<Napi::Number>().Uint32Value());
+            const auto sWidthInt = info[3].As<Napi::Number>().Int32Value();
+            const auto sHeightInt = info[4].As<Napi::Number>().Int32Value();
+            const auto dxInt = info[5].As<Napi::Number>().Int32Value();
+            const auto dyInt = info[6].As<Napi::Number>().Int32Value();
+            const auto dWidthInt = info[7].As<Napi::Number>().Int32Value();
+            const auto dHeightInt = info[8].As<Napi::Number>().Int32Value();
+
+            if (sWidthInt <= 0 || sHeightInt <= 0 || dWidthInt <= 0 || dHeightInt <= 0)
+            {
+                return;
+            }
+
+            const auto sWidth = static_cast<uint32_t>(sWidthInt);
+            const auto sHeight = static_cast<uint32_t>(sHeightInt);
+            const auto dx = static_cast<float>(dxInt);
+            const auto dy = static_cast<float>(dyInt);
+            const auto dWidth = static_cast<float>(dWidthInt);
+            const auto dHeight = static_cast<float>(dHeightInt);
 
             NVGpaint imagePaint = nvgImagePattern(*m_nvg, dx, dy, dWidth, dHeight, 0.f, imageIndex, 1.f);
 
@@ -1031,7 +1063,7 @@ namespace Babylon::Polyfills::Internal
             nvgFill(*m_nvg);
 
             BlitPixelsToCpu(srcPixels, srcWidth, srcHeight, sx, sy, sWidth, sHeight,
-                static_cast<int32_t>(dx), static_cast<int32_t>(dy), static_cast<uint32_t>(dWidth), static_cast<uint32_t>(dHeight));
+                dxInt, dyInt, static_cast<uint32_t>(dWidthInt), static_cast<uint32_t>(dHeightInt));
         }
         else
         {

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -2,6 +2,7 @@
 #include <map>
 #include <algorithm>
 #include <cassert>
+#include <cstring>
 #include <optional>
 #include <regex>
 
@@ -765,6 +766,111 @@ namespace Babylon::Polyfills::Internal
         nvgArc(*m_nvg, x, y, radius, startAngle, endAngle, winding);
     }
 
+    void Context::EnsureCpuBuffer()
+    {
+        const uint32_t width = m_canvas != nullptr ? m_canvas->GetWidth() : 0;
+        const uint32_t height = m_canvas != nullptr ? m_canvas->GetHeight() : 0;
+        if (width != m_cpuWidth || height != m_cpuHeight || m_cpuPixels.empty())
+        {
+            m_cpuWidth = width;
+            m_cpuHeight = height;
+            m_cpuPixels.assign(static_cast<size_t>(width) * height * 4, 0);
+        }
+    }
+
+    void Context::BlitImageToCpu(const NativeCanvasImage& image, int32_t sx, int32_t sy, uint32_t sw, uint32_t sh, int32_t dx, int32_t dy, uint32_t dw, uint32_t dh)
+    {
+        const uint8_t* src = image.GetPixels();
+        if (src == nullptr || dw == 0 || dh == 0)
+        {
+            return;
+        }
+
+        EnsureCpuBuffer();
+        if (m_cpuPixels.empty())
+        {
+            return;
+        }
+
+        const uint32_t srcWidth = image.GetWidth();
+        const uint32_t srcHeight = image.GetHeight();
+
+        for (uint32_t j = 0; j < dh; ++j)
+        {
+            const int32_t destY = dy + static_cast<int32_t>(j);
+            if (destY < 0 || destY >= static_cast<int32_t>(m_cpuHeight))
+            {
+                continue;
+            }
+
+            // Nearest-neighbor sample of the source row (exact when dh == sh).
+            const int32_t srcYRel = static_cast<int32_t>(static_cast<uint64_t>(j) * sh / dh);
+            const int32_t srcY = sy + srcYRel;
+            if (srcY < 0 || srcY >= static_cast<int32_t>(srcHeight))
+            {
+                continue;
+            }
+
+            for (uint32_t i = 0; i < dw; ++i)
+            {
+                const int32_t destX = dx + static_cast<int32_t>(i);
+                if (destX < 0 || destX >= static_cast<int32_t>(m_cpuWidth))
+                {
+                    continue;
+                }
+
+                const int32_t srcXRel = static_cast<int32_t>(static_cast<uint64_t>(i) * sw / dw);
+                const int32_t srcX = sx + srcXRel;
+                if (srcX < 0 || srcX >= static_cast<int32_t>(srcWidth))
+                {
+                    continue;
+                }
+
+                const size_t srcIndex = (static_cast<size_t>(srcY) * srcWidth + srcX) * 4;
+                const size_t destIndex = (static_cast<size_t>(destY) * m_cpuWidth + destX) * 4;
+                m_cpuPixels[destIndex + 0] = src[srcIndex + 0];
+                m_cpuPixels[destIndex + 1] = src[srcIndex + 1];
+                m_cpuPixels[destIndex + 2] = src[srcIndex + 2];
+                m_cpuPixels[destIndex + 3] = src[srcIndex + 3];
+            }
+        }
+    }
+
+    void Context::ReadPixels(int32_t sx, int32_t sy, uint32_t w, uint32_t h, uint8_t* dst) const
+    {
+        const size_t total = static_cast<size_t>(w) * h * 4;
+        std::memset(dst, 0, total);
+        if (m_cpuPixels.empty())
+        {
+            return;
+        }
+
+        for (uint32_t j = 0; j < h; ++j)
+        {
+            const int32_t srcY = sy + static_cast<int32_t>(j);
+            if (srcY < 0 || srcY >= static_cast<int32_t>(m_cpuHeight))
+            {
+                continue;
+            }
+
+            for (uint32_t i = 0; i < w; ++i)
+            {
+                const int32_t srcX = sx + static_cast<int32_t>(i);
+                if (srcX < 0 || srcX >= static_cast<int32_t>(m_cpuWidth))
+                {
+                    continue;
+                }
+
+                const size_t srcIndex = (static_cast<size_t>(srcY) * m_cpuWidth + srcX) * 4;
+                const size_t destIndex = (static_cast<size_t>(j) * w + i) * 4;
+                dst[destIndex + 0] = m_cpuPixels[srcIndex + 0];
+                dst[destIndex + 1] = m_cpuPixels[srcIndex + 1];
+                dst[destIndex + 2] = m_cpuPixels[srcIndex + 2];
+                dst[destIndex + 3] = m_cpuPixels[srcIndex + 3];
+            }
+        }
+    }
+
     void Context::DrawImage(const Napi::CallbackInfo& info)
     {
         const NativeCanvasImage* canvasImage = NativeCanvasImage::Unwrap(info[0].As<Napi::Object>());
@@ -800,6 +906,9 @@ namespace Babylon::Polyfills::Internal
             nvgFillPaint(*m_nvg, imagePaint);
             SetFilterStack();
             nvgFill(*m_nvg);
+
+            BlitImageToCpu(*canvasImage, 0, 0, canvasImage->GetWidth(), canvasImage->GetHeight(),
+                static_cast<int32_t>(dx), static_cast<int32_t>(dy), canvasImage->GetWidth(), canvasImage->GetHeight());
         }
         else if (info.Length() == 5)
         {
@@ -819,6 +928,9 @@ namespace Babylon::Polyfills::Internal
             nvgFillPaint(*m_nvg, imagePaint);
             SetFilterStack();
             nvgFill(*m_nvg);
+
+            BlitImageToCpu(*canvasImage, 0, 0, canvasImage->GetWidth(), canvasImage->GetHeight(),
+                static_cast<int32_t>(dx), static_cast<int32_t>(dy), static_cast<uint32_t>(dWidth), static_cast<uint32_t>(dHeight));
         }
         else if (info.Length() == 9)
         {
@@ -844,6 +956,9 @@ namespace Babylon::Polyfills::Internal
             nvgFillPaint(*m_nvg, imagePaint);
             SetFilterStack();
             nvgFill(*m_nvg);
+
+            BlitImageToCpu(*canvasImage, sx, sy, sWidth, sHeight,
+                static_cast<int32_t>(dx), static_cast<int32_t>(dy), static_cast<uint32_t>(dWidth), static_cast<uint32_t>(dHeight));
         }
         else
         {
@@ -853,13 +968,12 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value Context::GetImageData(const Napi::CallbackInfo& info)
     {
-        // TODO: support source x and y
-        //const auto sx = info[0].As<Napi::Number>().Uint32Value();
-        //const auto sy = info[1].As<Napi::Number>().Uint32Value();
+        const auto sx = info[0].As<Napi::Number>().Int32Value();
+        const auto sy = info[1].As<Napi::Number>().Int32Value();
         const auto sw = info[2].As<Napi::Number>().Uint32Value();
         const auto sh = info[3].As<Napi::Number>().Uint32Value();
 
-        return ImageData::CreateInstance(info.Env(), this, sw, sh);
+        return ImageData::CreateInstance(info.Env(), this, sx, sy, sw, sh);
     }
 
     void Context::SetLineDash(const Napi::CallbackInfo& info)

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -149,6 +149,10 @@ namespace Babylon::Polyfills::Internal
         uint32_t m_cpuHeight{0};
         void EnsureCpuBuffer();
         void BlitImageToCpu(const NativeCanvasImage& image, int32_t sx, int32_t sy, uint32_t sw, uint32_t sh, int32_t dx, int32_t dy, uint32_t dw, uint32_t dh);
+        // Core RGBA8 blit used by both the NativeCanvasImage and (plain) ImageBitmap drawImage paths.
+        void BlitPixelsToCpu(const uint8_t* src, uint32_t srcWidth, uint32_t srcHeight, int32_t sx, int32_t sy, uint32_t sw, uint32_t sh, int32_t dx, int32_t dy, uint32_t dw, uint32_t dh);
+        // Shared drawImage body: draws the nanovg image (arity 3/5/9) and mirrors it to the CPU buffer.
+        void DrawImageCommon(const Napi::CallbackInfo& info, int imageIndex, const uint8_t* srcPixels, uint32_t srcWidth, uint32_t srcHeight);
 
         friend class Canvas;
     };

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -9,6 +9,7 @@
 #include "nanovg/nanovg_filterstack.h"
 #include <variant>
 #include <vector>
+#include <cstdint>
 
 struct NVGcontext;
 
@@ -26,6 +27,10 @@ namespace Babylon::Polyfills::Internal
         virtual ~Context();
 
         NVGcontext* GetNVGContext() const { return *m_nvg.get(); }
+
+        // Copies a region of the CPU-side pixel mirror (populated by DrawImage) into dst (w*h*4 RGBA8 bytes).
+        // Out-of-range pixels are written as zero. Used to implement getImageData without a GPU readback.
+        void ReadPixels(int32_t sx, int32_t sy, uint32_t w, uint32_t h, uint8_t* dst) const;
 
     private:
         void FillRect(const Napi::CallbackInfo&);
@@ -136,6 +141,14 @@ namespace Babylon::Polyfills::Internal
         void FlushGraphicResources() override;
         void PlayPath2D(const NativeCanvasPath2D* path);
         void SetFilterStack();
+
+        // CPU-side RGBA8 mirror of the canvas, sized to the canvas, populated by DrawImage so that
+        // getImageData can return the exact decoded pixels (the GPU nanovg framebuffer is not read back).
+        std::vector<uint8_t> m_cpuPixels;
+        uint32_t m_cpuWidth{0};
+        uint32_t m_cpuHeight{0};
+        void EnsureCpuBuffer();
+        void BlitImageToCpu(const NativeCanvasImage& image, int32_t sx, int32_t sy, uint32_t sw, uint32_t sh, int32_t dx, int32_t dy, uint32_t dw, uint32_t dh);
 
         friend class Canvas;
     };

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -148,7 +148,6 @@ namespace Babylon::Polyfills::Internal
         uint32_t m_cpuWidth{0};
         uint32_t m_cpuHeight{0};
         void EnsureCpuBuffer();
-        void BlitImageToCpu(const NativeCanvasImage& image, int32_t sx, int32_t sy, uint32_t sw, uint32_t sh, int32_t dx, int32_t dy, uint32_t dw, uint32_t dh);
         // Core RGBA8 blit used by both the NativeCanvasImage and (plain) ImageBitmap drawImage paths.
         void BlitPixelsToCpu(const uint8_t* src, uint32_t srcWidth, uint32_t srcHeight, int32_t sx, int32_t sy, uint32_t sw, uint32_t sh, int32_t dx, int32_t dy, uint32_t dw, uint32_t dh);
         // Shared drawImage body: draws the nanovg image (arity 3/5/9) and mirrors it to the CPU buffer.

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -30,7 +30,7 @@ namespace Babylon::Polyfills::Internal
 
         // Copies a region of the CPU-side pixel mirror (populated by DrawImage) into dst (w*h*4 RGBA8 bytes).
         // Out-of-range pixels are written as zero. Used to implement getImageData without a GPU readback.
-        void ReadPixels(int32_t sx, int32_t sy, uint32_t w, uint32_t h, uint8_t* dst) const;
+        void ReadPixels(int32_t sx, int32_t sy, uint32_t w, uint32_t h, uint8_t* dst);
 
     private:
         void FillRect(const Napi::CallbackInfo&);

--- a/Polyfills/Canvas/Source/Image.cpp
+++ b/Polyfills/Canvas/Source/Image.cpp
@@ -193,6 +193,17 @@ namespace Babylon::Polyfills::Internal
         m_onerrorHandlerRef = Napi::Persistent(eventHandler);
     }
 
+    const uint8_t* NativeCanvasImage::GetPixels() const
+    {
+#ifdef BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES
+        if (m_imageContainer != nullptr)
+        {
+            return static_cast<const uint8_t*>(m_imageContainer->m_data);
+        }
+#endif
+        return nullptr;
+    }
+
     int NativeCanvasImage::CreateNVGImageForContext(NVGcontext* nvgContext) const
     {
 #ifdef BABYLON_NATIVE_PLUGIN_NATIVEENGINE_LOAD_IMAGES

--- a/Polyfills/Canvas/Source/Image.h
+++ b/Polyfills/Canvas/Source/Image.h
@@ -27,6 +27,9 @@ namespace Babylon::Polyfills::Internal
         uint32_t GetWidth() const { return m_width; }
         uint32_t GetHeight() const { return m_height; }
 
+        // Returns the decoded RGBA8 pixels (width*height*4 bytes), or nullptr if not loaded.
+        const uint8_t* GetPixels() const;
+
     private:
         Napi::Value GetWidth(const Napi::CallbackInfo&);
         Napi::Value GetHeight(const Napi::CallbackInfo&);

--- a/Polyfills/Canvas/Source/ImageData.cpp
+++ b/Polyfills/Canvas/Source/ImageData.cpp
@@ -1,6 +1,7 @@
 #include <bgfx/bgfx.h>
 #include <map>
 #include <cstring>
+#include <limits>
 #include "Canvas.h"
 #include "Context.h"
 #include "ImageData.h"
@@ -49,7 +50,15 @@ namespace Babylon::Polyfills::Internal
         m_width = info[3].As<Napi::Number>().Uint32Value();
         m_height = info[4].As<Napi::Number>().Uint32Value();
 
-        m_pixels.resize(static_cast<size_t>(m_width) * m_height * 4);
+        // Context::GetImageData already rejects regions this large, but keep the invariant local
+        // so the size_t multiplication below can never wrap (size_t is 32-bit on 32-bit ABIs).
+        const uint64_t pixelCount{static_cast<uint64_t>(m_width) * m_height};
+        if (pixelCount > std::numeric_limits<size_t>::max() / 4)
+        {
+            throw Napi::RangeError::New(info.Env(), "ImageData: requested region is too large.");
+        }
+
+        m_pixels.resize(static_cast<size_t>(pixelCount) * 4);
         if (context != nullptr && !m_pixels.empty())
         {
             context->ReadPixels(sx, sy, m_width, m_height, m_pixels.data());
@@ -68,7 +77,7 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value ImageData::GetData(const Napi::CallbackInfo& info)
     {
-        const auto size{static_cast<size_t>(m_width) * m_height * 4};
+        const auto size{m_pixels.size()};
         auto data{Napi::Uint8Array::New(info.Env(), size)};
         if (size > 0)
         {

--- a/Polyfills/Canvas/Source/ImageData.cpp
+++ b/Polyfills/Canvas/Source/ImageData.cpp
@@ -1,5 +1,6 @@
 #include <bgfx/bgfx.h>
 #include <map>
+#include <cstring>
 #include "Canvas.h"
 #include "Context.h"
 #include "ImageData.h"
@@ -19,7 +20,7 @@ namespace Babylon::Polyfills::Internal
 {
     static constexpr auto JS_IMAGEDATA_CONSTRUCTOR_NAME = "ImageData";
 
-    Napi::Value ImageData::CreateInstance(Napi::Env env, Context* context, uint32_t width, uint32_t height)
+    Napi::Value ImageData::CreateInstance(Napi::Env env, Context* context, int32_t sx, int32_t sy, uint32_t width, uint32_t height)
     {
         // No Napi::HandleScope here: the object created by func.New() is returned to the caller.
         // A plain HandleScope would free the handle on close, which under the reference-counted
@@ -32,17 +33,27 @@ namespace Babylon::Polyfills::Internal
                 InstanceAccessor("height", &ImageData::GetHeight, nullptr),
                 InstanceAccessor("data", &ImageData::GetData, nullptr),
             });
-        return func.New({Napi::External<Context>::New(env, context), Napi::Value::From(env, width), Napi::Value::From(env, height)});
+        return func.New({Napi::External<Context>::New(env, context),
+            Napi::Value::From(env, sx),
+            Napi::Value::From(env, sy),
+            Napi::Value::From(env, width),
+            Napi::Value::From(env, height)});
     }
 
     ImageData::ImageData(const Napi::CallbackInfo& info)
         : Napi::ObjectWrap<ImageData>{info}
     {
         auto context{info[0].As<Napi::External<Context>>().Data()};
-        auto width{info[1].As<Napi::Number>().Uint32Value()};
-        auto height{info[1].As<Napi::Number>().Uint32Value()};
-        m_width = width;
-        m_height = height;
+        const auto sx{info[1].As<Napi::Number>().Int32Value()};
+        const auto sy{info[2].As<Napi::Number>().Int32Value()};
+        m_width = info[3].As<Napi::Number>().Uint32Value();
+        m_height = info[4].As<Napi::Number>().Uint32Value();
+
+        m_pixels.resize(static_cast<size_t>(m_width) * m_height * 4);
+        if (context != nullptr && !m_pixels.empty())
+        {
+            context->ReadPixels(sx, sy, m_width, m_height, m_pixels.data());
+        }
     }
 
     Napi::Value ImageData::GetWidth(const Napi::CallbackInfo&)
@@ -57,11 +68,12 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value ImageData::GetData(const Napi::CallbackInfo& info)
     {
-        // return a well size array with 0
-        // TODO: Get datas from context/canvas
-        const auto size{m_width * m_height * 4};
+        const auto size{static_cast<size_t>(m_width) * m_height * 4};
         auto data{Napi::Uint8Array::New(info.Env(), size)};
-        memset(data.Data(), 0, size);
+        if (size > 0)
+        {
+            std::memcpy(data.Data(), m_pixels.data(), size);
+        }
         return Napi::Value::From(info.Env(), data);
     }
 }

--- a/Polyfills/Canvas/Source/ImageData.h
+++ b/Polyfills/Canvas/Source/ImageData.h
@@ -1,13 +1,15 @@
 #pragma once
 
 #include <Babylon/Polyfills/Canvas.h>
+#include <cstdint>
+#include <vector>
 
 namespace Babylon::Polyfills::Internal
 {
     class ImageData final : public Napi::ObjectWrap<ImageData>
     {
     public:
-        static Napi::Value CreateInstance(Napi::Env env, Context* context, uint32_t width, uint32_t height);
+        static Napi::Value CreateInstance(Napi::Env env, Context* context, int32_t sx, int32_t sy, uint32_t width, uint32_t height);
 
         explicit ImageData(const Napi::CallbackInfo& info);
 
@@ -18,5 +20,6 @@ namespace Babylon::Polyfills::Internal
 
         uint32_t m_width{};
         uint32_t m_height{};
+        std::vector<uint8_t> m_pixels;
     };
 }


### PR DESCRIPTION
Two Canvas 2D fixes that together make the `drawImage` → `getImageData` round trip work, plus input validation for the new entry points.

## 1. `getImageData` returned all zeros

`ImageData::GetData` was a stub:

```cpp
// return a well size array with 0
// TODO: Get datas from context/canvas
```

It allocated a buffer and `memset` it to 0, so every `getImageData()` call read back a fully transparent image no matter what had been drawn. `Context::GetImageData` also discarded the source x/y arguments (`// TODO: support source x and y`).

BN's canvas is GPU-backed (nanovg), and a framebuffer readback is a poor fit for the data-texture callers that rely on `getImageData`: the surface is premultiplied and may be resampled, so the bytes that come back are not the bytes that went in. Instead this keeps a **CPU-side RGBA8 mirror** — `drawImage` copies the decoded image's exact pixels (`Image::GetPixels` → bimg `m_data`) into `Context::m_cpuPixels`, and `getImageData` reads that region back out. `BlitPixelsToCpu` covers all three `drawImage` arities with nearest-neighbour sampling, which is exact for the 1:1 draws these callers use. The mirror is reallocated and cleared on canvas resize.

Also fixes a pre-existing `ImageData` constructor bug that read the height from `info[1]` instead of `info[2]`, so a non-square `ImageData` reported its width as its height.

## 2. `drawImage` access violation on a plain `ImageBitmap`

Babylon Native sets `forceBitmapOverHTMLImageElement`, which routes `LoadImage` through `NativeEngine::CreateImageBitmap`. That returns a plain JS object `{data, width, height, format}` — **not** a wrapped `NativeCanvasImage`. `Context::DrawImage` called `NativeCanvasImage::Unwrap` on whatever it was handed, so `napi_unwrap` dereferenced a never-wrapped object and crashed with an access violation (0xC0000005).

`DrawImage` now detects the plain `ImageBitmap` by its own `data` typed array, converts its pixels to RGBA8 via `bimg::imageConvert` (memcpy fast path when the source is already RGBA8), creates a transient nanovg image, and shares the arity-3/5/9 draw plus CPU-mirror blit with the existing path through a new `DrawImageCommon` helper. The `NativeCanvasImage` path is behaviour-identical.

## 3. Input validation

Both new paths take sizes straight from JS and hand them to bimg and to raw pointer arithmetic, so the third commit validates them at the boundary:

- `drawImage` rejects an out-of-range bimg texture format, dimensions whose pixel count would overflow the destination allocation, and a `data` array shorter than `width*height` for its format. **`bimg::imageConvert` is given neither buffer's real length**, so without these it would read past the end of the source.
- `getImageData` requires its four arguments and rejects a region whose byte size would overflow `size_t` before `ImageData` tries to allocate it.
- `BlitPixelsToCpu` clamps its iteration range to the destination rect's intersection with the canvas up front. The destination size is caller-controlled and arrives unsigned, so a negative width wraps to ~4e9; the previous per-pixel bounds test still walked the whole rect and could stall the JS thread for billions of no-op iterations.

Range checks are computed in `uint64_t` so they stay meaningful where `size_t` is 32-bit (Android armeabi-v7a), and the new arithmetic uses fixed-width types rather than `long`, whose width differs between MSVC and Apple clang.

## Validation

- **"Displacement map" (idx 200)** — `Mesh.applyDisplacementMap` is exactly this `drawImage` → `getImageData` round trip. It crashes on master; with this change it renders at **0.155% pixel difference** against a 2.5% limit. It is still `excludeFromAutomaticTesting` in `config.json`, so reproduce with `--include-excluded --test-index=200`. Un-excluding it is deliberately left to a separate test-enablement PR.
- **Full validation suite: `ran=295 passed=295 failed=0`** — no regressions.

<details>
<summary>Why 295 and not 300</summary>

The 5 tests at indices 53–57 (`Scissor test`, `Scissor test with 0.9 hardware scaling`, `… with 1.5 hardware scaling`, `… with negative x and y`, `… with out of bounds width and height`) are excluded from that run because they **crash on unmodified master**, not because of anything here:

```
--- BN: CRASH ---
Unknown signal? Exception Code 87a
  7: bgfx/src/renderer_d3d11.cpp  6173  bgfx::d3d11::RendererContextD3D11::submit
  8: bgfx/src/bgfx.cpp            2917  bgfx::Context::renderFrame
 13: Core/Graphics/Source/DeviceImpl.cpp  539  Babylon::Graphics::DeviceImpl::Frame
```

Exit code 3, Win32 x64 D3D11 Debug. Verified pre-existing by reverting `Polyfills/Canvas` to master and rebuilding — identical crash at the same test. (`0x87a` is the DXGI `0x887A…` device-removed family.) The duplicate `Scissor test` at idx 311 passes. Worth noting because it truncates any full-suite run at 52 tests; happy to file it separately.
</details>

## Not included

My working branch also un-excluded idx 106 "Gaussian Splatting Part Test" alongside this change. That does **not** hold on stock upstream, so it is left out: Babylon's SOG loader unpacks the `.sog` container and materialises its WebP images through `URL.createObjectURL`, and upstream JsRuntimeHost has no blob-URL support, so the load fails before any canvas work happens. That un-exclusion needs a JsRuntimeHost change first.

There are **no `config.json` changes in this PR** — it is native-only and enables no tests.
