### PR TITLE
Graphics/Canvas: fix bgfx view exhaustion (shared nanovg view + guarded mid-frame flush)

### DIFF
--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -4434,8 +4434,6 @@
         {
             "title": "Vertex Pulling - Normals UVs Colors Tangents",
             "playgroundId": "#664OF3#6",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Test crashes or hangs on Babylon Native",
             "referenceImage": "vertexPullingNormalsUVsColors.png"
         },
         {

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
@@ -120,6 +120,10 @@ namespace Babylon::Graphics
         bgfx::ViewId AcquireNewViewId();
         bgfx::ViewId PeekNextViewId() const;
 
+        // Bumped whenever a mid-frame flush resets the view counter. Cache this alongside any
+        // view id that is retained across draw calls and re-acquire when it changes.
+        uint32_t ViewIdGeneration() const;
+
         // If the current frame is close to exhausting bgfx views, flush accumulated
         // views (cross-thread bgfx::frame + view-counter reset) so rendering can
         // continue within the same logical frame. Call at draw/clear op boundaries.

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/DeviceContext.h
@@ -120,6 +120,11 @@ namespace Babylon::Graphics
         bgfx::ViewId AcquireNewViewId();
         bgfx::ViewId PeekNextViewId() const;
 
+        // If the current frame is close to exhausting bgfx views, flush accumulated
+        // views (cross-thread bgfx::frame + view-counter reset) so rendering can
+        // continue within the same logical frame. Call at draw/clear op boundaries.
+        void FlushViewsIfNeeded();
+
         // TODO: find a different way to get the texture info for frame capture
         void AddTexture(bgfx::TextureHandle handle, uint16_t width, uint16_t height, bool hasMips, uint16_t numLayers, bgfx::TextureFormat::Enum format);
         void RemoveTexture(bgfx::TextureHandle handle);

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/FrameBuffer.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/FrameBuffer.h
@@ -62,6 +62,11 @@ namespace Babylon::Graphics
 
         std::optional<bgfx::ViewId> m_viewId{};
 
+        // Generation that m_viewId was acquired in. A mid-frame view flush resets the device's
+        // view counter, which makes a retained id sort after freshly acquired ones; comparing
+        // against DeviceContext::ViewIdGeneration() detects that and forces a re-acquire.
+        uint32_t m_viewIdGeneration{0};
+
         Rect m_bgfxViewPort{0.0f, 0.0f, 1.0f, 1.0f};
         Rect m_desiredViewPort{0.0f, 0.0f, 1.0f, 1.0f};
 

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
@@ -45,9 +45,17 @@ namespace Babylon::Graphics
         void ViewNumLayers(uint16_t);
 
         // View id reserved (by the Canvas polyfill) for the canvas->texture blit that fills
-        // this texture. UINT16_MAX means "unset"; consumers fall back to a freshly peeked view.
+        // this texture, together with the view-id generation it was reserved in. UINT16_MAX
+        // means "unset"; a generation mismatch means a mid-frame view flush has since reset the
+        // view counter and the reservation no longer orders before later views. In both cases
+        // consumers fall back to a freshly peeked view.
         bgfx::ViewId BlitViewId() const { return m_blitViewId; }
-        void BlitViewId(bgfx::ViewId viewId) { m_blitViewId = viewId; }
+        uint32_t BlitViewIdGeneration() const { return m_blitViewIdGeneration; }
+        void BlitViewId(bgfx::ViewId viewId, uint32_t generation)
+        {
+            m_blitViewId = viewId;
+            m_blitViewIdGeneration = generation;
+        }
 
     private:
         bgfx::TextureHandle m_handle{bgfx::kInvalidHandle};
@@ -62,6 +70,7 @@ namespace Babylon::Graphics
         uint16_t m_viewFirstLayer{0};
         uint16_t m_viewNumLayers{0};
         bgfx::ViewId m_blitViewId{UINT16_MAX};
+        uint32_t m_blitViewIdGeneration{0};
         uintptr_t m_deviceID;
         DeviceContext& m_deviceContext;
     };

--- a/Core/Graphics/Source/DeviceContext.cpp
+++ b/Core/Graphics/Source/DeviceContext.cpp
@@ -137,6 +137,11 @@ namespace Babylon::Graphics
         return m_graphicsImpl.PeekNextViewId();
     }
 
+    void DeviceContext::FlushViewsIfNeeded()
+    {
+        m_graphicsImpl.FlushViewsIfNeeded();
+    }
+
     void DeviceContext::AddTexture(bgfx::TextureHandle handle, uint16_t width, uint16_t height, bool hasMips, uint16_t numLayers, bgfx::TextureFormat::Enum format)
     {
         std::scoped_lock lock{m_textureHandleToInfoMutex};

--- a/Core/Graphics/Source/DeviceContext.cpp
+++ b/Core/Graphics/Source/DeviceContext.cpp
@@ -137,6 +137,11 @@ namespace Babylon::Graphics
         return m_graphicsImpl.PeekNextViewId();
     }
 
+    uint32_t DeviceContext::ViewIdGeneration() const
+    {
+        return m_graphicsImpl.ViewIdGeneration();
+    }
+
     void DeviceContext::FlushViewsIfNeeded()
     {
         m_graphicsImpl.FlushViewsIfNeeded();

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -494,6 +494,11 @@ namespace Babylon::Graphics
         return m_nextViewId.load();
     }
 
+    uint32_t DeviceImpl::ViewIdGeneration() const
+    {
+        return m_viewIdGeneration.load();
+    }
+
     void DeviceImpl::FlushViewsIfNeeded()
     {
         // Reserve headroom below the hard cap: a single draw/clear operation can
@@ -561,6 +566,12 @@ namespace Babylon::Graphics
 
         bgfx::frame();
         m_nextViewId.store(0);
+
+        // Publish a new generation so holders of cached view ids (FrameBuffer's m_viewId, the
+        // Canvas blit reservation) can detect that their id predates the reset and re-acquire.
+        // Without this a cached high id would sort *after* every id handed out from the reset
+        // counter, inverting submission order relative to the JS-side draw order.
+        m_viewIdGeneration.fetch_add(1);
 
         m_frameEncoder = bgfx::begin(true);
     }

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -521,6 +521,15 @@ namespace Babylon::Graphics
         // (maxViews - 1) is reserved for readback blits.
         constexpr bgfx::ViewId kViewFlushMargin = 16;
 
+        // Maximum mid-frame flushes allowed in one logical frame. Measured: no test in the
+        // validation suite needs any at the real 256-view budget, and the heaviest content
+        // found so far (the excluded "Nested BBG", which renders in a setInterval) peaks at
+        // 5. 64 leaves generous headroom for legitimately heavy content while bounding a
+        // mechanism that is otherwise unlimited: each flush is a blocking round-trip to the
+        // render thread, so an unbounded number of them would degrade into an apparent hang
+        // rather than an error.
+        constexpr uint32_t kMaxMidFrameViewFlushes = 64;
+
         const bgfx::ViewId maxViews = static_cast<bgfx::ViewId>(bgfx::getCaps()->limits.maxViews);
         if (maxViews <= kViewFlushMargin)
         {
@@ -528,6 +537,17 @@ namespace Babylon::Graphics
         }
 
         if (m_nextViewId.load() < static_cast<uint32_t>(maxViews - kViewFlushMargin))
+        {
+            return;
+        }
+
+        // Bound the rescue. Each flush is a blocking round-trip to the render thread, so
+        // content that needs an unbounded number of them (e.g. a snippet that renders in a
+        // setInterval without ever letting the frame present) would appear to hang rather
+        // than fail. Past the budget, stop flushing and let AcquireNewViewId throw
+        // "Too many views" — the pre-existing behaviour, and a far better diagnostic than a
+        // process that makes progress too slowly to ever finish.
+        if (m_midFrameFlushCount.load() >= kMaxMidFrameViewFlushes)
         {
             return;
         }
@@ -586,6 +606,7 @@ namespace Babylon::Graphics
         // still flips exactly once.
         bgfx::frame(BGFX_FRAME_FLUSH);
         m_nextViewId.store(0);
+        m_midFrameFlushCount.fetch_add(1);
 
         // Publish a new generation so holders of cached view ids (FrameBuffer's m_viewId, the
         // Canvas blit reservation) can detect that their id predates the reset and re-acquire.
@@ -666,6 +687,7 @@ namespace Babylon::Graphics
         }
 
         m_nextViewId.store(0);
+        m_midFrameFlushCount.store(0);
     }
 
     void DeviceImpl::CaptureCallback(const BgfxCallback::CaptureData& data)

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -331,9 +331,27 @@ namespace Babylon::Graphics
         // Close the gate: wait until JS thread has released all FrameCompletionScopes
         // (meaning all encoder work for this frame is done), then block new acquisitions.
         // After this point, no bgfx encoder calls can be in flight on the JS thread.
+        //
+        // While waiting, also service any mid-frame view-flush requests from the JS
+        // thread (see FlushViewsIfNeeded): the JS thread parks itself and we advance a
+        // bgfx frame here on the render thread to reset the view counter, then hand a
+        // fresh encoder back so rendering continues within the same logical frame.
         {
             std::unique_lock lock{m_frameSyncMutex};
-            m_frameSyncCV.wait(lock, [this] { return m_pendingFrameScopes == 0; });
+            while (true)
+            {
+                m_frameSyncCV.wait(lock, [this] { return m_pendingFrameScopes == 0 || m_flushRequested; });
+
+                if (m_flushRequested)
+                {
+                    PerformMidFrameViewFlush();
+                    m_flushRequested = false;
+                    m_flushCompleteCV.notify_all();
+                    continue;
+                }
+
+                break;
+            }
             m_frameBlocked = true;
         }
 
@@ -474,6 +492,77 @@ namespace Babylon::Graphics
     bgfx::ViewId DeviceImpl::PeekNextViewId() const
     {
         return m_nextViewId.load();
+    }
+
+    void DeviceImpl::FlushViewsIfNeeded()
+    {
+        // Reserve headroom below the hard cap: a single draw/clear operation can
+        // acquire a couple of views before the next flush check, and one view
+        // (maxViews - 1) is reserved for readback blits.
+        constexpr bgfx::ViewId kViewFlushMargin = 16;
+
+        const bgfx::ViewId maxViews = static_cast<bgfx::ViewId>(bgfx::getCaps()->limits.maxViews);
+        if (maxViews <= kViewFlushMargin)
+        {
+            return;
+        }
+
+        if (m_nextViewId.load() < static_cast<bgfx::ViewId>(maxViews - kViewFlushMargin))
+        {
+            return;
+        }
+
+        // The flush advances a bgfx frame, which must happen on the render (bgfx API)
+        // thread. This method is only expected to be called from the JS thread while
+        // the render thread is parked in FinishRenderingCurrentFrame. If we're on the
+        // render thread (or affinity is unset), there is nothing safe to do here.
+        if (m_renderThreadAffinity.check())
+        {
+            return;
+        }
+
+        std::unique_lock lock{m_frameSyncMutex};
+
+        // The mid-frame flush advances a bgfx frame on the render thread, which
+        // can only be serviced while the render thread is parked in
+        // FinishRenderingCurrentFrame waiting for frame scopes to drain. That is
+        // only guaranteed while at least one FrameCompletionScope is active (the
+        // normal requestAnimationFrame render path). When a snippet drives frames
+        // manually (e.g. setInterval + engine.beginFrame/scene.render/
+        // engine.endFrame) there is no frame scope, the render thread is not
+        // parked to service the request, and parking the JS thread on
+        // m_flushCompleteCV would deadlock. Skip the flush in that case; the hard
+        // cap in AcquireNewViewId remains as a backstop. Likewise skip if the gate
+        // is currently closed (bgfx::frame() in progress).
+        if (m_frameBlocked || m_pendingFrameScopes == 0)
+        {
+            return;
+        }
+
+        m_flushRequested = true;
+        m_frameSyncCV.notify_all();
+        m_flushCompleteCV.wait(lock, [this] { return !m_flushRequested; });
+    }
+
+    // Called on the render thread from FinishRenderingCurrentFrame while holding
+    // m_frameSyncMutex, with the requesting JS thread parked in FlushViewsIfNeeded
+    // (so the frame encoder is idle). End the current encoder, advance a bgfx frame
+    // to submit the accumulated views and reset the view counter, then begin a fresh
+    // encoder for the remainder of the logical frame.
+    void DeviceImpl::PerformMidFrameViewFlush()
+    {
+        ASSERT_THREAD_AFFINITY(m_renderThreadAffinity);
+
+        if (m_frameEncoder)
+        {
+            bgfx::end(m_frameEncoder);
+            m_frameEncoder = nullptr;
+        }
+
+        bgfx::frame();
+        m_nextViewId.store(0);
+
+        m_frameEncoder = bgfx::begin(true);
     }
 
     void DeviceImpl::UpdateBgfxState()

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -334,8 +334,9 @@ namespace Babylon::Graphics
         //
         // While waiting, also service any mid-frame view-flush requests from the JS
         // thread (see FlushViewsIfNeeded): the JS thread parks itself and we advance a
-        // bgfx frame here on the render thread to reset the view counter, then hand a
-        // fresh encoder back so rendering continues within the same logical frame.
+        // non-presenting bgfx frame here on the render thread to reset the view counter,
+        // then hand a fresh encoder back so rendering continues within the same logical
+        // frame.
         {
             std::unique_lock lock{m_frameSyncMutex};
             while (true)
@@ -551,9 +552,9 @@ namespace Babylon::Graphics
 
     // Called on the render thread from FinishRenderingCurrentFrame while holding
     // m_frameSyncMutex, with the requesting JS thread parked in FlushViewsIfNeeded
-    // (so the frame encoder is idle). End the current encoder, advance a bgfx frame
-    // to submit the accumulated views and reset the view counter, then begin a fresh
-    // encoder for the remainder of the logical frame.
+    // (so the frame encoder is idle). End the current encoder, advance a non-presenting
+    // bgfx frame to submit the accumulated views and reset the view counter, then begin
+    // a fresh encoder for the remainder of the logical frame.
     void DeviceImpl::PerformMidFrameViewFlush()
     {
         ASSERT_THREAD_AFFINITY(m_renderThreadAffinity);
@@ -564,7 +565,12 @@ namespace Babylon::Graphics
             m_frameEncoder = nullptr;
         }
 
-        bgfx::frame();
+        // BGFX_FRAME_FLUSH executes all queued rendering commands and resets bgfx's per-frame
+        // state (including the view counter) without presenting the backbuffer. A plain
+        // bgfx::frame() would flip a half-drawn backbuffer to the screen partway through the
+        // logical frame; bgfx remembers the flush in m_flushPrevFrame so the next real frame
+        // still flips exactly once.
+        bgfx::frame(BGFX_FRAME_FLUSH);
         m_nextViewId.store(0);
 
         // Publish a new generation so holders of cached view ids (FrameBuffer's m_viewId, the

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -482,17 +482,31 @@ namespace Babylon::Graphics
 
     bgfx::ViewId DeviceImpl::AcquireNewViewId()
     {
-        bgfx::ViewId viewId = m_nextViewId.fetch_add(1);
-        if (viewId >= bgfx::getCaps()->limits.maxViews)
+        // Saturating increment. A plain fetch_add that is undone on the throw path would be
+        // two separate atomic operations, so a concurrent PeekNextViewId could observe an
+        // out-of-range value in between, and repeated failed acquisitions could drive the
+        // counter past the cap. This loop fuses the "check the cap" and "take the id" steps,
+        // clamping at maxViews, so the counter is never observable above the cap no matter
+        // how many acquisitions fail.
+        const uint32_t maxViews = bgfx::getCaps()->limits.maxViews;
+
+        uint32_t viewId = m_nextViewId.load(std::memory_order_relaxed);
+        while (viewId < maxViews && !m_nextViewId.compare_exchange_weak(viewId, viewId + 1))
+        {
+        }
+
+        if (viewId >= maxViews)
         {
             throw std::runtime_error{"Too many views"};
         }
-        return viewId;
+
+        return static_cast<bgfx::ViewId>(viewId);
     }
 
     bgfx::ViewId DeviceImpl::PeekNextViewId() const
     {
-        return m_nextViewId.load();
+        // Saturated at maxViews by AcquireNewViewId, so this always narrows safely.
+        return static_cast<bgfx::ViewId>(m_nextViewId.load());
     }
 
     uint32_t DeviceImpl::ViewIdGeneration() const
@@ -513,7 +527,7 @@ namespace Babylon::Graphics
             return;
         }
 
-        if (m_nextViewId.load() < static_cast<bgfx::ViewId>(maxViews - kViewFlushMargin))
+        if (m_nextViewId.load() < static_cast<uint32_t>(maxViews - kViewFlushMargin))
         {
             return;
         }

--- a/Core/Graphics/Source/DeviceImpl.h
+++ b/Core/Graphics/Source/DeviceImpl.h
@@ -95,6 +95,14 @@ namespace Babylon::Graphics
         bgfx::ViewId AcquireNewViewId();
         bgfx::ViewId PeekNextViewId() const;
 
+        // Mid-frame view flush. If the current logical frame has acquired close to
+        // the maximum number of bgfx views, flush the accumulated views via a
+        // cross-thread bgfx::frame() and reset the view counter so rendering can
+        // continue within the same Babylon frame instead of running out of views
+        // (which previously threw "Too many views"). Called from the JS thread at
+        // draw/clear operation boundaries where no encoder work is pending.
+        void FlushViewsIfNeeded();
+
         // Frame completion scope support
         void IncrementPendingFrameScopes();
         void DecrementPendingFrameScopes();
@@ -128,6 +136,7 @@ namespace Babylon::Graphics
         void UpdateBgfxResolution();
         void RequestScreenShots();
         void Frame();
+        void PerformMidFrameViewFlush();
         void CaptureCallback(const BgfxCallback::CaptureData&);
 
         arcana::affinity m_renderThreadAffinity{};
@@ -213,6 +222,13 @@ namespace Babylon::Graphics
         std::condition_variable m_frameSyncCV{};
         int m_pendingFrameScopes{0};
         bool m_frameBlocked{true};
+
+        // Mid-frame view-flush handshake (guarded by m_frameSyncMutex):
+        //   - JS thread sets m_flushRequested and waits on m_flushCompleteCV.
+        //   - Render thread (parked in FinishRenderingCurrentFrame) services the
+        //     request via PerformMidFrameViewFlush, clears the flag, and notifies.
+        bool m_flushRequested{false};
+        std::condition_variable m_flushCompleteCV{};
 
         std::mutex m_captureCallbacksMutex{};
         arcana::ticketed_collection<std::function<void(const BgfxCallback::CaptureData&)>> m_captureCallbacks{};

--- a/Core/Graphics/Source/DeviceImpl.h
+++ b/Core/Graphics/Source/DeviceImpl.h
@@ -149,7 +149,10 @@ namespace Babylon::Graphics
         // Read by all consumers via DeviceContext::GetActiveEncoder() → DeviceImpl::GetActiveEncoder().
         bgfx::Encoder* m_frameEncoder{nullptr};
 
-        std::atomic<bgfx::ViewId> m_nextViewId{0};
+        // Widened to uint32_t so that a run of failed acquisitions cannot wrap the counter
+        // back into the valid view range. AcquireNewViewId saturates it at limits.maxViews,
+        // so it is always safe to narrow back to a bgfx::ViewId.
+        std::atomic<uint32_t> m_nextViewId{0};
 
         // Incremented every time PerformMidFrameViewFlush resets m_nextViewId in the middle of a
         // logical frame. Anything that caches a view id across draw calls must also cache this

--- a/Core/Graphics/Source/DeviceImpl.h
+++ b/Core/Graphics/Source/DeviceImpl.h
@@ -94,6 +94,7 @@ namespace Babylon::Graphics
 
         bgfx::ViewId AcquireNewViewId();
         bgfx::ViewId PeekNextViewId() const;
+        uint32_t ViewIdGeneration() const;
 
         // Mid-frame view flush. If the current logical frame has acquired close to
         // the maximum number of bgfx views, flush the accumulated views via a
@@ -149,6 +150,12 @@ namespace Babylon::Graphics
         bgfx::Encoder* m_frameEncoder{nullptr};
 
         std::atomic<bgfx::ViewId> m_nextViewId{0};
+
+        // Incremented every time PerformMidFrameViewFlush resets m_nextViewId in the middle of a
+        // logical frame. Anything that caches a view id across draw calls must also cache this
+        // value and re-acquire when it no longer matches, otherwise the cached (high) id would
+        // sort after ids acquired from the reset counter and invert submission order.
+        std::atomic<uint32_t> m_viewIdGeneration{0};
 
         std::atomic<bool> m_captureNextFrame{false};
 

--- a/Core/Graphics/Source/DeviceImpl.h
+++ b/Core/Graphics/Source/DeviceImpl.h
@@ -160,6 +160,14 @@ namespace Babylon::Graphics
         // sort after ids acquired from the reset counter and invert submission order.
         std::atomic<uint32_t> m_viewIdGeneration{0};
 
+        // Number of mid-frame view flushes performed during the current logical frame; reset
+        // when the frame is actually presented. The flush lets a logical frame exceed bgfx's
+        // per-frame view budget, but each one is a blocking round-trip to the render thread,
+        // so an unbounded number of them turns pathological content into an apparent hang
+        // instead of an error. FlushViewsIfNeeded stops rescuing past kMaxMidFrameViewFlushes
+        // and lets AcquireNewViewId throw, which is the pre-existing behaviour.
+        std::atomic<uint32_t> m_midFrameFlushCount{0};
+
         std::atomic<bool> m_captureNextFrame{false};
 
         std::optional<arcana::cancellation_source> m_cancellationSource{};

--- a/Core/Graphics/Source/FrameBuffer.cpp
+++ b/Core/Graphics/Source/FrameBuffer.cpp
@@ -82,6 +82,7 @@ namespace Babylon::Graphics
     {
         // BGFX requires us to create a new viewID, this will ensure that the view gets cleared.
         m_viewId = m_deviceContext.AcquireNewViewId();
+        m_viewIdGeneration = m_deviceContext.ViewIdGeneration();
 
         bgfx::setViewMode(m_viewId.value(), bgfx::ViewMode::Sequential);
         bgfx::setViewClear(m_viewId.value(), flags, rgba, depth, stencil);
@@ -197,12 +198,14 @@ namespace Babylon::Graphics
 
     void FrameBuffer::SetBgfxViewPortAndScissor(const Rect& viewPort, const Rect& scissor)
     {
-        if (m_viewId.has_value() && viewPort.Equals(m_bgfxViewPort) && scissor.Equals(m_bgfxScissor))
+        if (m_viewId.has_value() && m_viewIdGeneration == m_deviceContext.ViewIdGeneration() &&
+            viewPort.Equals(m_bgfxViewPort) && scissor.Equals(m_bgfxScissor))
         {
             return;
         }
 
         m_viewId = m_deviceContext.AcquireNewViewId();
+        m_viewIdGeneration = m_deviceContext.ViewIdGeneration();
 
         bgfx::setViewMode(m_viewId.value(), bgfx::ViewMode::Sequential);
         bgfx::setViewClear(m_viewId.value(), BGFX_CLEAR_NONE, 0, 1.0f, 0);

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -2597,6 +2597,12 @@ namespace Babylon
 
     bgfx::Encoder* NativeEngine::GetEncoder()
     {
+        // Draw/clear/compute operations all fetch the encoder here before recording
+        // any state. This is a safe boundary to flush accumulated bgfx views (which
+        // may swap the active encoder) so a single Babylon frame that renders many
+        // passes (e.g. nested utility layers) never runs out of views.
+        m_deviceContext.FlushViewsIfNeeded();
+
         bgfx::Encoder* encoder = m_deviceContext.GetActiveEncoder();
         assert(encoder != nullptr);
         return encoder;

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -1409,6 +1409,8 @@ namespace Babylon
 
     void NativeEngine::CopyTexture(NativeDataStream::Reader& data)
     {
+        // Note: GetEncoder may perform a mid-frame view flush, which resets the view counter.
+        // Fetch it before reading the reservation below so the generation check sees that.
         bgfx::Encoder* encoder = GetEncoder();
 
         const auto textureSource = data.ReadPointer<Graphics::Texture>();
@@ -1421,8 +1423,16 @@ namespace Babylon
         // view id immediately after the canvas draws (before the scene render is recorded) and
         // hands it to the source texture; use it here. Non-canvas sources have no reserved id, so
         // fall back to PeekNextViewId() (a view greater than every view used so far). See #1683.
+        //
+        // A reservation is only usable while it is still ordered relative to views handed out
+        // now: if a mid-frame flush reset the counter since the reservation was made, the
+        // reserved (high) id would sort *after* the consumer's freshly acquired (low) id and
+        // reintroduce exactly the latency the reservation exists to prevent. In that case the
+        // flush has already submitted the canvas draws in a previous bgfx frame, so the source
+        // is complete and PeekNextViewId() — which precedes every view the consumer has yet to
+        // acquire — is both safe and correctly ordered.
         bgfx::ViewId blitView = textureSource->BlitViewId();
-        if (blitView == UINT16_MAX)
+        if (blitView == UINT16_MAX || textureSource->BlitViewIdGeneration() != m_deviceContext.ViewIdGeneration())
         {
             blitView = m_deviceContext.PeekNextViewId();
         }

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -217,7 +217,7 @@ namespace Babylon::Polyfills::Internal
         m_texture->Attach(bgfx::getTexture(m_frameBuffer->Handle()), false, m_width, m_height, false, 1, bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT);
         // Hand the blit view id reserved during the preceding Context::Flush to the texture so
         // NativeEngine::CopyTexture blits on a view ordered before the consuming layer.
-        m_texture->BlitViewId(m_blitViewId);
+        m_texture->BlitViewId(m_blitViewId, m_blitViewIdGeneration);
         return Napi::Pointer<Graphics::Texture>::Create(info.Env(), m_texture.get());
     }
 

--- a/Polyfills/Canvas/Source/Canvas.h
+++ b/Polyfills/Canvas/Source/Canvas.h
@@ -72,8 +72,13 @@ namespace Babylon::Polyfills::Internal
         FrameBufferPool m_frameBufferPool;
 
         // View id reserved by Context::Flush (right after this canvas' draws) for the
-        // canvas->texture blit issued from NativeEngine::CopyTexture. See Context::Flush.
-        void SetBlitViewId(bgfx::ViewId viewId) { m_blitViewId = viewId; }
+        // canvas->texture blit issued from NativeEngine::CopyTexture, plus the view-id
+        // generation it was reserved in so a mid-frame flush can invalidate it. See Context::Flush.
+        void SetBlitViewId(bgfx::ViewId viewId, uint32_t generation)
+        {
+            m_blitViewId = viewId;
+            m_blitViewIdGeneration = generation;
+        }
 
         Graphics::DeviceContext& GetGraphicsContext()
         {
@@ -104,6 +109,7 @@ namespace Babylon::Polyfills::Internal
         std::unique_ptr<Graphics::FrameBuffer> m_frameBuffer;
         std::unique_ptr<Graphics::Texture> m_texture{};
         bgfx::ViewId m_blitViewId{UINT16_MAX};
+        uint32_t m_blitViewIdGeneration{0};
         bool m_dirty{};
         bool m_clear{};
 

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -741,7 +741,7 @@ namespace Babylon::Polyfills::Internal
             // layer samples the destination texture. Deferring to CopyTexture's
             // PeekNextViewId() would place the blit after the backbuffer view, so the layer
             // would sample the previous frame's content (a one-frame GUI latency).
-            m_canvas->SetBlitViewId(m_graphicsContext.AcquireNewViewId());
+            m_canvas->SetBlitViewId(m_graphicsContext.AcquireNewViewId(), m_graphicsContext.ViewIdGeneration());
 
             for (auto& buffer : m_canvas->m_frameBufferPool.GetPoolBuffers())
             {

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -681,6 +681,25 @@ namespace Babylon::Polyfills::Internal
             scope.emplace(m_graphicsContext.AcquireFrameCompletionScope());
         }
 
+        // A canvas flush is the one stretch of a frame that acquires views without ever
+        // reaching NativeEngine::GetEncoder, so no budget check runs inside it. Its cost is
+        // not bounded either: the pool recycles framebuffers but not view ids (Acquire ->
+        // Bind() drops the cached id, the draw re-acquires, Release -> Clear() acquires
+        // again), so it scales with filter-op count. That means kViewFlushMargin cannot be
+        // sized to cover it, and a frame that is just under the flush threshold on entry
+        // here would run past maxViews and throw "Too many views".
+        //
+        // Check once, here. This is the only safe point in the flush:
+        //   - after the scope above, so m_pendingFrameScopes > 0 and the flush handshake is
+        //     actually serviceable by the parked render thread (it no-ops otherwise);
+        //   - before the encoder is read below, so a flush that swaps the frame encoder
+        //     cannot leave us holding a stale pointer;
+        //   - before nvgBeginFrame, so no nanovg transient buffer exists to be invalidated
+        //     (those are allocated in glnvg__renderFlush during nvgEndFrame).
+        // This does not bound a single canvas' cost, but it reduces the requirement from
+        // "the margin must cover an arbitrary canvas" to "one canvas must fit in maxViews".
+        m_graphicsContext.FlushViewsIfNeeded();
+
         bgfx::Encoder* encoder = m_graphicsContext.GetActiveEncoder();
         if (encoder == nullptr)
         {

--- a/Polyfills/Canvas/Source/nanovg/nanovg_babylon.cpp
+++ b/Polyfills/Canvas/Source/nanovg/nanovg_babylon.cpp
@@ -1031,44 +1031,57 @@ namespace
 
         if (gl->ncalls > 0)
         {
-            bgfx::allocTransientVertexBuffer(&gl->tvb, gl->nverts, s_nvgLayout);
+            // bgfx asserts inside allocTransientVertexBuffer when the request exceeds what
+            // remains of this frame's transient buffer, so the request must be checked
+            // *before* the call - inspecting gl->tvb afterwards (as this code used to) is
+            // unreachable in an assert-enabled build. A canvas painted with a very large
+            // number of ops, or several canvases sharing one frame, can legitimately exceed
+            // the budget.
+            //
+            // The draw calls below index the buffer using offsets recorded while the geometry
+            // was built, so a partial allocation cannot be rendered: every draw past the
+            // truncation point would read outside the buffer. That is not merely wrong
+            // visually - it makes the D3D11 debug layer emit an oversized diagnostic per draw
+            // call, which is slow enough to stall a validation run for the better part of an
+            // hour. Drop the whole flush instead, so the frame is simply missing this canvas
+            // content rather than issuing out-of-bounds draws or aborting the process.
+            const uint32_t availVerts = bgfx::getAvailTransientVertexBuffer(uint32_t(gl->nverts), s_nvgLayout);
+            const bool vertsFit = availVerts >= uint32_t(gl->nverts);
+            BX_WARN(vertsFit, "Canvas draw skipped: transient vertex buffer exhausted (%d requested, %u available)", gl->nverts, availVerts);
 
-            int allocated = gl->tvb.size/gl->tvb.stride;
-
-            if (allocated < gl->nverts)
+            if (vertsFit && gl->nverts > 0)
             {
-                gl->nverts = allocated;
-                BX_WARN(true, "Vertex number truncated due to transient vertex buffer overflow");
-            }
+                bgfx::allocTransientVertexBuffer(&gl->tvb, uint32_t(gl->nverts), s_nvgLayout);
 
-            bx::memCopy(gl->tvb.data, gl->verts, gl->nverts * sizeof(struct NVGvertex) );
+                bx::memCopy(gl->tvb.data, gl->verts, gl->nverts * sizeof(struct NVGvertex) );
 
-            for (uint32_t ii = 0, num = gl->ncalls; ii < num; ++ii)
-            {
-                struct GLNVGcall* call = &gl->calls[ii];
-
-                const GLNVGblend* blend = &call->blendFunc;
-                gl->state = BGFX_STATE_BLEND_FUNC_SEPARATE(blend->srcRGB, blend->dstRGB, blend->srcAlpha, blend->dstAlpha)
-                    | BGFX_STATE_WRITE_RGB
-                    | BGFX_STATE_WRITE_A
-                    ;
-                switch (call->type)
+                for (uint32_t ii = 0, num = gl->ncalls; ii < num; ++ii)
                 {
-                case GLNVG_FILL:
-                    glnvg__fill(gl, call);
-                    break;
+                    struct GLNVGcall* call = &gl->calls[ii];
 
-                case GLNVG_CONVEXFILL:
-                    glnvg__convexFill(gl, call);
-                    break;
+                    const GLNVGblend* blend = &call->blendFunc;
+                    gl->state = BGFX_STATE_BLEND_FUNC_SEPARATE(blend->srcRGB, blend->dstRGB, blend->srcAlpha, blend->dstAlpha)
+                        | BGFX_STATE_WRITE_RGB
+                        | BGFX_STATE_WRITE_A
+                        ;
+                    switch (call->type)
+                    {
+                    case GLNVG_FILL:
+                        glnvg__fill(gl, call);
+                        break;
 
-                case GLNVG_STROKE:
-                    glnvg__stroke(gl, call);
-                    break;
+                    case GLNVG_CONVEXFILL:
+                        glnvg__convexFill(gl, call);
+                        break;
 
-                case GLNVG_TRIANGLES:
-                    glnvg__triangles(gl, call);
-                    break;
+                    case GLNVG_STROKE:
+                        glnvg__stroke(gl, call);
+                        break;
+
+                    case GLNVG_TRIANGLES:
+                        glnvg__triangles(gl, call);
+                        break;
+                    }
                 }
             }
         }

--- a/Polyfills/Canvas/Source/nanovg/nanovg_babylon.cpp
+++ b/Polyfills/Canvas/Source/nanovg/nanovg_babylon.cpp
@@ -259,6 +259,14 @@ namespace
         PoolInterface frameBufferPool;
         bgfx::Encoder* encoder;
 
+        // When true, the next non-filtered draw call must acquire a fresh (higher)
+        // bgfx view on the canvas framebuffer so it is ordered after any pool-buffer
+        // views used by a preceding filtered draw. Consecutive non-filtered draws
+        // otherwise share a single view to avoid exhausting the bgfx view budget
+        // (a canvas painted with thousands of ops would otherwise leak thousands of
+        // views within a single device frame -> "Too many views").
+        bool canvasViewNeedsRefresh;
+
         struct GLNVGtexture* textures;
         float view[2];
         int ntextures;
@@ -702,6 +710,27 @@ namespace
         encoder->setIndexBuffer(&tib);
     }
 
+    // Gates acquisition of a fresh bgfx view for a canvas draw call. A filtered draw
+    // (blur/etc.) uses intermediate pool framebuffers on higher-id views, so the next
+    // canvas draw must be re-bound to a fresh (higher) view to preserve draw order.
+    // Consecutive non-filtered draws instead share the canvas framebuffer's current
+    // view, preventing view-budget exhaustion ("Too many views") when a DynamicTexture
+    // is painted with thousands of ops in a single device frame.
+    static Babylon::Graphics::FrameBuffer* glnvg__beginFinalFrameBuffer(struct GLNVGcontext* gl, struct GLNVGcall* call)
+    {
+        Babylon::Graphics::FrameBuffer* finalFrameBuffer = gl->frameBuffer;
+        if (call->filterStack.HasFilters() || gl->canvasViewNeedsRefresh)
+        {
+            finalFrameBuffer->Bind();
+        }
+        return finalFrameBuffer;
+    }
+
+    static void glnvg__endFinalFrameBuffer(struct GLNVGcontext* gl, struct GLNVGcall* call)
+    {
+        gl->canvasViewNeedsRefresh = call->filterStack.HasFilters();
+    }
+
     static void glnvg__fill(struct GLNVGcontext* gl, struct GLNVGcall* call)
     {
         bgfx::ProgramHandle firstProg = gl->prog;
@@ -797,10 +826,9 @@ namespace
             screenSpaceQuad(gl->encoder, s_originBottomLeft);
             outBuffer->Submit(*gl->encoder, prog, BGFX_DISCARD_ALL);
         };
-        Babylon::Graphics::FrameBuffer *finalFrameBuffer = gl->frameBuffer;
-        finalFrameBuffer->Bind(); // Should this be bound elsewhere?
-
+        Babylon::Graphics::FrameBuffer *finalFrameBuffer = glnvg__beginFinalFrameBuffer(gl, call);
         call->filterStack.Render(firstProg, setUniform, firstPass, filterPass, finalPass, finalFrameBuffer, gl->frameBufferPool.acquire, gl->frameBufferPool.release);
+        glnvg__endFinalFrameBuffer(gl, call);
     }
 
     static void glnvg__convexFill(struct GLNVGcontext* gl, struct GLNVGcall* call)
@@ -857,10 +885,9 @@ namespace
             screenSpaceQuad(gl->encoder, s_originBottomLeft);
             outBuffer->Submit(*gl->encoder, prog, BGFX_DISCARD_ALL);
         };
-        Babylon::Graphics::FrameBuffer *finalFrameBuffer = gl->frameBuffer;
-        finalFrameBuffer->Bind(); // Should this be bound elsewhere?
-
+        Babylon::Graphics::FrameBuffer *finalFrameBuffer = glnvg__beginFinalFrameBuffer(gl, call);
         call->filterStack.Render(firstProg, setUniform, firstPass, filterPass, finalPass, finalFrameBuffer, gl->frameBufferPool.acquire, gl->frameBufferPool.release);
+        glnvg__endFinalFrameBuffer(gl, call);
     }
 
     static void glnvg__stroke(struct GLNVGcontext* gl, struct GLNVGcall* call)
@@ -900,10 +927,9 @@ namespace
             screenSpaceQuad(gl->encoder, s_originBottomLeft);
             outBuffer->Submit(*gl->encoder, prog, BGFX_DISCARD_ALL);
         };
-        Babylon::Graphics::FrameBuffer *finalFrameBuffer = gl->frameBuffer;
-        finalFrameBuffer->Bind(); // Should this be bound elsewhere?
-
+        Babylon::Graphics::FrameBuffer *finalFrameBuffer = glnvg__beginFinalFrameBuffer(gl, call);
         call->filterStack.Render(firstProg, setUniform, firstPass, filterPass, finalPass, finalFrameBuffer, gl->frameBufferPool.acquire, gl->frameBufferPool.release);
+        glnvg__endFinalFrameBuffer(gl, call);
     }
 
     static void glnvg__triangles(struct GLNVGcontext* gl, struct GLNVGcall* call)
@@ -938,10 +964,9 @@ namespace
                 screenSpaceQuad(gl->encoder, s_originBottomLeft);
                 outBuffer->Submit(*gl->encoder, prog, BGFX_DISCARD_ALL);
 			};
-            Babylon::Graphics::FrameBuffer *finalFrameBuffer = gl->frameBuffer;
-            finalFrameBuffer->Bind(); // Should this be bound elsewhere?
-
+            Babylon::Graphics::FrameBuffer *finalFrameBuffer = glnvg__beginFinalFrameBuffer(gl, call);
             call->filterStack.Render(firstProg, setUniform, firstPass, filterPass, finalPass, finalFrameBuffer, gl->frameBufferPool.acquire, gl->frameBufferPool.release);
+            glnvg__endFinalFrameBuffer(gl, call);
         }
     }
 
@@ -988,6 +1013,9 @@ namespace
     {
         struct GLNVGcontext* gl = (struct GLNVGcontext*)_userPtr;
         //gl->frameBuffer->SetViewPort(gl->encoder, 0.f, 0.f, gl->view[0], gl->view[1]);
+        // The canvas framebuffer is bound with a fresh view by Context::Flush before this
+        // flush runs, so the first draw call can reuse that view without re-binding.
+        gl->canvasViewNeedsRefresh = false;
         if (!gl->prog.idx)
         {
             bgfx::RendererType::Enum type = bgfx::getRendererType();

--- a/Polyfills/Canvas/Source/nanovg/nanovg_filterstack.h
+++ b/Polyfills/Canvas/Source/nanovg/nanovg_filterstack.h
@@ -37,6 +37,11 @@ public:
     );
     void Render(std::function<void()> element);
 
+    // Returns true if this stack has any filter elements (blur/sepia/etc.) that
+    // require intermediate pool framebuffers. When false, draws render straight
+    // into the final (canvas) framebuffer and can share a single bgfx view.
+    bool HasFilters() const { return stackElementCount > 0; }
+
     void ParseString(const std::string& string);
     static bool ValidString(const std::string& string);
 


### PR DESCRIPTION
Second half of the Canvas/bgfx work whose first half landed as #1800. Independent of it; this one is about **bgfx view exhaustion**, not pixel readback.

## The problem

`nanovg_babylon` acquired a fresh bgfx view for every draw call. bgfx caps view ids, so a scene with enough canvas draws runs out and dies with `Error: Too many views`.

## The changes

**1. Share a view across non-filtered draws.** Only filtered draws need a private view (the filter stack renders into it). Non-filtered draws now acquire lazily and reuse one.

**2. Add a mid-frame view flush.** Sharing raises the ceiling but does not remove it, so views can now be recycled mid-frame.

## The deadlock this could have introduced

The flush handshake parks the requesting JS thread and relies on the render thread being parked in `FinishRenderingCurrentFrame` to service it. That only holds while a `FrameCompletionScope` is active — the normal `requestAnimationFrame` path.

Snippets that drive frames manually (`setInterval` + `engine.beginFrame`/`scene.render`/`engine.endFrame`) acquire no scope, so the handshake would never be serviced and the snippet would hang. `FlushViewsIfNeeded` skips the flush when `m_pendingFrameScopes == 0`; the `AcquireNewViewId` cap remains the backstop, so those snippets behave exactly as they do today.

The guard is folded into commit 2 rather than added as a follow-up, so no commit in this branch's history contains the deadlocking version.

## Evidence

Re-enables **"Vertex Pulling - Normals UVs Colors Tangents"** (idx 665), excluded as *"Test crashes or hangs on Babylon Native"*. This is the only `config.json` change in the PR — a single hunk dropping that one test's `excludeFromAutomaticTesting`/`reason` pair.

**Negative control**, both at base `03c4d965`, Win32 D3D11 RelWithDebInfo:

| build | idx 665 |
|---|---|
| without this branch | `Error: Too many views`, exit -1 |
| with this branch | passes, 5394/240000 px (**2.248%**, allowed 2.5%) |

The pixel count is bit-identical across three consecutive runs.

Full validation suite: **301/301, 0 failures.**

> **Note for reviewers:** that hunk was in the branch until a rebase on 2026-07-30 silently dropped it, so for several pushes this section described a control that was not in the diff. Caught in review by @bghgary; restored in 8fd08711 and re-verified from scratch. The 2.248% / 2.5% margin is thin — deterministic here, but it is the one test in this PR that could plausibly need an `errorRatio` bump on other hardware.

## On the other five un-exclusions

The shotgun branch this comes from also un-excluded idx 185, 253, 653, 654 and 659. **I tested each individually and they are not earned by this PR**, so they are not included:

| test | result on this branch alone |
|---|---|
| 185 Particle Helper | fails, 12.117% (deterministic over 3 runs) |
| 253 MultiSample render targets | fails, `Error: Failed to create frame buffer` — needs the MRT work |
| 653 Particles - Billboard False | fails, 12.302% |
| 654 Particles - Multiply Blend | fails |
| 659 Particles - Helper - Fire | fails |

They passed on the shotgun branch only because other changes were present alongside. They will come back with the PR that actually earns them.

Worth noting for anyone reading suite output: **the runner aborts on the first failure**, so an un-exclusion early in the config can silently mask everything after it. Un-excluding all six produced a green-looking `ran=127 passed=126 failed=1` that had simply stopped at idx 185 and never reached the other five.

---

## Update: mid-frame flush invalidates cached view ids (d2988010)

Review raised that `PerformMidFrameViewFlush` resets `m_nextViewId` while a logical frame is in flight, which strands view ids cached across draw calls. That was correct, and broader than the canvas blit alone — `FrameBuffer::m_viewId` is retained by `SetBgfxViewPortAndScissor` and only cleared by `Bind()` at frame start.

Added a view-id generation counter bumped on each flush. `FrameBuffer` re-acquires on mismatch; `CopyTexture` falls back to `PeekNextViewId()` (safe, because a flush has already submitted the canvas draws in a prior bgfx frame).

### Where the flush actually fires

It does **not** fire anywhere in the enabled suite (256 views, margin 16 — instrumented count 0). It **does** fire under `--include-excluded` on idx 170 "Nested BBG", which is the case the mechanism exists for: on master that content runs the view counter to exhaustion and throws `Too many views`, while on this branch the counter is held below the cap and the flush fires repeatedly instead.

Because the enabled suite never reaches it, the generation fix was verified by temporarily forcing a flush every 8 views:

| build | result |
|---|---|
| with the fix | 417 flushes, 318 stale ids re-acquired, **301/301 pass** |
| generation check neutralized | **`Native Canvas` fails at 21.9% pixel divergence** |

### Known limitation on idx 170

Flagged by @bghgary and confirmed here at this head: on master, idx 170 fails in ~18s with `Too many views`; on this branch it no longer throws, but it also does not finish.

This is not flush thrash. Instrumented over 90s: **~7,600 presents (~84 fps), 5 mid-frame flushes total**, peak 5 in any single frame. The app renders at full speed. The snippet (`#ZG0C8B#12`) drives a `setInterval` whose only exit is `gizmo.gizmoLayer.utilityLayerScene.executeWhenReady(...)`, and on Babylon Native that readiness callback never fires — silently, with no output on stdout or stderr. Master's throw was tearing that loop down; removing the throw exposes the underlying hang.

So this PR converts a fast failure into a slow one **for one already-excluded test**. Its exclusion predates this PR and the root cause is a separate pre-existing bug in utility-layer scene readiness, which I will file separately. Practical consequence, per @bghgary: enabling idx 170 would cost a CI timeout where master costs a ~17s failure, so it should stay excluded until that bug is fixed.

`kMaxMidFrameViewFlushes = 64` (commit 9f6f95fe) bounds the rescue per logical frame, since the review exposed that it was otherwise unbounded. To be explicit: **it does not fix idx 170** — the counter resets on every presented frame and this content presents constantly, so the budget never binds. Measured peak is 5, so it is inert for all known content.
