### PR TITLE
Disable C++ RTTI by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,15 +388,9 @@ endif()
 
 # Re-enables RTTI for a single target. Needed by dependencies that genuinely
 # require it; see the call sites for the specific reason in each case.
-#
-# A missing target is a hard error rather than a silent no-op: call sites are
-# expected to gate on whatever configuration provides the target, so a name
-# that does not resolve means the dependency was renamed upstream. Returning
-# quietly there would defer the failure to a missing-`typeinfo` link error.
+# Call sites gate on the configuration that provides the target, so an
+# unresolved name is a mistake and target_compile_options reports it.
 function(babylon_native_force_rtti target)
-    if(NOT TARGET ${target})
-        message(FATAL_ERROR "babylon_native_force_rtti: no such target '${target}'.")
-    endif()
     if(MSVC)
         target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX,OBJCXX>:/GR>)
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,13 @@ option(BABYLON_NATIVE_EMBEDDING_ANDROID "Build the Android JNI interop layer for
 # hosts that don't want the interop layer can explicitly disable.
 option(BABYLON_NATIVE_EMBEDDING_APPLE "Build the Apple (iOS / macOS / visionOS) Obj-C++ interop layer for Babylon::Embedding." ${APPLE})
 
+# RTTI
+# Babylon Native does not use dynamic_cast or typeid anywhere in Core, Plugins,
+# Polyfills, Embedding or Apps, but compilers emit RTTI records for every
+# polymorphic class by default. Disabling it is a pure size win. UBSan's vptr
+# check does need RTTI, so the sanitizer block below forces this back ON.
+option(ENABLE_RTTI "Emit C++ RTTI. Required by UBSan's vptr check." OFF)
+
 # Sanitizers
 option(ENABLE_SANITIZERS "Enable AddressSanitizer and UBSan" OFF)
 
@@ -361,6 +368,18 @@ if(MSVC)
 
     # Enable multiprocessor compilation for faster builds
     add_compile_options(/MP)
+endif()
+
+if(NOT ENABLE_RTTI)
+    # Applied to C++ only: /GR- and -fno-rtti are not valid for C sources, and
+    # the guard also keeps the flag off any C dependency compiled in-tree.
+    # .mm/.mmm sources compile as CXX here because project() only enables C and
+    # CXX, so Objective-C++ is covered by the same guard.
+    if(MSVC)
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/GR->)
+    else()
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+    endif()
 endif()
 
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,18 +161,23 @@ option(BABYLON_NATIVE_EMBEDDING_ANDROID "Build the Android JNI interop layer for
 # hosts that don't want the interop layer can explicitly disable.
 option(BABYLON_NATIVE_EMBEDDING_APPLE "Build the Apple (iOS / macOS / visionOS) Obj-C++ interop layer for Babylon::Embedding." ${APPLE})
 
+# Sanitizers
+option(ENABLE_SANITIZERS "Enable AddressSanitizer and UBSan" OFF)
+
 # RTTI
 # Babylon Native does not use dynamic_cast or typeid anywhere in Core, Plugins,
 # Polyfills, Embedding or Apps, but compilers emit RTTI records for every
 # polymorphic class by default. Disabling it is a pure size win. UBSan's vptr
-# check does need RTTI, so the sanitizer block below forces this back ON.
-option(ENABLE_RTTI "Emit C++ RTTI. Required by UBSan's vptr check." OFF)
-
-# Sanitizers
-option(ENABLE_SANITIZERS "Enable AddressSanitizer and UBSan" OFF)
+# check is the only thing that needs RTTI, so it is derived from the sanitizer
+# switch rather than exposed as an option of its own.
+#
+# Deliberately a plain variable and not a cache entry: a cached ENABLE_RTTI
+# would persist ON in any build directory that was configured with
+# -DENABLE_SANITIZERS=ON even once, so re-configuring that directory without
+# sanitizers would silently keep emitting RTTI and lose the size win.
+set(ENABLE_RTTI ${ENABLE_SANITIZERS})
 
 if(ENABLE_SANITIZERS)
-    set(ENABLE_RTTI ON CACHE BOOL "" FORCE)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
         set(SANITIZERS "address,undefined")
         # Check for Clang since vptr and fdsan are Clang-specific
@@ -383,9 +388,14 @@ endif()
 
 # Re-enables RTTI for a single target. Needed by dependencies that genuinely
 # require it; see the call sites for the specific reason in each case.
+#
+# A missing target is a hard error rather than a silent no-op: call sites are
+# expected to gate on whatever configuration provides the target, so a name
+# that does not resolve means the dependency was renamed upstream. Returning
+# quietly there would defer the failure to a missing-`typeinfo` link error.
 function(babylon_native_force_rtti target)
     if(NOT TARGET ${target})
-        return()
+        message(FATAL_ERROR "babylon_native_force_rtti: no such target '${target}'.")
     endif()
     if(MSVC)
         target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX,OBJCXX>:/GR>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,16 +371,28 @@ if(MSVC)
 endif()
 
 if(NOT ENABLE_RTTI)
-    # Applied to C++ only: /GR- and -fno-rtti are not valid for C sources, and
-    # the guard also keeps the flag off any C dependency compiled in-tree.
-    # .mm/.mmm sources compile as CXX here because project() only enables C and
-    # CXX, so Objective-C++ is covered by the same guard.
+    # Applied to C++ only: /GR- and -fno-rtti are not valid for C sources.
+    # OBJCXX is listed explicitly so Objective-C++ (.mm) sources are covered on
+    # Apple regardless of whether CMake classifies them as CXX or OBJCXX.
     if(MSVC)
-        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/GR->)
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX,OBJCXX>:/GR->)
     else()
-        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX,OBJCXX>:-fno-rtti>)
     endif()
 endif()
+
+# Re-enables RTTI for a single target. Needed by dependencies that genuinely
+# require it; see the call sites for the specific reason in each case.
+function(babylon_native_force_rtti target)
+    if(NOT TARGET ${target})
+        return()
+    endif()
+    if(MSVC)
+        target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX,OBJCXX>:/GR>)
+    else()
+        target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX,OBJCXX>:-frtti>)
+    endif()
+endfunction()
 
 if(APPLE)
     # Create scheme for installation and other targets

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -277,13 +277,22 @@ FetchContent_MakeAvailable_With_Message(JsRuntimeHost)
 #   v8inspector - includes asio, whose headers use typeid() unconditionally
 #                 (any_executor.hpp, service_registry.hpp, handler_work.hpp).
 #                 Clang and GCC reject this outright; MSVC only warns.
+#                 Only defined for V8 with the inspector enabled
+#                 (JsRuntimeHost Core/AppRuntime/CMakeLists.txt).
 #   jsi         - Hermes (fetched by JsRuntimeHost) builds its API/hermes
 #                 targets with RTTI, and their vtables reference "typeinfo for
 #                 facebook::jsi::*" which only jsi.cpp emits. Compiling jsi
 #                 without RTTI drops those definitions and the link fails.
 #                 The same target name is used by Node-API-JSI for V8JSI.
-babylon_native_force_rtti(v8inspector)
-babylon_native_force_rtti(jsi)
+# Each call is gated on the engine that defines the target, so a target that
+# stops existing upstream fails configuration instead of silently going by.
+if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8" AND JSRUNTIMEHOST_CORE_APPRUNTIME AND JSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR)
+    babylon_native_force_rtti(v8inspector)
+endif()
+
+if(NAPI_JAVASCRIPT_ENGINE STREQUAL "JSI" OR NAPI_JAVASCRIPT_ENGINE STREQUAL "Hermes")
+    babylon_native_force_rtti(jsi)
+endif()
 
 # --------------------------------------------------
 # metal-cpp

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -273,6 +273,18 @@ endif()
 # --------------------------------------------------
 FetchContent_MakeAvailable_With_Message(JsRuntimeHost)
 
+# Two JsRuntimeHost targets cannot be built without RTTI:
+#   v8inspector - includes asio, whose headers use typeid() unconditionally
+#                 (any_executor.hpp, service_registry.hpp, handler_work.hpp).
+#                 Clang and GCC reject this outright; MSVC only warns.
+#   jsi         - Hermes (fetched by JsRuntimeHost) builds its API/hermes
+#                 targets with RTTI, and their vtables reference "typeinfo for
+#                 facebook::jsi::*" which only jsi.cpp emits. Compiling jsi
+#                 without RTTI drops those definitions and the link fails.
+#                 The same target name is used by Node-API-JSI for V8JSI.
+babylon_native_force_rtti(v8inspector)
+babylon_native_force_rtti(jsi)
+
 # --------------------------------------------------
 # metal-cpp
 # --------------------------------------------------


### PR DESCRIPTION
Babylon Native contains no `dynamic_cast` or `typeid` expressions in `Core`, `Plugins`, `Polyfills`, `Embedding` or `Apps`, yet MSVC, GCC and Clang all emit RTTI records (`type_info` objects and the vtable slots that reach them) for every polymorphic class by default. That metadata is dead weight in the shipped binary.

## Change

A single `ENABLE_RTTI` option, defaulting to `OFF`, in the top-level `CMakeLists.txt`:

```cmake
option(ENABLE_RTTI "Emit C++ RTTI. Required by UBSan's vptr check." OFF)

if(NOT ENABLE_RTTI)
    if(MSVC)
        add_compile_options($<$<COMPILE_LANGUAGE:CXX,OBJCXX>:/GR->)
    else()
        add_compile_options($<$<COMPILE_LANGUAGE:CXX,OBJCXX>:-fno-rtti>)
    endif()
endif()
```

Notes on the details:

- **`ENABLE_RTTI` is not a new name.** It is the exact variable the sanitizer block already sets via `set(ENABLE_RTTI ON CACHE BOOL "" FORCE)`. Because that `FORCE` runs after the `option()`, `-DENABLE_SANITIZERS=ON` still turns RTTI back on and UBSan's `vptr` check keeps working. Declaring the option just makes the knob discoverable and gives it a default.
- **`COMPILE_LANGUAGE:CXX,OBJCXX` guard.** Neither `/GR-` nor `-fno-rtti` is valid for C sources, so the guard keeps them off the C dependencies built in-tree. `OBJCXX` is listed explicitly so Objective-C++ (`.mm`) sources are covered on Apple regardless of how CMake classifies them.
- **Placement.** `add_compile_options` at this point reaches every target added afterwards, which is all of `Dependencies`, `Core`, `Plugins`, `Polyfills`, `Embedding` and `Apps`.
- **Per-target opt-out.** Dependencies that genuinely need RTTI can ask for it back. DirectXTK already does exactly this — `target_compile_options(${t} PRIVATE /Wall /EHsc /GR)`, commented *"Model uses dynamic_cast, so we need /GR (Enable RTTI)"*. A directory-scoped flag cannot break it.

Anyone who wants the old behaviour can configure with `-DENABLE_RTTI=ON`.

## Dependencies that need RTTI

Two JsRuntimeHost targets do not build without it. They get it back through a `babylon_native_force_rtti()` helper, called right after `FetchContent_MakeAvailable_With_Message(JsRuntimeHost)` — Hermes is fetched from inside JsRuntimeHost, so both targets already exist at that point.

| target | why |
| --- | --- |
| `v8inspector` | Pulls in asio, whose headers call `typeid()` unconditionally (`any_executor.hpp`, `service_registry.hpp`, `handler_work.hpp`). Clang and GCC reject that outright; MSVC only warns, which is why the Windows V8 job passed and the Android ones did not. |
| `jsi` | `jsi.cpp` is the only translation unit that defines `typeinfo for facebook::jsi::*`. Hermes builds its `API/hermes` targets with RTTI and their vtables reference those symbols, so compiling `jsi` without RTTI breaks the link of `libhermesvmlean.so`. Node-API-JSI uses the same target name for V8JSI, so one call covers both engines. |

This is the same escape hatch DirectXTK uses, just applied from the consumer side because these targets live in another repo.

## Measurements

Windows x64, `RelWithDebInfo`, `Apps/Playground/Playground.exe`:

| | bytes |
| --- | ---: |
| before | 11,116,032 |
| after | 10,927,616 |
| **delta** | **-188,416 (-1.70%)** |

RTTI content in the image, from the linker map (`??_R0` … `??_R4` symbols):

| | bytes | % of exe |
| --- | ---: | ---: |
| before | 202,000 | 1.85% |
| after | 20,632 | 0.19% |

Before, that RTTI was spread across the whole tree — Babylon Native itself 144,280 B, DirectXTK/UrlLib/arcana 31,392 B, glslang/SPIRV 14,056 B, bgfx/bimg/bx 12,096 B — which is why a global flag is the right scope rather than a per-target one.

The 20,632 B that remain are `??_R0` type descriptors MSVC emits for `throw` / `catch` under `/EHsc`. That is exception-handling metadata rather than RTTI proper, and cannot be removed while exceptions are enabled.

## Validation

Full build of `Playground` and all dependencies produced **zero C4541** (`'dynamic_cast' used on polymorphic type with /GR-`) and **zero C4530** warnings. C4541 is only a warning and not an error, so this is the check that actually proves no `dynamic_cast` was silently broken.

Playground validation suite on D3D11, run in eight chunks of 100 test indices:

| indices | ran | passed | failed |
| --- | ---: | ---: | ---: |
| 0-99 | 95 | 95 | 0 |
| 100-199 | 34 | 34 | 0 |
| 200-299 | 41 | 41 | 0 |
| 300-399 | 39 | 39 | 0 |
| 400-499 | 12 | 12 | 0 |
| 500-599 | 22 | 22 | 0 |
| 600-699 | 54 | 54 | 0 |
| 700-719 | 4 | 4 | 0 |
| **total** | **301** | **301** | **0** |

Only the Windows/MSVC path was built and measured locally. Every other platform, engine and toolchain is covered by CI, which is green across all 34 checks — including Android, Apple, Linux and UWP on JSC, QuickJS, V8, Hermes and JSI, plus the Windows and macOS sanitizer jobs that exercise the `ENABLE_SANITIZERS` path where RTTI stays on.
