### PR TITLE
Update bgfx.cmake to latest and drop the local SSE4.2 workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ FetchContent_Declare(base-n
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(bgfx.cmake
     GIT_REPOSITORY https://github.com/BabylonJS/bgfx.cmake.git
-    GIT_TAG 6c5515826c428337b7cbc0a5a7cc6d12325ce72b
+    GIT_TAG 5c98749de48e8609a62e5c1fd2cfffbbd970588e
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(CMakeExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/CMakeExtensions.git

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -115,21 +115,6 @@ if(NOT BABYLON_NATIVE_PLUGIN_NATIVEENGINE_WEBP AND TARGET bimg_decode)
     target_compile_definitions(bimg_decode PRIVATE BIMG_CONFIG_PARSE_WEBP=0)
 endif()
 
-if(NOT APPLE AND NOT ANDROID AND CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64|AMD64)" AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    # The new bx requires SSE4.2 on x86_64 (see bx scripts/toolchain.lua and
-    # include/bx/inline/simd128_sse.inl which uses _mm_round_ps / _mm_blendv_ps
-    # under "SSE4.1 - always available with SSE4.2 minspec"). bgfx.cmake does
-    # not propagate this flag, so add it explicitly for any GCC/Clang frontend on
-    # x86_64 (e.g. Linux, or Clang targeting Windows), none of which enable SSE4.x
-    # by default. MSVC (cl.exe) allows the intrinsics regardless and Apple Silicon
-    # is unaffected.
-    foreach(_bx_target IN ITEMS bx bgfx bimg bimg_decode bimg_encode)
-        if(TARGET ${_bx_target})
-            target_compile_options(${_bx_target} PRIVATE -msse4.2)
-        endif()
-    endforeach()
-endif()
-
 if(UNIX AND NOT APPLE AND NOT ANDROID)
     # Use GLVND libraries for EGL support in bgfx
     set(OpenGL_GL_PREFERENCE GLVND)


### PR DESCRIPTION
Bumps `bgfx.cmake` from `6c55158` to
[`5c98749`](https://github.com/BabylonJS/bgfx.cmake/commit/5c98749de48e8609a62e5c1fd2cfffbbd970588e),
which brings in:

- [BabylonJS/bgfx.cmake#135](https://github.com/BabylonJS/bgfx.cmake/pull/135) — bx's SSE4.2
  minspec is now applied to every x86 target instead of only x86_64, and Apple universal
  builds scope it per slice with `-Xarch_`.
- [BabylonJS/bgfx.cmake#136](https://github.com/BabylonJS/bgfx.cmake/pull/136) — bgfx and
  bimg submodule updates.

## Why

`bx/include/bx/simd_t.h` uses SSE4.1 intrinsics (`_mm_round_ps`, `_mm_blendv_ps`) whenever
`BX_CPU_X86 && __SSE2__`, so every x86 target needs the SSE4.2 minspec that bx's own
`scripts/toolchain.lua` sets. Two configurations were missing it:

- **the x86_64 slice of Apple universal builds** — `CMAKE_SYSTEM_PROCESSOR` names only one
  slice, so ios-cmake's `SIMULATOR64COMBINED` (which reports `aarch64` while *also* building
  an x86_64 slice) compiled that slice without the flag;
- **32-bit x86** — the Android NDK sets `CMAKE_SYSTEM_PROCESSOR` to `i686` for the `x86` ABI,
  which the old `x86_64`-only guard did not match.

Both failed with:

```
simd128_sse.inl:296:10: error: '__builtin_ia32_roundps' needs target feature sse4.1
simd128_sse.inl:769:10: error: always_inline function '_mm_blendv_ps' requires target
                               feature 'sse4.1', but would be inlined into function
                               'simd128_selb' that is compiled without support for 'sse4.1'
```

## Removed workaround

`Dependencies/CMakeLists.txt` carried a local `-msse4.2` workaround. The minspec is now
applied `PUBLIC` on the `bx` target, and `bgfx` / `bimg` / `bimg_decode` / `bimg_encode` all
link `bx` `PUBLIC`, so it is redundant.

It was also narrower than the problem it was working around — `NOT APPLE AND NOT ANDROID`
plus an `x86_64`-only processor match meant it never covered the Apple universal or
Android x86 cases that were actually failing.

## Verification

Reproduced and validated on a mirror of the NuGet packager pipeline (iOS
`SIMULATOR64COMBINED` / `Debug`, Xcode 26.0.1, `macos-latest`):

| | before the bgfx.cmake fix | after |
| --- | --- | --- |
| `needs target feature sse4.1` errors | 2 | **0** |
| result | FAILED at `bimg` → `image.o` (x86_64 slice) | **BUILD SUCCEEDED** |
| static libs linked / files installed | 12 / — | **70 / 66** |

The bgfx.cmake change itself was verified across 25 platform configurations (macOS/iOS/watchOS
single and universal slices, Android `x86`/`x86_64`/`armeabi-v7a`/`arm64-v8a`, Linux
`x86_64`/`i686`/`aarch64`, MSVC `x64`/`ARM64`/`Win32`, clang-cl, Emscripten) — see
BabylonJS/bgfx.cmake#135 for the full table.
