### PR TITLE
Fix shape conversion for uniforms used as return expressions

### DIFF
--- a/Apps/UnitTests/Source/Tests.ShaderCompilation.cpp
+++ b/Apps/UnitTests/Source/Tests.ShaderCompilation.cpp
@@ -123,3 +123,57 @@ TEST(ShaderCompilation, ExistingVec4UniformArrayIsNotReshaped)
 
     device.FinishRenderingCurrentFrame();
 }
+
+TEST(ShaderCompilation, ReturnedUniformIsShapeConverted)
+{
+    Babylon::Graphics::Device device{g_deviceConfig};
+
+    device.StartRenderingCurrentFrame();
+
+    Babylon::AppRuntime::Options options{};
+    options.UnhandledExceptionHandler = [](const Napi::Error& error) {
+        std::cerr << "[Uncaught Error] " << Napi::GetErrorString(error) << std::endl;
+        std::quick_exit(1);
+    };
+
+    Babylon::AppRuntime runtime{options};
+    runtime.Dispatch([&device](Napi::Env env) {
+        device.AddToJavaScript(env);
+
+        Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
+            std::cout << message << std::endl;
+        });
+        Babylon::Polyfills::Window::Initialize(env);
+        Babylon::Plugins::NativeEngine::Initialize(env);
+    });
+
+    Babylon::ScriptLoader loader{runtime};
+    loader.LoadScript("app:///Assets/babylon.max.js");
+    loader.Eval(R"(
+        const engine = new BABYLON.NativeEngine();
+        engine.getCaps().parallelShaderCompile = null;
+        const effect = engine.createEffect({
+            vertexSource: `
+                attribute vec2 position;
+                void main() { gl_Position = vec4(position, 0.0, 1.0); }
+            `,
+            fragmentSource: `
+                precision highp float;
+                uniform vec3 tint;
+                vec3 readTint() { return tint; }
+                void main() { gl_FragColor = vec4(readTint(), 1.0); }
+            `
+        }, ["position"], ["tint"], []);
+        if (!effect.isReady()) { throw new Error("Vec3 return effect should compile synchronously"); }
+        effect.dispose();
+        engine.dispose();
+    )", "returned_uniform_shape_conversion_test.js");
+
+    std::promise<void> done{};
+    loader.Dispatch([&done](Napi::Env) {
+        done.set_value();
+    });
+    done.get_future().get();
+
+    device.FinishRenderingCurrentFrame();
+}

--- a/Apps/UnitTests/Source/Tests.ShaderCompilation.cpp
+++ b/Apps/UnitTests/Source/Tests.ShaderCompilation.cpp
@@ -69,3 +69,57 @@ TEST(ShaderCompilation, CompileComprehensiveGLSL)
 
     device.FinishRenderingCurrentFrame();
 }
+
+TEST(ShaderCompilation, ExistingVec4UniformArrayIsNotReshaped)
+{
+    Babylon::Graphics::Device device{g_deviceConfig};
+
+    device.StartRenderingCurrentFrame();
+
+    Babylon::AppRuntime::Options options{};
+    options.UnhandledExceptionHandler = [](const Napi::Error& error) {
+        std::cerr << "[Uncaught Error] " << Napi::GetErrorString(error) << std::endl;
+        std::quick_exit(1);
+    };
+
+    Babylon::AppRuntime runtime{options};
+    runtime.Dispatch([&device](Napi::Env env) {
+        device.AddToJavaScript(env);
+
+        Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
+            std::cout << message << std::endl;
+        });
+        Babylon::Polyfills::Window::Initialize(env);
+        Babylon::Plugins::NativeEngine::Initialize(env);
+    });
+
+    Babylon::ScriptLoader loader{runtime};
+    loader.LoadScript("app:///Assets/babylon.max.js");
+    loader.Eval(R"(
+        const engine = new BABYLON.NativeEngine();
+        engine.getCaps().parallelShaderCompile = null;
+        const effect = engine.createEffect({
+            vertexSource: `
+                attribute vec2 position;
+                void main() { gl_Position = vec4(position, 0.0, 1.0); }
+            `,
+            fragmentSource: `
+                precision highp float;
+                uniform vec4 values[2];
+                vec4 readValue() { return values[0]; }
+                void main() { gl_FragColor = readValue(); }
+            `
+        }, ["position"], ["values"], []);
+        if (!effect.isReady()) { throw new Error("Vec4 uniform array effect should compile synchronously"); }
+        effect.dispose();
+        engine.dispose();
+    )", "existing_vec4_uniform_array_test.js");
+
+    std::promise<void> done{};
+    loader.Dispatch([&done](Napi::Env) {
+        done.set_value();
+    });
+    done.get_future().get();
+
+    device.FinishRenderingCurrentFrame();
+}

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
@@ -319,6 +319,7 @@ namespace Babylon::ShaderCompilerTraversers
                 const auto basic = type.getBasicType();
                 if (type.getQualifier().isUniformOrBuffer()
                     && !type.isMatrix()
+                    && type.getVectorSize() < 4
                     && (basic == EbtFloat || basic == EbtInt || basic == EbtUint || basic == EbtBool))
                 {
                     // At present, this may end up creating layered swizzles; i.e., if a vec3 was already being projected

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
@@ -315,7 +315,9 @@ namespace Babylon::ShaderCompilerTraversers
                 // We only care about loose scalar/vector uniforms. Excluding matrices, samplers,
                 // UBO blocks (EbtBlock) and uniform struct instances (EbtStruct) prevents the
                 // traverser from rewriting whole blocks/structs to vec4, which destroys their
-                // member layout and member names.
+                // member layout and member names. Uniforms that are already vec4 need no widening,
+                // so they are skipped as a fast path: retyping them is a no-op and addShapeConversion
+                // would return the node unchanged, leaving only pointless AST churn.
                 const auto basic = type.getBasicType();
                 if (type.getQualifier().isUniformOrBuffer()
                     && !type.isMatrix()
@@ -391,6 +393,12 @@ namespace Babylon::ShaderCompilerTraversers
                             {
                                 selection->setFalseBlock(shapeConversion);
                             }
+                        }
+                        else if (auto* branch = parent->getAsBranchNode())
+                        {
+                            // A uniform returned directly (`return someUniform;`) is the branch's
+                            // expression, so the conversion replaces that expression in place.
+                            branch->setExpression(shapeConversion);
                         }
                         else
                         {


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- handle `TIntermBranch` parents in `injectShapeConversion`, so a uniform used directly as a `return` expression can be rewritten
- skip uniforms that are already `vec4` in `UniformTypeChangeTraverser` as a fast path
- add regression tests for a returned uniform and for an existing `vec4` uniform array

## Root cause

`UniformTypeChangeTraverser` widens loose scalar, `vec2`, and `vec3` uniforms to `vec4`, then injects a shape conversion and replaces the original node in its parent. `injectShapeConversion` only handled aggregate, binary, unary, and selection parents, and threw for anything else:

```
Cannot replace symbol: node type handler unimplemented
```

The failing trigger is **the parent node type, not the vector width**. For `return someUniform;` the parent is a `TIntermBranch`, which was unhandled. Adding a branch handler is the actual fix.

An earlier revision of this PR attributed the failure to `vec4` array reshaping. That was wrong: `return someVec3;` fails identically, and a `vec3` must be widened so it cannot be skipped. Thanks to @bghgary for catching this.

## Fast path (not the fix)

The `type.getVectorSize() < 4` guard is retained because widening an existing `vec4` is a no-op — the type is unchanged and `addShapeConversion` returns the node as-is, so the rewrite is pointless AST churn. It is an optimization, not the fix, and it does not resolve the underlying bug on its own.

## Known remaining gaps

The same class of failure still exists for parents that glslang exposes without a setter, so they cannot be fixed here:

| Construct | Parent node | Status |
| --- | --- | --- |
| `return u;` | `TIntermBranch` | fixed by this PR |
| `while (u)` | `TIntermLoop` | still throws — `TIntermLoop` has `getTest()` but no setter |
| `switch (u)` | `TIntermSwitch` | still throws — `TIntermSwitch` has `getCondition()` but no setter |

These need an upstream glslang change to expose setters, so the underlying bug should not be considered fully closed.

## Validation

Built `UnitTests` from a clean worktree based on upstream `master`. Win32 D3D11 Debug.

| Run | `ExistingVec4UniformArrayIsNotReshaped` | `ReturnedUniformIsShapeConverted` |
| --- | --- | --- |
| This PR (branch handler + guard) | pass | pass |
| Guard reverted, branch handler kept | pass | pass |
| Branch handler reverted, guard kept | pass | **fail** — `Vec3 return effect should compile synchronously` |

Row 2 shows the guard is not what fixes the bug. Row 3 shows the branch handler is. `ShaderCompilation.CompileComprehensiveGLSL` passes in all three configurations.
