### PR TITLE
Playground: load earcut and procedural textures, and provide `name` to test scripts

### DIFF
--- a/Apps/Playground/Android/app/build.gradle
+++ b/Apps/Playground/Android/app/build.gradle
@@ -108,6 +108,16 @@ tasks.register('copyFiles') {
             into 'src/main/assets/Scripts'
         }
         copy {
+            from '../../../node_modules/babylonjs-procedural-textures'
+            include "babylonjs.proceduralTextures.js"
+            into 'src/main/assets/Scripts'
+        }
+        copy {
+            from '../../../node_modules/earcut/dist'
+            include "earcut.min.js"
+            into 'src/main/assets/Scripts'
+        }
+        copy {
             from '../../../Dependencies'
             include "*.js"
             into 'src/main/assets/Scripts'

--- a/Apps/Playground/CMakeLists.txt
+++ b/Apps/Playground/CMakeLists.txt
@@ -6,7 +6,9 @@ set(BABYLON_SCRIPTS
     "../node_modules/babylonjs/babylon.max.js"
     "../node_modules/babylonjs-materials/babylonjs.materials.js"
     "../node_modules/babylonjs-gui/babylon.gui.js"
-    "../node_modules/babylonjs-serializers/babylonjs.serializers.js")
+    "../node_modules/babylonjs-serializers/babylonjs.serializers.js"
+    "../node_modules/babylonjs-procedural-textures/babylonjs.proceduralTextures.js"
+    "../node_modules/earcut/dist/earcut.min.js")
 
 set(DEPENDENCIES
     "../Dependencies/ammo.js"

--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -405,6 +405,8 @@
                             // native XHR dispatch frames and can overflow engines
                             // with a small C stack (e.g. QuickJS).
                             setTimeout(function () {
+                                // eslint-disable-next-line no-unused-vars
+                                var name = ""; // see the note on the scriptToRun eval below
                                 try {
                                     currentScene = eval(pgCode);
 
@@ -491,6 +493,15 @@
                         // the native XHR dispatch frames and can overflow engines
                         // with a small C stack (e.g. QuickJS).
                         setTimeout(function () {
+                            // Browser scripts sometimes reference `name` without declaring it. In a
+                            // page that silently resolves to window.name (""), so the mistake is
+                            // invisible there but throws "ReferenceError: name is not defined"
+                            // here. eval() below is a *direct* eval, so the evaluated script sees
+                            // this function's scope and finds this binding -- same as it would on
+                            // the web, without leaking an actual global. (A real global `name`
+                            // is not an option: it breaks the Babylon UMD bundles at load time.)
+                            // eslint-disable-next-line no-unused-vars
+                            var name = "";
                             try {
                                 currentScene = eval(scriptCode);
                                 processCurrentScene(test, referenceImage, done, compareFunction);

--- a/Apps/Playground/Shared/PlaygroundScripts.cpp
+++ b/Apps/Playground/Shared/PlaygroundScripts.cpp
@@ -35,10 +35,8 @@ namespace Playground
         runtime.LoadScript("app:///Scripts/ammo.js");
         // Commenting out recast.js for now because v8jsi is incompatible with asm.js.
         // runtime.LoadScript("app:///Scripts/recast.js");
-        // PolygonMeshBuilder resolves `earcut` as a global at triangulation time rather than
-        // importing it, so it has to be present before any polygon scene runs. The browser
-        // Playground loads it the same way; without it those scenes fail with
-        // `ReferenceError: earcut is not defined`.
+        // PolygonMeshBuilder resolves `earcut` as a global at triangulation time, so without this
+        // any polygon scene fails with `ReferenceError: earcut is not defined`.
         runtime.LoadScript("app:///Scripts/earcut.min.js");
         runtime.LoadScript("app:///Scripts/babylon.max.js");
         // Load addons right after babylon.max.js so addons init sees a fully
@@ -49,8 +47,6 @@ namespace Playground
         runtime.LoadScript("app:///Scripts/babylon.gui.js");
         runtime.LoadScript("app:///Scripts/meshwriter.min.js");
         runtime.LoadScript("app:///Scripts/babylonjs.serializers.js");
-        // Procedural texture classes (WoodProceduralTexture, BrickProceduralTexture, ...) live
-        // in their own package, which the browser Playground also loads separately.
         runtime.LoadScript("app:///Scripts/babylonjs.proceduralTextures.js");
     }
 

--- a/Apps/Playground/Shared/PlaygroundScripts.cpp
+++ b/Apps/Playground/Shared/PlaygroundScripts.cpp
@@ -35,6 +35,11 @@ namespace Playground
         runtime.LoadScript("app:///Scripts/ammo.js");
         // Commenting out recast.js for now because v8jsi is incompatible with asm.js.
         // runtime.LoadScript("app:///Scripts/recast.js");
+        // PolygonMeshBuilder resolves `earcut` as a global at triangulation time rather than
+        // importing it, so it has to be present before any polygon scene runs. The browser
+        // Playground loads it the same way; without it those scenes fail with
+        // `ReferenceError: earcut is not defined`.
+        runtime.LoadScript("app:///Scripts/earcut.min.js");
         runtime.LoadScript("app:///Scripts/babylon.max.js");
         // Load addons right after babylon.max.js so addons init sees a fully
         // constructed BABYLON global.
@@ -44,6 +49,9 @@ namespace Playground
         runtime.LoadScript("app:///Scripts/babylon.gui.js");
         runtime.LoadScript("app:///Scripts/meshwriter.min.js");
         runtime.LoadScript("app:///Scripts/babylonjs.serializers.js");
+        // Procedural texture classes (WoodProceduralTexture, BrickProceduralTexture, ...) live
+        // in their own package, which the browser Playground also loads separately.
+        runtime.LoadScript("app:///Scripts/babylonjs.proceduralTextures.js");
     }
 
     std::function<void(Babylon::Embedding::LogLevel, std::string_view)>

--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -17,7 +17,7 @@
         "babylonjs-gui": "^9.15.0",
         "babylonjs-loaders": "^9.15.0",
         "babylonjs-materials": "^9.15.0",
-        "babylonjs-procedural-textures": "^9.15.0",
+        "babylonjs-procedural-textures": "9.15.0",
         "babylonjs-serializers": "^9.15.0",
         "earcut": "^2.2.4",
         "jsc-android": "^241213.1.0",

--- a/Apps/package-lock.json
+++ b/Apps/package-lock.json
@@ -17,7 +17,9 @@
         "babylonjs-gui": "^9.15.0",
         "babylonjs-loaders": "^9.15.0",
         "babylonjs-materials": "^9.15.0",
+        "babylonjs-procedural-textures": "^9.15.0",
         "babylonjs-serializers": "^9.15.0",
+        "earcut": "^2.2.4",
         "jsc-android": "^241213.1.0",
         "v8-android": "^7.8.2"
       },
@@ -2648,6 +2650,15 @@
         "babylonjs": "9.15.0"
       }
     },
+    "node_modules/babylonjs-procedural-textures": {
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-procedural-textures/-/babylonjs-procedural-textures-9.15.0.tgz",
+      "integrity": "sha512-sWMWq/TUDhleL6Bwu8kwV3+5kMwZQ6X4W4fNTgvzUaUARWn7uB0+3OEE5K2GoLFQ4UvUMv2ZxItv/2Xn06Mxww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "babylonjs": "9.15.0"
+      }
+    },
     "node_modules/babylonjs-serializers": {
       "version": "9.15.0",
       "resolved": "https://registry.npmjs.org/babylonjs-serializers/-/babylonjs-serializers-9.15.0.tgz",
@@ -3179,6 +3190,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -6,7 +6,7 @@
     "UnitTests/JavaScript"
   ],
   "scripts": {
-    "getNightly": "node scripts/getNightly.js && npm run downlevel:native-scripts -- node_modules/babylonjs/babylon.max.js",
+    "getNightly": "node scripts/getNightly.js",
     "downlevel:native-scripts": "node scripts/downlevelNativeScripts.mjs"
   },
   "devDependencies": {
@@ -19,7 +19,7 @@
     "babylonjs-gui": "^9.15.0",
     "babylonjs-loaders": "^9.15.0",
     "babylonjs-materials": "^9.15.0",
-    "babylonjs-procedural-textures": "^9.15.0",
+    "babylonjs-procedural-textures": "9.15.0",
     "babylonjs-serializers": "^9.15.0",
     "earcut": "^2.2.4",
     "jsc-android": "^241213.1.0",

--- a/Apps/package.json
+++ b/Apps/package.json
@@ -19,7 +19,9 @@
     "babylonjs-gui": "^9.15.0",
     "babylonjs-loaders": "^9.15.0",
     "babylonjs-materials": "^9.15.0",
+    "babylonjs-procedural-textures": "^9.15.0",
     "babylonjs-serializers": "^9.15.0",
+    "earcut": "^2.2.4",
     "jsc-android": "^241213.1.0",
     "v8-android": "^7.8.2"
   }

--- a/Apps/scripts/getNightly.js
+++ b/Apps/scripts/getNightly.js
@@ -1,5 +1,7 @@
 var https = require('https');
 var fs = require('fs');
+var path = require('path');
+var spawnSync = require('child_process').spawnSync;
 
 function download(filename, url) {
   return new Promise(function (resolve, reject) {
@@ -70,7 +72,31 @@ console.log('Downloading babylon.js nightly');
 // file in place, and so the down-level step that runs next cannot race an incomplete write.
 Promise.all(files.map(function (f) { return download(f[0], f[1]); })).then(function () {
   console.log('Downloaded ' + files.length + ' file(s)');
-}, function (err) {
+
+  // Every bundle we just replaced needs the ES5 down-level, not just babylon.max.js: they all end up
+  // in BABYLON_SCRIPTS and all have to run on Chakra. Deriving the list from `files` means adding a
+  // new download above can never again silently skip this step.
+  var scripts = files
+    .map(function (f) { return f[0]; })
+    .filter(function (p) { return /babylon.*\.js$/i.test(p); });
+
+  if (scripts.length === 0) {
+    return;
+  }
+
+  console.log('Down-leveling ' + scripts.length + ' script(s)');
+  var result = spawnSync(
+    process.execPath,
+    [path.join(__dirname, 'downlevelNativeScripts.mjs')].concat(scripts),
+    { stdio: 'inherit' });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error('downlevelNativeScripts.mjs exited with code ' + result.status);
+  }
+}).catch(function (err) {
   console.error(err.message);
   process.exit(1);
 });

--- a/Apps/scripts/getNightly.js
+++ b/Apps/scripts/getNightly.js
@@ -60,6 +60,8 @@ var files = [
   ['node_modules/babylonjs-gui/babylon.gui.js.map', 'https://preview.babylonjs.com/gui/babylon.gui.js.map'],
   ['node_modules/babylonjs-serializers/babylonjs.serializers.js', 'https://preview.babylonjs.com/serializers/babylonjs.serializers.js'],
   ['node_modules/babylonjs-serializers/babylonjs.serializers.js.map', 'https://preview.babylonjs.com/serializers/babylonjs.serializers.js.map'],
+  ['node_modules/babylonjs-procedural-textures/babylonjs.proceduralTextures.js', 'https://preview.babylonjs.com/proceduralTexturesLibrary/babylonjs.proceduralTextures.js'],
+  ['node_modules/babylonjs-procedural-textures/babylonjs.proceduralTextures.js.map', 'https://preview.babylonjs.com/proceduralTexturesLibrary/babylonjs.proceduralTextures.js.map'],
 ];
 
 console.log('Downloading babylon.js nightly');


### PR DESCRIPTION
Three test failures on the native Playground turned out to have the same root cause: the native harness provides a smaller browser environment than the web Playground, so scripts that work on babylonjs.com die here on a missing global. None of it is renderer-specific, so this fixes the same scenes on both the bgfx and the WebGPU/Dawn paths.

### `earcut is not defined`

`PolygonMeshBuilder` resolves `earcut` as a *global* at triangulation time rather than importing it, so any scene that builds a polygon throws. The web Playground loads earcut as a separate script; we never did.

Pinned to `^2.2.4` deliberately, for two reasons — 3.x does ship `dist/earcut.min.js`, so "no UMD build" is *not* one of them:

- **The shape of the global changed.** 2.x assigns the function itself (`.earcut = e()`); 3.x assigns a namespace object (`.earcut = {}`). `PolygonMeshBuilder` calls `earcut(...)`, so 3.x throws at triangulation time.
- **It matches the environment these tests replicate.** `cdn.babylonjs.com/earcut.min.js`, which `playground/index.html` loads, is itself 2.x (6,519 bytes, global-is-the-function).

Thanks to @bghgary for catching the original, incorrect rationale.

### `BABYLON.WoodProceduralTexture is not a constructor`

The procedural texture classes live in their own `babylonjs-procedural-textures` package, which was never in the bundle. The existing config even documents this â€” one test is disabled with the reason *"BABYLON.NormalMapProceduralTexture is not included in the native script bundle"*.

Wired into `BABYLON_SCRIPTS`, `PlaygroundScripts.cpp`, the Android asset copy, and `getNightly.js` so it stays in step with the other Babylon packages. Pinned to `9.15.0` to match every other `babylonjs-*` entry in the lock file â€” on `^9.15.0` npm resolves it to 9.20.0 and then nests a second full copy of `babylonjs` under it.

### `name is not defined`

Some scripts reference a bare `name` without declaring it. In a browser that silently resolves to `window.name` (`""`), so the bug is invisible on the web but throws here.

Fixed by declaring `var name = ""` in the function that *encloses* the `eval`. Because those are **direct** evals, the evaluated script sees that scope and resolves `name` exactly as it would on the web â€” without leaking a real global, and without rewriting the script text (so line numbers in stack traces and any `"use strict"` prologue are preserved).

Defining an actual global `name` is **not** an option, and I tried: it breaks the Babylon UMD bundles, which probe for `name` while being evaluated. `babylonjs.loaders.js` then throws `Error: Invalid argument` at load time and *every* test fails.

### Depends on

BabylonJS/Babylon.js#18799 must land first. The nightly's "Update scripts from snapshot" step refills every `babylon*` file in the Native artifact from the CDN snapshot, but the downlevel that follows names only `babylon.max.js` — so a newly added bundle is refilled and then run un-downleveled. #18799 passes the directory instead, which is correct both before and after this PR.

### Validation

Full 680-test sweep on the Dawn/WebGPU backend, before vs. after:

| | before | after |
|---|---|---|
| PASS | 622 | **625** |
| FAIL | 56 | 53 |

**Zero regressions.** `Polygon` flips to PASS outright; `Procedural textures` and `Show all procedural textures` go from hard exceptions to rendering (they still miss the pixel threshold, tracked separately). The other two deltas (`Iridescence NME`, `Sprite maps`) are known order-dependent flakes, not caused by this change.
