### PR TITLE
Size bgfx render-item arrays dynamically instead of reserving the maximum

### DIFF
--- a/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
+++ b/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
@@ -56,14 +56,6 @@ namespace Babylon::Graphics
         // Format to use when creating the depth/stencil texture for the back buffer.
         // Specify DepthStencilFormat::None to not create a depth/stencil texture.
         DepthStencilFormat BackBufferDepthStencilFormat{DepthStencilFormat::Depth24Stencil8};
-
-        // Number of draw call slots bgfx reserves per frame up front. bgfx grows this
-        // on demand up to BGFX_CONFIG_MAX_DRAW_CALLS, so this is a starting point, not
-        // a cap. The frame that first exceeds it drops the draws past it, so lower it
-        // only when the scene's draw call ceiling is known. bgfx rounds the value up to
-        // a multiple of BGFX_CONFIG_DRAW_CALL_BLOCK (1024 by default), which is also
-        // the smallest capacity it will ever use.
-        uint32_t InitialDrawCallCapacity{4096};
     };
 
     class DeviceImpl;

--- a/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
+++ b/Core/Graphics/Include/Shared/Babylon/Graphics/Device.h
@@ -56,6 +56,14 @@ namespace Babylon::Graphics
         // Format to use when creating the depth/stencil texture for the back buffer.
         // Specify DepthStencilFormat::None to not create a depth/stencil texture.
         DepthStencilFormat BackBufferDepthStencilFormat{DepthStencilFormat::Depth24Stencil8};
+
+        // Number of draw call slots bgfx reserves per frame up front. bgfx grows this
+        // on demand up to BGFX_CONFIG_MAX_DRAW_CALLS, so this is a starting point, not
+        // a cap. The frame that first exceeds it drops the draws past it, so lower it
+        // only when the scene's draw call ceiling is known. bgfx rounds the value up to
+        // a multiple of BGFX_CONFIG_DRAW_CALL_BLOCK (1024 by default), which is also
+        // the smallest capacity it will ever use.
+        uint32_t InitialDrawCallCapacity{4096};
     };
 
     class DeviceImpl;

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -46,18 +46,24 @@ namespace Babylon::Graphics
         // object. That is tens of megabytes reserved regardless of how much a
         // consumer actually draws.
         //
-        // Ask for the smallest bgfx allows instead and let it grow the arrays on
-        // demand, up to the same BGFX_CONFIG_MAX_DRAW_CALLS ceiling, so the headroom
-        // is still there for scenes that need it but is not paid for when it is
-        // unused. bgfx::init clamps numDrawCalls up to BGFX_CONFIG_DRAW_CALL_BLOCK,
-        // so 0 here means one block, not nothing. Growth and shrink are both in
-        // block-sized steps, and the arrays are never shrunk below one block.
+        // Ask for a much smaller starting capacity instead and let bgfx grow the
+        // arrays on demand, up to the same BGFX_CONFIG_MAX_DRAW_CALLS ceiling, so the
+        // headroom is still there for scenes that need it but is not paid for when it
+        // is unused. Growth and shrink are both in BGFX_CONFIG_DRAW_CALL_BLOCK steps,
+        // and the arrays are never shrunk below one block.
+        //
+        // Growth is reactive: the frame that first exceeds the current capacity drops
+        // the draws past it and only the next frame sees the larger arrays. 4096 is
+        // high enough that no realistic Babylon Native scene starts above it, so the
+        // growth path is effectively a safety net rather than something a scene hits
+        // on its way up. An embedder that knows its own ceiling can go lower by
+        // overriding BGFX_CONFIG_DRAW_CALL_BLOCK and InitialDrawCallCapacity.
         //
         // numDrawCallPeakFrames is how many frames a high-water mark must go
         // unmatched before the arrays are shrunk again. It must be non-zero, or
         // bgfx skips the resizing entirely and the arrays stay fixed at whatever
         // numDrawCalls asked for.
-        init.limits.numDrawCalls = 0;
+        init.limits.numDrawCalls = config.InitialDrawCallCapacity;
         init.limits.numDrawCallPeakFrames = 60;
 
         // Use the noop renderer if the configuration has no window and no size.

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -40,30 +40,17 @@ namespace Babylon::Graphics
         auto& init = m_state.Bgfx.InitState;
         init.callback = &m_bgfxCallback;
 
-        // bgfx sizes its per-frame render-item arrays (sort keys, RenderItem,
-        // RenderBind) from limits.numDrawCalls, and by default that is
-        // BGFX_CONFIG_MAX_DRAW_CALLS (65535) allocated up front, for every Frame
-        // object. That is tens of megabytes reserved regardless of how much a
-        // consumer actually draws.
+        // bgfx reserves limits.numDrawCalls render-item slots (sort keys, RenderItem,
+        // RenderBind) up front for every Frame, and defaults to
+        // BGFX_CONFIG_MAX_DRAW_CALLS (65535) -- tens of megabytes.
         //
-        // Ask for the smallest capacity bgfx allows instead and let it grow the arrays
-        // on demand, up to the same BGFX_CONFIG_MAX_DRAW_CALLS ceiling, so the headroom
-        // is still there for scenes that need it but is not paid for when it is unused.
-        // bgfx clamps numDrawCalls up to BGFX_CONFIG_DRAW_CALL_BLOCK, so 0 asks for one
-        // block, not for nothing. Growth and shrink are both in block-sized steps, and
-        // the arrays are never shrunk below one block, which makes the block the single
-        // knob for how much a consumer reserves. Babylon Native sets it to 4096 in
-        // Dependencies/CMakeLists.txt.
+        // 0 asks for a single BGFX_CONFIG_DRAW_CALL_BLOCK instead (4096, set in
+        // Dependencies/CMakeLists.txt), and bgfx resizes in block steps up to that same
+        // ceiling. Growth is reactive -- the frame that overflows drops the draws past
+        // capacity -- so the block should sit above the expected peak.
         //
-        // Growth is reactive: the frame that first exceeds the current capacity drops
-        // the draws past it and only the next frame sees the larger arrays. That is why
-        // the block is not left at bgfx's default of 1024 -- a consumer should reserve
-        // above its own ceiling and treat growth as a safety net.
-        //
-        // numDrawCallPeakFrames is how many frames a high-water mark must go
-        // unmatched before the arrays are shrunk again. It must be non-zero, or
-        // bgfx skips the resizing entirely and the arrays stay fixed at whatever
-        // numDrawCalls asked for.
+        // numDrawCallPeakFrames is the shrink delay in frames, ~1s at 60fps. Resizing
+        // is disabled entirely at 0.
         init.limits.numDrawCalls = 0;
         init.limits.numDrawCallPeakFrames = 60;
 

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -40,6 +40,25 @@ namespace Babylon::Graphics
         auto& init = m_state.Bgfx.InitState;
         init.callback = &m_bgfxCallback;
 
+        // bgfx sizes its per-frame render-item arrays (sort keys, RenderItem,
+        // RenderBind) from limits.numDrawCalls, and by default that is
+        // BGFX_CONFIG_MAX_DRAW_CALLS (65535) allocated up front, for every Frame
+        // object. That is tens of megabytes reserved regardless of how much a
+        // consumer actually draws.
+        //
+        // Start empty instead and let bgfx grow the arrays on demand, up to the
+        // same BGFX_CONFIG_MAX_DRAW_CALLS ceiling, so the headroom is still there
+        // for scenes that need it but is not paid for when it is unused. Growth is
+        // in BGFX_CONFIG_DRAW_CALL_BLOCK-sized steps, and once grown the arrays are
+        // never shrunk below one such block.
+        //
+        // numDrawCallPeakFrames is how many frames a high-water mark must go
+        // unmatched before the arrays are shrunk again. It must be non-zero, or
+        // bgfx skips the resizing entirely and the arrays stay fixed at whatever
+        // numDrawCalls asked for.
+        init.limits.numDrawCalls = 0;
+        init.limits.numDrawCallPeakFrames = 60;
+
         // Use the noop renderer if the configuration has no window and no size.
         if (config.Window == WindowT{} && config.Width == 0 && config.Height == 0)
         {

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -46,24 +46,25 @@ namespace Babylon::Graphics
         // object. That is tens of megabytes reserved regardless of how much a
         // consumer actually draws.
         //
-        // Ask for a much smaller starting capacity instead and let bgfx grow the
-        // arrays on demand, up to the same BGFX_CONFIG_MAX_DRAW_CALLS ceiling, so the
-        // headroom is still there for scenes that need it but is not paid for when it
-        // is unused. Growth and shrink are both in BGFX_CONFIG_DRAW_CALL_BLOCK steps,
-        // and the arrays are never shrunk below one block.
+        // Ask for the smallest capacity bgfx allows instead and let it grow the arrays
+        // on demand, up to the same BGFX_CONFIG_MAX_DRAW_CALLS ceiling, so the headroom
+        // is still there for scenes that need it but is not paid for when it is unused.
+        // bgfx clamps numDrawCalls up to BGFX_CONFIG_DRAW_CALL_BLOCK, so 0 asks for one
+        // block, not for nothing. Growth and shrink are both in block-sized steps, and
+        // the arrays are never shrunk below one block, which makes the block the single
+        // knob for how much a consumer reserves. Babylon Native sets it to 4096 in
+        // Dependencies/CMakeLists.txt.
         //
         // Growth is reactive: the frame that first exceeds the current capacity drops
-        // the draws past it and only the next frame sees the larger arrays. 4096 is
-        // high enough that no realistic Babylon Native scene starts above it, so the
-        // growth path is effectively a safety net rather than something a scene hits
-        // on its way up. An embedder that knows its own ceiling can go lower by
-        // overriding BGFX_CONFIG_DRAW_CALL_BLOCK and InitialDrawCallCapacity.
+        // the draws past it and only the next frame sees the larger arrays. That is why
+        // the block is not left at bgfx's default of 1024 -- a consumer should reserve
+        // above its own ceiling and treat growth as a safety net.
         //
         // numDrawCallPeakFrames is how many frames a high-water mark must go
         // unmatched before the arrays are shrunk again. It must be non-zero, or
         // bgfx skips the resizing entirely and the arrays stay fixed at whatever
         // numDrawCalls asked for.
-        init.limits.numDrawCalls = config.InitialDrawCallCapacity;
+        init.limits.numDrawCalls = 0;
         init.limits.numDrawCallPeakFrames = 60;
 
         // Use the noop renderer if the configuration has no window and no size.

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -46,11 +46,12 @@ namespace Babylon::Graphics
         // object. That is tens of megabytes reserved regardless of how much a
         // consumer actually draws.
         //
-        // Start empty instead and let bgfx grow the arrays on demand, up to the
-        // same BGFX_CONFIG_MAX_DRAW_CALLS ceiling, so the headroom is still there
-        // for scenes that need it but is not paid for when it is unused. Growth is
-        // in BGFX_CONFIG_DRAW_CALL_BLOCK-sized steps, and once grown the arrays are
-        // never shrunk below one such block.
+        // Ask for the smallest bgfx allows instead and let it grow the arrays on
+        // demand, up to the same BGFX_CONFIG_MAX_DRAW_CALLS ceiling, so the headroom
+        // is still there for scenes that need it but is not paid for when it is
+        // unused. bgfx::init clamps numDrawCalls up to BGFX_CONFIG_DRAW_CALL_BLOCK,
+        // so 0 here means one block, not nothing. Growth and shrink are both in
+        // block-sized steps, and the arrays are never shrunk below one block.
         //
         // numDrawCallPeakFrames is how many frames a high-water mark must go
         // unmatched before the arrays are shrunk again. It must be non-zero, or

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -46,6 +46,7 @@ FetchContent_MakeAvailable_With_Message(bgfx.cmake)
 target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_DEBUG_ANNOTATION=0)
 
 target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_DEFAULT_MAX_ENCODERS=2)
+target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_DRAW_CALL_BLOCK=4096)
 target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_MAX_VERTEX_STREAMS=18)
 target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_MIN_RESOURCE_COMMAND_BUFFER_SIZE=16)
 target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_MIN_UNIFORM_BUFFER_SIZE=4096)


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

## Context

bgfx sizes its per-frame render-item arrays (sort keys, `RenderItem`, `RenderBind`) from `Init::Limits::numDrawCalls`, which defaults to `BGFX_CONFIG_MAX_DRAW_CALLS` (65535) and is allocated up front for every `Frame`. A consumer drawing a handful of quads still reserves tens of megabytes.

bgfx can grow and shrink those arrays on demand, but it is opt-in — the defaults are `numDrawCalls = BGFX_CONFIG_MAX_DRAW_CALLS` and `numDrawCallPeakFrames = 0` (disabled) — so picking up the newer bgfx alone changes nothing. This PR starts at 4096 slots and lets bgfx grow them.

## Worth a look

- `numDrawCallPeakFrames` must be non-zero: at `0`, `adjustCapacity()` returns immediately and the arrays stay fixed.
- Growth is reactive — the frame that first exceeds capacity discards the draws past it, and only the next frame sees the larger arrays. 4096 sits above where any realistic scene starts, so the growth path is a safety net rather than something a scene walks through on its way up.
- Lowering `BGFX_CONFIG_MAX_DRAW_CALLS` instead would shrink the allocation but lower the ceiling with it, and submissions past the limit are dropped rather than queued (`m_maxDrawCalls <= renderItemIdx` discards the draw and counts it in `m_numDropped`). Geometry disappears with nothing raised to say so.

## Measurements

At Babylon Native's configuration the slot is 522 bytes, so the 65536 reserved slots cost **65 MB** across the submit and render `Frame`. 4096 slots cost 4 MB, saving about **61 MB**.

UnitTests pass (17/17).
