### PR TITLE
Playground validation: fix undefined `renderImage` in the scriptToRun path

### DIFF
--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -493,7 +493,7 @@
                         setTimeout(function () {
                             try {
                                 currentScene = eval(scriptCode);
-                                processCurrentScene(test, renderImage, done, compareFunction);
+                                processCurrentScene(test, referenceImage, done, compareFunction);
                             }
                             catch (e) {
                                 console.error(e);


### PR DESCRIPTION
### Problem

`loadPlayground` declares its third parameter as `referenceImage`:

```js
function loadPlayground(test, done, referenceImage, compareFunction) {
```

but the `test.scriptToRun` branch passes `renderImage`:

```js
setTimeout(function () {
    try {
        currentScene = eval(scriptCode);
        processCurrentScene(test, renderImage, done, compareFunction);   // <-- not in scope
```

`renderImage` is not bound in that scope. It is only the *parameter name* of
`processCurrentScene(test, renderImage, done, compareFunction)`. So the moment
a `scriptToRun` scene is evaluated, the call throws
`ReferenceError: renderImage is not defined`, the enclosing `catch` logs it,
and the test is marked failed.

Every other call site in `loadPlayground` already passes `referenceImage`,
and `processCurrentScene` forwards the argument straight through to
`evaluateScreenshot(test, screenshot, renderImage, ...)` where it is used as
the reference image to compare against. `referenceImage` is clearly the
intended value.

### Why this was never noticed

The `scriptToRun` tests could not reach this line. They wait on
`request.onreadystatechange`, and the JsRuntimeHost `XMLHttpRequest`
polyfill never invokes it -- `RaiseEvent` only dispatches handlers registered
via `addEventListener`, and there are no `on<event>` property accessors at
all. So the request completed (`readyState` 4, `status` 200) but the
callback never ran and the test hung until the harness timeout.

That is fixed separately in BabylonJS/JsRuntimeHost#TBD. With the polyfill fixed,
these tests finally get as far as evaluating the scene -- and immediately hit
this ReferenceError.

### Effect

Tests affected: Fog, Polygon, Lines, Lens, Self shadowing, GUI, Procedural
textures. They are currently excluded on **every** graphics API (D3D11, D3D12,
OpenGL, Vulkan, Metal, WebGPU) because they hang, so this is not WebGPU/Dawn
specific -- it affects every rendering backend.

With this fix plus the JsRuntimeHost one, locally:

| Test | Before | After |
| --- | --- | --- |
| Fog | hang | **pass** |
| Lines | hang | **pass** |
| Lens | hang | **pass** |
| Self shadowing | hang | **pass** |
| Polygon | hang | fails fast (`earcut is not defined`) |
| GUI | hang | fails fast (pixel diff 10.3%) |
| Procedural textures | hang | fails fast (`name is not defined`) |

The three remaining failures are separate, unrelated issues that were previously
invisible; they now surface as fast, actionable errors instead of a hang.
