### PR TITLE
Update JsRuntimeHost to pick up the UrlLib error-reporting fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ FetchContent_Declare(ios-cmake
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(JsRuntimeHost
     GIT_REPOSITORY https://github.com/BabylonJS/JsRuntimeHost.git
-    GIT_TAG 8cd142951018de07c89c23f726fb7dc9c8374599)
+    GIT_TAG 9271f13b654665e343aa0e80ad872b4674534163)
 FetchContent_Declare(metal-cpp
     GIT_REPOSITORY https://github.com/bkaradzic/metal-cpp.git
     GIT_TAG metal-cpp_26


### PR DESCRIPTION
## Problem

BabylonNative pins JsRuntimeHost at `8cd1429`, which in turn pins UrlLib at `e86ffb3`. That UrlLib predates:

> [BabylonJS/UrlLib#36](https://github.com/BabylonJS/UrlLib/pull/36) — `425c9f1` *Win32: surface the real error when opening a URL fails*

so on Win32 **every** failure to open a URL reaches JavaScript as the constant string:

```
Error opening URL: Unknown error opening URL
```

No URL, no reason. Any asset or network loading failure in a Babylon Native app is effectively undiagnosable — you cannot tell *which* request failed, let alone *why*.

## Change

Move the pin to JsRuntimeHost `main` (`9271f13`), which pins UrlLib `0c99133` and therefore contains the fix.

`8cd1429` is an ancestor of `9271f13` (verified with `git merge-base --is-ancestor`), and there is exactly **one** commit in between, so this is a straight fast-forward of the dependency.

## Effect

Real example, from triaging a Gaussian Splatting test failure:

**Before**
```
RuntimeError: Unable to load from https://.../adobe_backpack.spz: Error opening URL: Unknown error opening URL
```

**After**
```
RuntimeError: Unable to load from https://.../adobe_backpack.spz: Error opening URL:
Unable to open URL 'import createSpzModule from 'https://unpkg.com/@adobe/spz@0.2.0/dist/spz.js';...'
```

The second message immediately identifies the real defect (ES module source text being passed where a URL is expected — see [BabylonJS/Babylon.js#18776](https://github.com/BabylonJS/Babylon.js/pull/18776)). The first is a dead end.

This is engine independent: it improves diagnosability for every graphics backend.

## Validation

Built for Win32 and ran the full Playground validation catalog (680 runnable tests) before and after the bump:

| | PASS | FAIL | TIMEOUT | CRASH |
|---|---|---|---|---|
| before (`8cd1429`) | 619 | 52 | 8 | 1 |
| after (`9271f13`) | 618 | 53 | 8 | 1 |

The single differing test is `SOGS with SH no texture lookup`. It was re-run in isolation on **both** pins and is pre-existing flaky, not a regression:

* old pin `8cd1429`: 3 PASS / 5 FAIL over 8 runs
* new pin `9271f13`: 3 PASS / 3 FAIL over 6 runs

No other test changed status.
