### PR TITLE
Canvas: fix 21 correctness and robustness bugs in the shared Canvas2D polyfill

### DIFF
--- a/Apps/Playground/Scripts/config.json
+++ b/Apps/Playground/Scripts/config.json
@@ -2324,22 +2324,16 @@
         {
             "title": "GUI Gradient Linear",
             "playgroundId": "#XCPP9Y#17227",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Pixel comparison fails (more than 20% pixels differ)",
             "referenceImage": "GUI-Gradient-Linear.png"
         },
         {
             "title": "GUI Gradient Radial",
             "playgroundId": "#4Z7EK3",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Test crashes or hangs on Babylon Native",
             "referenceImage": "GUI-Gradient-Radial.png"
         },
         {
             "title": "GUI Gradient Linear with transparency",
             "playgroundId": "#PFK1Z5",
-            "excludeFromAutomaticTesting": true,
-            "reason": "Test crashes or hangs on Babylon Native",
             "referenceImage": "GUI-Gradient-Linear-with-transparency.png"
         },
         {

--- a/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
+++ b/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
@@ -28282,13 +28282,29 @@ describe("ColorParsing", function () {
   (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.Canvas.parseColor("#12345678")).to.equal(0x78563412);
   (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.Canvas.parseColor("snow")).to.equal(0xfffafaff);
   (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.Canvas.parseColor("rgb(16,32,48)")).to.equal(0xff302010);
-  (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.Canvas.parseColor("rgba(16,32,48,64)")).to.equal(0x40302010);
+  // Alpha is a 0-1 number (or a percentage) per CSS Color, so any value above
+  // 1 clamps to fully opaque. It is not a 0-255 channel like r/g/b.
+  (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.Canvas.parseColor("rgba(16,32,48,64)")).to.equal(0xff302010);
   (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.Canvas.parseColor("rgb(16,     32   ,  48   )")).to.equal(
     0xff302010
   );
   (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(
     _native.Canvas.parseColor("rgba(    16,     32   ,  48 , 64  )")
-  ).to.equal(0x40302010);
+  ).to.equal(0xff302010);
+  (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.Canvas.parseColor("rgba(16,32,48,1)")).to.equal(0xff302010);
+  (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.Canvas.parseColor("rgba(16,32,48,0)")).to.equal(0x00302010);
+  // Fractional and percentage alpha, whitespace-separated components and the
+  // "/ alpha" form all used to fall through to the "unable to parse" throw.
+  (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.Canvas.parseColor("rgba(16,32,48,0.5)")).to.equal(0x80302010);
+  (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.Canvas.parseColor("rgba(16 32 48 / 50%)")).to.equal(
+    0x80302010
+  );
+  (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.Canvas.parseColor("rgb(16 32 48)")).to.equal(0xff302010);
+  (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.Canvas.parseColor("rgb(100%,0%,0%)")).to.equal(0xff0000ff);
+  (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.Canvas.parseColor("hsl(0,100%,50%)")).to.equal(0xff0000ff);
+  (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.Canvas.parseColor("hsla(0,100%,50%,0.5)")).to.equal(
+    0x800000ff
+  );
 
   it("should throw", function () {
     function incorrectColor() {

--- a/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
+++ b/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
@@ -28438,6 +28438,42 @@ describe("Canvas2D", function () {
     ctx.restore();
     (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.strokeStyle).to.equal("#0000ff");
   });
+
+  // The three parsers below all used to reach std::stof/std::stoi with a value the regex
+  // admits but the target type cannot hold. The resulting std::out_of_range is not a
+  // Napi::Error, so it escaped the N-API callback and terminated the host process outright
+  // rather than surfacing as a JS exception. Reaching the assertion at all is the test.
+  it("survives an out-of-range rgb() component", function () {
+    var ctx = createContext();
+    var huge = "9".repeat(400);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(function () {
+      ctx.fillStyle = "rgb(".concat(huge, ", 0, 0)");
+    }).to.not.throw();
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(function () {
+      ctx.fillStyle = "rgba(0, 0, 0, ".concat(huge, ")");
+    }).to.not.throw();
+  });
+
+  it("survives an out-of-range font size and weight", function () {
+    var ctx = createContext();
+    ctx.font = "18px Arial";
+    // The size regex accepts an exponent, so this parses but does not fit a float.
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(function () {
+      ctx.font = "18e999px Arial";
+    }).to.not.throw();
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(function () {
+      ctx.font = "".concat("9".repeat(400), " 18px Arial");
+    }).to.not.throw();
+    // An unparseable font is ignored, so the previous one stays in effect.
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.font).to.contain("18px");
+  });
+
+  it("survives an out-of-range letterSpacing", function () {
+    var ctx = createContext();
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(function () {
+      ctx.letterSpacing = "".concat("9".repeat(400), "px");
+    }).to.not.throw();
+  });
 });
 
 function createSceneAndWait(callback, done) {

--- a/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
+++ b/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
@@ -28376,6 +28376,70 @@ describe("ColorParsing", function () {
   });
 });
 
+describe("Canvas2D", function () {
+  function createContext() {
+    var canvas = new _native.Canvas();
+    canvas.width = 64;
+    canvas.height = 64;
+    return canvas.getContext("2d");
+  }
+
+  it("round-trips a string fillStyle and strokeStyle", function () {
+    var ctx = createContext();
+    ctx.fillStyle = "#ff0000";
+    ctx.strokeStyle = "#00ff00";
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.fillStyle).to.equal("#ff0000");
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.strokeStyle).to.equal("#00ff00");
+  });
+
+  it("accepts a CanvasGradient as fillStyle", function () {
+    var ctx = createContext();
+    var gradient = ctx.createLinearGradient(0, 0, 64, 64);
+    gradient.addColorStop(0, "red");
+    gradient.addColorStop(1, "blue");
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(function () {
+      ctx.fillStyle = gradient;
+    }).to.not.throw();
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.fillStyle).to.not.equal("#ff0000");
+  });
+
+  it("accepts a CanvasGradient as strokeStyle", function () {
+    // strokeStyle used to be string-only and threw "A string was expected",
+    // which broke every GUI control that strokes with a gradient (Line, Button border).
+    var ctx = createContext();
+    var gradient = ctx.createLinearGradient(0, 0, 64, 64);
+    gradient.addColorStop(0, "red");
+    gradient.addColorStop(1, "blue");
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(function () {
+      ctx.strokeStyle = gradient;
+    }).to.not.throw();
+  });
+
+  it("accepts a radial CanvasGradient defined by two independent circles", function () {
+    var ctx = createContext();
+    // Neither concentric nor r0 == 0: both circles have to be honored.
+    var gradient = ctx.createRadialGradient(10, 10, 5, 40, 32, 30);
+    gradient.addColorStop(0, "yellow");
+    gradient.addColorStop(0.5, "pink");
+    gradient.addColorStop(1, "green");
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(function () {
+      ctx.fillStyle = gradient;
+      ctx.strokeStyle = gradient;
+    }).to.not.throw();
+  });
+
+  it("restores a gradient strokeStyle across save/restore", function () {
+    var ctx = createContext();
+    var gradient = ctx.createLinearGradient(0, 0, 64, 64);
+    gradient.addColorStop(0, "red");
+    ctx.strokeStyle = "#0000ff";
+    ctx.save();
+    ctx.strokeStyle = gradient;
+    ctx.restore();
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.strokeStyle).to.equal("#0000ff");
+  });
+});
+
 function createSceneAndWait(callback, done) {
   var engine = new _babylonjs_core__WEBPACK_IMPORTED_MODULE_4__.NativeEngine();
   var scene = new _babylonjs_core__WEBPACK_IMPORTED_MODULE_4__.Scene(engine);

--- a/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
+++ b/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
@@ -28663,6 +28663,32 @@ describe("Canvas2D", function () {
       ctx.letterSpacing = "".concat("9".repeat(400), "px");
     }).to.not.throw();
   });
+
+  it("rejects a createImageData source whose dimensions are not valid extents", function () {
+    var ctx = createContext();
+    // The ImageData overload is duck-typed, so these never went through WebIDL's
+    // unsigned long conversion. A negative width used to wrap to 4294967295 and ask
+    // for a ~17 GB allocation instead of being rejected.
+    var bad = [
+    { width: -1, height: 1 },
+    { width: 1, height: -1 },
+    { width: 1.5, height: 1 },
+    { width: 5e9, height: 1 },
+    { width: Infinity, height: 1 }];
+
+    bad.forEach(function (source) {
+      (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(function () {
+        ctx.createImageData(source);
+      }, JSON.stringify(source)).to.throw();
+    });
+  });
+
+  it("creates image data from a valid source object", function () {
+    var ctx = createContext();
+    var data = ctx.createImageData({ width: 4, height: 3 });
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(data.width).to.equal(4);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(data.height).to.equal(3);
+  });
 });
 
 function createSceneAndWait(callback, done) {

--- a/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
+++ b/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
@@ -28504,10 +28504,69 @@ describe("Canvas2D", function () {
     (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.getLineDash()).to.deep.equal([]);
   });
 
-  it("keeps two color stops at the same offset", function () {
-    // Stops were stored in a std::map keyed by offset, so the second stop at an
-    // identical offset was silently dropped and the hard transition it encodes -- a
-    // stripe pattern, for instance -- came out as a smooth fade instead.
+  it("keeps the previous dash list when the argument is not a list", function () {
+    // A present-but-rejected argument skipped the parse loop and then committed the
+    // empty temporary, so setLineDash("x") cleared the list where setLineDash([-1])
+    // correctly kept it. An absent argument still means "solid".
+    var ctx = createContext();
+    ctx.setLineDash([5, 10]);
+    ctx.setLineDash("x");
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.getLineDash()).to.deep.equal([5, 10]);
+    ctx.setLineDash(null);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.getLineDash()).to.deep.equal([5, 10]);
+    ctx.setLineDash(7);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.getLineDash()).to.deep.equal([5, 10]);
+    ctx.setLineDash();
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.getLineDash()).to.deep.equal([]);
+  });
+
+  it("restores font", function () {
+    // font was the one exposed attribute left out of the saved state. It is worse than
+    // the getter-only cases: the font id resolved here is what the text draw path binds,
+    // so the wrong face actually rendered after a restore().
+    var ctx = createContext();
+    ctx.font = "18px Arial";
+    // The getter reports a normalized serialization, so compare against the round-tripped
+    // value rather than the literal that was assigned.
+    var saved = ctx.font;
+    ctx.save();
+    ctx.font = "40px Times";
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.font).to.not.equal(saved);
+    ctx.restore();
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.font).to.equal(saved);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(function () {
+      ctx.fillText("after restore", 0, 20);
+    }).to.not.throw();
+  });
+
+  it("ignores a fillStyle or strokeStyle that is neither a color string nor a gradient", function () {
+    // Both setters reached napi_unwrap for any object, so `ctx.strokeStyle = {}` unwrapped
+    // an object that was never wrapped and dereferenced whatever the slot held. Per spec
+    // an unusable value leaves the attribute unchanged.
+    var ctx = createContext();
+    ctx.fillStyle = "#ff0000";
+    ctx.strokeStyle = "#00ff00";
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(function () {
+      ctx.fillStyle = {};
+      ctx.strokeStyle = {};
+      ctx.fillStyle = [];
+      ctx.strokeStyle = function () {};
+    }).to.not.throw();
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.fillStyle).to.equal("#ff0000");
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.strokeStyle).to.equal("#00ff00");
+    // A real gradient is still accepted.
+    var gradient = ctx.createLinearGradient(0, 0, 64, 0);
+    gradient.addColorStop(0, "red");
+    gradient.addColorStop(1, "blue");
+    ctx.fillStyle = gradient;
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.fillStyle).to.not.equal("#ff0000");
+  });
+
+  it("accepts two color stops at the same offset", function () {
+    // Only checks that the insertion path accepts the duplicate offset the spec allows;
+    // std::map::insert() dropped it by returning {it, false} rather than throwing, so this
+    // does not by itself prove the stop survives. Asserting that needs the rendered ramp,
+    // and gradient fills are not read back by getImageData.
     var ctx = createContext();
     var gradient = ctx.createLinearGradient(0, 0, 64, 0);
     gradient.addColorStop(0, "red");

--- a/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
+++ b/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
@@ -28504,6 +28504,55 @@ describe("Canvas2D", function () {
     (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.getLineDash()).to.deep.equal([]);
   });
 
+  it("keeps a gradient assigned to fillStyle alive across a collection", function () {
+    var ctx = createContext();
+    var global = Function("return this")();
+
+    // Create and assign the gradient inside a scope that keeps no reference to it, so
+    // the only thing left pointing at it is whatever fillStyle stored. CanvasGradient is
+    // an ObjectWrap, so if the style does not root the JavaScript wrapper the finalizer
+    // deletes the native gradient and the next fill dereferences freed memory.
+    (function () {
+      var gradient = ctx.createLinearGradient(0, 0, 64, 0);
+      gradient.addColorStop(0, "red");
+      gradient.addColorStop(1, "blue");
+      gradient.tag = "kept";
+      ctx.fillStyle = gradient;
+    })();
+
+    // Not every engine the polyfill runs on exposes a collection hook; the assertions
+    // below are worth making either way.
+    if (typeof global.CollectGarbage === "function") {
+      global.CollectGarbage();
+    }
+
+    // The getter has to hand back the object that was assigned. The expando proves it is
+    // that same JavaScript object rather than a fresh wrapper.
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.fillStyle.tag).to.equal("kept");
+    // ...and the native gradient behind it has to still be there.
+    ctx.fillStyle.addColorStop(0.5, "green");
+    ctx.fillRect(0, 0, 64, 64);
+  });
+  it("keeps a gradient assigned to strokeStyle alive across a collection", function () {
+    var ctx = createContext();
+    var global = Function("return this")();
+
+    (function () {
+      var gradient = ctx.createRadialGradient(32, 32, 0, 32, 32, 32);
+      gradient.addColorStop(0, "red");
+      gradient.addColorStop(1, "blue");
+      gradient.tag = "kept";
+      ctx.strokeStyle = gradient;
+    })();
+
+    if (typeof global.CollectGarbage === "function") {
+      global.CollectGarbage();
+    }
+
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.strokeStyle.tag).to.equal("kept");
+    ctx.strokeStyle.addColorStop(0.5, "green");
+    ctx.strokeRect(0, 0, 64, 64);
+  });
   it("keeps the previous dash list when the argument is not a list", function () {
     // A present-but-rejected argument skipped the parse loop and then committed the
     // empty temporary, so setLineDash("x") cleared the list where setLineDash([-1])

--- a/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
+++ b/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
@@ -28439,6 +28439,69 @@ describe("Canvas2D", function () {
     (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.strokeStyle).to.equal("#0000ff");
   });
 
+  it("restores the shadow attributes across save/restore", function () {
+    // These have no nanovg counterpart, so nvgRestore() never rewound them and a
+    // value assigned after save() survived restore().
+    var ctx = createContext();
+    ctx.shadowColor = "#00ff00";
+    ctx.shadowBlur = 1;
+    ctx.shadowOffsetX = 2;
+    ctx.shadowOffsetY = 3;
+    ctx.save();
+    ctx.shadowColor = "#ff0000";
+    ctx.shadowBlur = 40;
+    ctx.shadowOffsetX = 50;
+    ctx.shadowOffsetY = 60;
+    ctx.restore();
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.shadowColor).to.equal("#00ff00");
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.shadowBlur).to.equal(1);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.shadowOffsetX).to.equal(2);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.shadowOffsetY).to.equal(3);
+  });
+
+  it("restores the remaining drawing state across save/restore", function () {
+    // nvgRestore() rewinds nanovg's copy of these, but the wrapper kept its own
+    // mirror, so the getters reported the post-save() value forever after.
+    // globalAlpha is set but not asserted: it is declared write-only (nullptr
+    // getter), so it has no observable value to check.
+    var ctx = createContext();
+    ctx.lineWidth = 1;
+    ctx.globalAlpha = 1;
+    ctx.lineCap = "butt";
+    ctx.lineJoin = "miter";
+    ctx.miterLimit = 10;
+    ctx.setLineDash([1, 2]);
+    ctx.save();
+    ctx.lineWidth = 9;
+    ctx.globalAlpha = 0.25;
+    ctx.lineCap = "round";
+    ctx.lineJoin = "bevel";
+    ctx.miterLimit = 3;
+    ctx.setLineDash([7, 8, 9]);
+    ctx.restore();
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.lineWidth).to.equal(1);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.lineCap).to.equal("butt");
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.lineJoin).to.equal("miter");
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.miterLimit).to.equal(10);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.getLineDash()).to.deep.equal([1, 2]);
+  });
+
+  it("keeps two color stops at the same offset", function () {
+    // Stops were stored in a std::map keyed by offset, so the second stop at an
+    // identical offset was silently dropped and the hard transition it encodes -- a
+    // stripe pattern, for instance -- came out as a smooth fade instead.
+    var ctx = createContext();
+    var gradient = ctx.createLinearGradient(0, 0, 64, 0);
+    gradient.addColorStop(0, "red");
+    gradient.addColorStop(0.5, "red");
+    gradient.addColorStop(0.5, "blue");
+    gradient.addColorStop(1, "blue");
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(function () {
+      ctx.fillStyle = gradient;
+      ctx.fillRect(0, 0, 64, 64);
+    }).to.not.throw();
+  });
+
   // The three parsers below all used to reach std::stof/std::stoi with a value the regex
   // admits but the target type cannot hold. The resulting std::out_of_range is not a
   // Napi::Error, so it escaped the N-API callback and terminated the host process outright

--- a/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
+++ b/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
@@ -28486,6 +28486,24 @@ describe("Canvas2D", function () {
     (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.getLineDash()).to.deep.equal([1, 2]);
   });
 
+  it("keeps the previous dash list when a new one is rejected", function () {
+    // The list was cleared before validation, so a rejected argument -- which the
+    // spec says must leave the previous list untouched -- wiped it instead.
+    var ctx = createContext();
+    ctx.setLineDash([5, 10]);
+    ctx.setLineDash([-1]);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.getLineDash()).to.deep.equal([5, 10]);
+    ctx.setLineDash([2, "x"]);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.getLineDash()).to.deep.equal([5, 10]);
+    ctx.setLineDash([Number.NaN]);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.getLineDash()).to.deep.equal([5, 10]);
+    // A valid list still replaces it, and an empty list still means "solid".
+    ctx.setLineDash([3, 4]);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.getLineDash()).to.deep.equal([3, 4]);
+    ctx.setLineDash([]);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.getLineDash()).to.deep.equal([]);
+  });
+
   it("keeps two color stops at the same offset", function () {
     // Stops were stored in a std::map keyed by offset, so the second stop at an
     // identical offset was silently dropped and the hard transition it encodes -- a

--- a/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
+++ b/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
@@ -51,13 +51,29 @@ describe("ColorParsing", function () {
   expect(_native.Canvas.parseColor("#12345678")).to.equal(0x78563412);
   expect(_native.Canvas.parseColor("snow")).to.equal(0xfffafaff);
   expect(_native.Canvas.parseColor("rgb(16,32,48)")).to.equal(0xff302010);
-  expect(_native.Canvas.parseColor("rgba(16,32,48,64)")).to.equal(0x40302010);
+  // Alpha is a 0-1 number (or a percentage) per CSS Color, so any value above
+  // 1 clamps to fully opaque. It is not a 0-255 channel like r/g/b.
+  expect(_native.Canvas.parseColor("rgba(16,32,48,64)")).to.equal(0xff302010);
   expect(_native.Canvas.parseColor("rgb(16,     32   ,  48   )")).to.equal(
     0xff302010
   );
   expect(
     _native.Canvas.parseColor("rgba(    16,     32   ,  48 , 64  )")
-  ).to.equal(0x40302010);
+  ).to.equal(0xff302010);
+  expect(_native.Canvas.parseColor("rgba(16,32,48,1)")).to.equal(0xff302010);
+  expect(_native.Canvas.parseColor("rgba(16,32,48,0)")).to.equal(0x00302010);
+  // Fractional and percentage alpha, whitespace-separated components and the
+  // "/ alpha" form all used to fall through to the "unable to parse" throw.
+  expect(_native.Canvas.parseColor("rgba(16,32,48,0.5)")).to.equal(0x80302010);
+  expect(_native.Canvas.parseColor("rgba(16 32 48 / 50%)")).to.equal(
+    0x80302010
+  );
+  expect(_native.Canvas.parseColor("rgb(16 32 48)")).to.equal(0xff302010);
+  expect(_native.Canvas.parseColor("rgb(100%,0%,0%)")).to.equal(0xff0000ff);
+  expect(_native.Canvas.parseColor("hsl(0,100%,50%)")).to.equal(0xff0000ff);
+  expect(_native.Canvas.parseColor("hsla(0,100%,50%,0.5)")).to.equal(
+    0x800000ff
+  );
 
   it("should throw", function () {
     function incorrectColor() {

--- a/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
+++ b/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
@@ -145,6 +145,70 @@ describe("ColorParsing", function () {
   });
 });
 
+describe("Canvas2D", function () {
+  function createContext(): any {
+    const canvas = new _native.Canvas();
+    canvas.width = 64;
+    canvas.height = 64;
+    return canvas.getContext("2d");
+  }
+
+  it("round-trips a string fillStyle and strokeStyle", function () {
+    const ctx = createContext();
+    ctx.fillStyle = "#ff0000";
+    ctx.strokeStyle = "#00ff00";
+    expect(ctx.fillStyle).to.equal("#ff0000");
+    expect(ctx.strokeStyle).to.equal("#00ff00");
+  });
+
+  it("accepts a CanvasGradient as fillStyle", function () {
+    const ctx = createContext();
+    const gradient = ctx.createLinearGradient(0, 0, 64, 64);
+    gradient.addColorStop(0, "red");
+    gradient.addColorStop(1, "blue");
+    expect(function () {
+      ctx.fillStyle = gradient;
+    }).to.not.throw();
+    expect(ctx.fillStyle).to.not.equal("#ff0000");
+  });
+
+  it("accepts a CanvasGradient as strokeStyle", function () {
+    // strokeStyle used to be string-only and threw "A string was expected",
+    // which broke every GUI control that strokes with a gradient (Line, Button border).
+    const ctx = createContext();
+    const gradient = ctx.createLinearGradient(0, 0, 64, 64);
+    gradient.addColorStop(0, "red");
+    gradient.addColorStop(1, "blue");
+    expect(function () {
+      ctx.strokeStyle = gradient;
+    }).to.not.throw();
+  });
+
+  it("accepts a radial CanvasGradient defined by two independent circles", function () {
+    const ctx = createContext();
+    // Neither concentric nor r0 == 0: both circles have to be honored.
+    const gradient = ctx.createRadialGradient(10, 10, 5, 40, 32, 30);
+    gradient.addColorStop(0, "yellow");
+    gradient.addColorStop(0.5, "pink");
+    gradient.addColorStop(1, "green");
+    expect(function () {
+      ctx.fillStyle = gradient;
+      ctx.strokeStyle = gradient;
+    }).to.not.throw();
+  });
+
+  it("restores a gradient strokeStyle across save/restore", function () {
+    const ctx = createContext();
+    const gradient = ctx.createLinearGradient(0, 0, 64, 64);
+    gradient.addColorStop(0, "red");
+    ctx.strokeStyle = "#0000ff";
+    ctx.save();
+    ctx.strokeStyle = gradient;
+    ctx.restore();
+    expect(ctx.strokeStyle).to.equal("#0000ff");
+  });
+});
+
 function createSceneAndWait(callback: (engine: NativeEngine, scene: Scene) => void, done: () => void) {
   const engine = new NativeEngine();
   const scene = new Scene(engine);

--- a/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
+++ b/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
@@ -207,6 +207,42 @@ describe("Canvas2D", function () {
     ctx.restore();
     expect(ctx.strokeStyle).to.equal("#0000ff");
   });
+
+  // The three parsers below all used to reach std::stof/std::stoi with a value the regex
+  // admits but the target type cannot hold. The resulting std::out_of_range is not a
+  // Napi::Error, so it escaped the N-API callback and terminated the host process outright
+  // rather than surfacing as a JS exception. Reaching the assertion at all is the test.
+  it("survives an out-of-range rgb() component", function () {
+    const ctx = createContext();
+    const huge = "9".repeat(400);
+    expect(function () {
+      ctx.fillStyle = `rgb(${huge}, 0, 0)`;
+    }).to.not.throw();
+    expect(function () {
+      ctx.fillStyle = `rgba(0, 0, 0, ${huge})`;
+    }).to.not.throw();
+  });
+
+  it("survives an out-of-range font size and weight", function () {
+    const ctx = createContext();
+    ctx.font = "18px Arial";
+    // The size regex accepts an exponent, so this parses but does not fit a float.
+    expect(function () {
+      ctx.font = "18e999px Arial";
+    }).to.not.throw();
+    expect(function () {
+      ctx.font = `${"9".repeat(400)} 18px Arial`;
+    }).to.not.throw();
+    // An unparseable font is ignored, so the previous one stays in effect.
+    expect(ctx.font).to.contain("18px");
+  });
+
+  it("survives an out-of-range letterSpacing", function () {
+    const ctx = createContext();
+    expect(function () {
+      ctx.letterSpacing = `${"9".repeat(400)}px`;
+    }).to.not.throw();
+  });
 });
 
 function createSceneAndWait(callback: (engine: NativeEngine, scene: Scene) => void, done: () => void) {

--- a/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
+++ b/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
@@ -1,4 +1,4 @@
-﻿import * as Mocha from "mocha";
+import * as Mocha from "mocha";
 import { expect } from "chai";
 import {
   RequestFile,
@@ -273,6 +273,55 @@ describe("Canvas2D", function () {
     expect(ctx.getLineDash()).to.deep.equal([]);
   });
 
+  it("keeps a gradient assigned to fillStyle alive across a collection", function () {
+    const ctx = createContext();
+    const global: any = Function("return this")();
+
+    // Create and assign the gradient inside a scope that keeps no reference to it, so
+    // the only thing left pointing at it is whatever fillStyle stored. CanvasGradient is
+    // an ObjectWrap, so if the style does not root the JavaScript wrapper the finalizer
+    // deletes the native gradient and the next fill dereferences freed memory.
+    (function () {
+      const gradient: any = ctx.createLinearGradient(0, 0, 64, 0);
+      gradient.addColorStop(0, "red");
+      gradient.addColorStop(1, "blue");
+      gradient.tag = "kept";
+      ctx.fillStyle = gradient;
+    })();
+
+    // Not every engine the polyfill runs on exposes a collection hook; the assertions
+    // below are worth making either way.
+    if (typeof global.CollectGarbage === "function") {
+      global.CollectGarbage();
+    }
+
+    // The getter has to hand back the object that was assigned. The expando proves it is
+    // that same JavaScript object rather than a fresh wrapper.
+    expect(ctx.fillStyle.tag).to.equal("kept");
+    // ...and the native gradient behind it has to still be there.
+    ctx.fillStyle.addColorStop(0.5, "green");
+    ctx.fillRect(0, 0, 64, 64);
+  });
+  it("keeps a gradient assigned to strokeStyle alive across a collection", function () {
+    const ctx = createContext();
+    const global: any = Function("return this")();
+
+    (function () {
+      const gradient: any = ctx.createRadialGradient(32, 32, 0, 32, 32, 32);
+      gradient.addColorStop(0, "red");
+      gradient.addColorStop(1, "blue");
+      gradient.tag = "kept";
+      ctx.strokeStyle = gradient;
+    })();
+
+    if (typeof global.CollectGarbage === "function") {
+      global.CollectGarbage();
+    }
+
+    expect(ctx.strokeStyle.tag).to.equal("kept");
+    ctx.strokeStyle.addColorStop(0.5, "green");
+    ctx.strokeRect(0, 0, 64, 64);
+  });
   it("keeps the previous dash list when the argument is not a list", function () {
     // A present-but-rejected argument skipped the parse loop and then committed the
     // empty temporary, so setLineDash("x") cleared the list where setLineDash([-1])

--- a/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
+++ b/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
@@ -255,6 +255,24 @@ describe("Canvas2D", function () {
     expect(ctx.getLineDash()).to.deep.equal([1, 2]);
   });
 
+  it("keeps the previous dash list when a new one is rejected", function () {
+    // The list was cleared before validation, so a rejected argument -- which the
+    // spec says must leave the previous list untouched -- wiped it instead.
+    const ctx = createContext();
+    ctx.setLineDash([5, 10]);
+    ctx.setLineDash([-1]);
+    expect(ctx.getLineDash()).to.deep.equal([5, 10]);
+    ctx.setLineDash([2, "x"]);
+    expect(ctx.getLineDash()).to.deep.equal([5, 10]);
+    ctx.setLineDash([Number.NaN]);
+    expect(ctx.getLineDash()).to.deep.equal([5, 10]);
+    // A valid list still replaces it, and an empty list still means "solid".
+    ctx.setLineDash([3, 4]);
+    expect(ctx.getLineDash()).to.deep.equal([3, 4]);
+    ctx.setLineDash([]);
+    expect(ctx.getLineDash()).to.deep.equal([]);
+  });
+
   it("keeps two color stops at the same offset", function () {
     // Stops were stored in a std::map keyed by offset, so the second stop at an
     // identical offset was silently dropped and the hard transition it encodes -- a

--- a/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
+++ b/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
@@ -273,10 +273,69 @@ describe("Canvas2D", function () {
     expect(ctx.getLineDash()).to.deep.equal([]);
   });
 
-  it("keeps two color stops at the same offset", function () {
-    // Stops were stored in a std::map keyed by offset, so the second stop at an
-    // identical offset was silently dropped and the hard transition it encodes -- a
-    // stripe pattern, for instance -- came out as a smooth fade instead.
+  it("keeps the previous dash list when the argument is not a list", function () {
+    // A present-but-rejected argument skipped the parse loop and then committed the
+    // empty temporary, so setLineDash("x") cleared the list where setLineDash([-1])
+    // correctly kept it. An absent argument still means "solid".
+    const ctx = createContext();
+    ctx.setLineDash([5, 10]);
+    ctx.setLineDash("x" as any);
+    expect(ctx.getLineDash()).to.deep.equal([5, 10]);
+    ctx.setLineDash(null as any);
+    expect(ctx.getLineDash()).to.deep.equal([5, 10]);
+    ctx.setLineDash(7 as any);
+    expect(ctx.getLineDash()).to.deep.equal([5, 10]);
+    (ctx.setLineDash as any)();
+    expect(ctx.getLineDash()).to.deep.equal([]);
+  });
+
+  it("restores font", function () {
+    // font was the one exposed attribute left out of the saved state. It is worse than
+    // the getter-only cases: the font id resolved here is what the text draw path binds,
+    // so the wrong face actually rendered after a restore().
+    const ctx = createContext();
+    ctx.font = "18px Arial";
+    // The getter reports a normalized serialization, so compare against the round-tripped
+    // value rather than the literal that was assigned.
+    const saved = ctx.font;
+    ctx.save();
+    ctx.font = "40px Times";
+    expect(ctx.font).to.not.equal(saved);
+    ctx.restore();
+    expect(ctx.font).to.equal(saved);
+    expect(function () {
+      ctx.fillText("after restore", 0, 20);
+    }).to.not.throw();
+  });
+
+  it("ignores a fillStyle or strokeStyle that is neither a color string nor a gradient", function () {
+    // Both setters reached napi_unwrap for any object, so `ctx.strokeStyle = {}` unwrapped
+    // an object that was never wrapped and dereferenced whatever the slot held. Per spec
+    // an unusable value leaves the attribute unchanged.
+    const ctx = createContext();
+    ctx.fillStyle = "#ff0000";
+    ctx.strokeStyle = "#00ff00";
+    expect(function () {
+      ctx.fillStyle = {} as any;
+      ctx.strokeStyle = {} as any;
+      ctx.fillStyle = [] as any;
+      ctx.strokeStyle = (function () {}) as any;
+    }).to.not.throw();
+    expect(ctx.fillStyle).to.equal("#ff0000");
+    expect(ctx.strokeStyle).to.equal("#00ff00");
+    // A real gradient is still accepted.
+    const gradient = ctx.createLinearGradient(0, 0, 64, 0);
+    gradient.addColorStop(0, "red");
+    gradient.addColorStop(1, "blue");
+    ctx.fillStyle = gradient;
+    expect(ctx.fillStyle).to.not.equal("#ff0000");
+  });
+
+  it("accepts two color stops at the same offset", function () {
+    // Only checks that the insertion path accepts the duplicate offset the spec allows;
+    // std::map::insert() dropped it by returning {it, false} rather than throwing, so this
+    // does not by itself prove the stop survives. Asserting that needs the rendered ramp,
+    // and gradient fills are not read back by getImageData.
     const ctx = createContext();
     const gradient = ctx.createLinearGradient(0, 0, 64, 0);
     gradient.addColorStop(0, "red");

--- a/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
+++ b/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
@@ -208,6 +208,69 @@ describe("Canvas2D", function () {
     expect(ctx.strokeStyle).to.equal("#0000ff");
   });
 
+  it("restores the shadow attributes across save/restore", function () {
+    // These have no nanovg counterpart, so nvgRestore() never rewound them and a
+    // value assigned after save() survived restore().
+    const ctx = createContext();
+    ctx.shadowColor = "#00ff00";
+    ctx.shadowBlur = 1;
+    ctx.shadowOffsetX = 2;
+    ctx.shadowOffsetY = 3;
+    ctx.save();
+    ctx.shadowColor = "#ff0000";
+    ctx.shadowBlur = 40;
+    ctx.shadowOffsetX = 50;
+    ctx.shadowOffsetY = 60;
+    ctx.restore();
+    expect(ctx.shadowColor).to.equal("#00ff00");
+    expect(ctx.shadowBlur).to.equal(1);
+    expect(ctx.shadowOffsetX).to.equal(2);
+    expect(ctx.shadowOffsetY).to.equal(3);
+  });
+
+  it("restores the remaining drawing state across save/restore", function () {
+    // nvgRestore() rewinds nanovg's copy of these, but the wrapper kept its own
+    // mirror, so the getters reported the post-save() value forever after.
+    // globalAlpha is set but not asserted: it is declared write-only (nullptr
+    // getter), so it has no observable value to check.
+    const ctx = createContext();
+    ctx.lineWidth = 1;
+    ctx.globalAlpha = 1;
+    ctx.lineCap = "butt";
+    ctx.lineJoin = "miter";
+    ctx.miterLimit = 10;
+    ctx.setLineDash([1, 2]);
+    ctx.save();
+    ctx.lineWidth = 9;
+    ctx.globalAlpha = 0.25;
+    ctx.lineCap = "round";
+    ctx.lineJoin = "bevel";
+    ctx.miterLimit = 3;
+    ctx.setLineDash([7, 8, 9]);
+    ctx.restore();
+    expect(ctx.lineWidth).to.equal(1);
+    expect(ctx.lineCap).to.equal("butt");
+    expect(ctx.lineJoin).to.equal("miter");
+    expect(ctx.miterLimit).to.equal(10);
+    expect(ctx.getLineDash()).to.deep.equal([1, 2]);
+  });
+
+  it("keeps two color stops at the same offset", function () {
+    // Stops were stored in a std::map keyed by offset, so the second stop at an
+    // identical offset was silently dropped and the hard transition it encodes -- a
+    // stripe pattern, for instance -- came out as a smooth fade instead.
+    const ctx = createContext();
+    const gradient = ctx.createLinearGradient(0, 0, 64, 0);
+    gradient.addColorStop(0, "red");
+    gradient.addColorStop(0.5, "red");
+    gradient.addColorStop(0.5, "blue");
+    gradient.addColorStop(1, "blue");
+    expect(function () {
+      ctx.fillStyle = gradient;
+      ctx.fillRect(0, 0, 64, 64);
+    }).to.not.throw();
+  });
+
   // The three parsers below all used to reach std::stof/std::stoi with a value the regex
   // admits but the target type cannot hold. The resulting std::out_of_range is not a
   // Napi::Error, so it escaped the N-API callback and terminated the host process outright

--- a/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
+++ b/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
@@ -432,6 +432,32 @@ describe("Canvas2D", function () {
       ctx.letterSpacing = `${"9".repeat(400)}px`;
     }).to.not.throw();
   });
+
+  it("rejects a createImageData source whose dimensions are not valid extents", function () {
+    const ctx = createContext();
+    // The ImageData overload is duck-typed, so these never went through WebIDL's
+    // unsigned long conversion. A negative width used to wrap to 4294967295 and ask
+    // for a ~17 GB allocation instead of being rejected.
+    const bad = [
+      { width: -1, height: 1 },
+      { width: 1, height: -1 },
+      { width: 1.5, height: 1 },
+      { width: 5e9, height: 1 },
+      { width: Infinity, height: 1 },
+    ];
+    bad.forEach(function (source) {
+      expect(function () {
+        ctx.createImageData(source);
+      }, JSON.stringify(source)).to.throw();
+    });
+  });
+
+  it("creates image data from a valid source object", function () {
+    const ctx = createContext();
+    const data = ctx.createImageData({ width: 4, height: 3 });
+    expect(data.width).to.equal(4);
+    expect(data.height).to.equal(3);
+  });
 });
 
 function createSceneAndWait(callback: (engine: NativeEngine, scene: Scene) => void, done: () => void) {

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include "Colors.h"
 #include "Gradient.h"
+#include "Font.h"
 
 namespace
 {
@@ -63,15 +64,17 @@ namespace Babylon::Polyfills::Internal
 
     void NativeCanvas::LoadTTF(const Napi::CallbackInfo& info)
     {
+        if (info.Length() < 1 || !info[0].IsString())
+        {
+            throw Napi::TypeError::New(info.Env(), "Canvas.loadTTF expects the font name as a string in argument 1.");
+        }
+
         // don't allow same font to be loaded more than once
         // why? because Context doesn't update nvgCreateFontMem when old fontBuffer released
         auto fontName = info[0].As<Napi::String>().Utf8Value();
         if (fontsInfos.find(fontName) == fontsInfos.end())
         {
-            const auto buffer = info[1].As<Napi::ArrayBuffer>();
-            std::vector<uint8_t> fontBuffer(buffer.ByteLength());
-            memcpy(fontBuffer.data(), (uint8_t*)buffer.Data(), buffer.ByteLength());
-            fontsInfos[fontName] = std::move(fontBuffer);
+            fontsInfos[fontName] = GetFontDataArgument(info, 1, "Canvas.loadTTF");
         }
     }
 

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -64,9 +64,14 @@ namespace Babylon::Polyfills::Internal
 
     void NativeCanvas::LoadTTF(const Napi::CallbackInfo& info)
     {
+        LoadTTFCore(info, "Canvas.loadTTF");
+    }
+
+    void NativeCanvas::LoadTTFCore(const Napi::CallbackInfo& info, const char* methodName)
+    {
         if (info.Length() < 1 || !info[0].IsString())
         {
-            throw Napi::TypeError::New(info.Env(), "Canvas.loadTTF expects the font name as a string in argument 1.");
+            throw Napi::TypeError::New(info.Env(), std::string{methodName} + " expects the font name as a string in argument 1.");
         }
 
         // don't allow same font to be loaded more than once
@@ -74,14 +79,14 @@ namespace Babylon::Polyfills::Internal
         auto fontName = info[0].As<Napi::String>().Utf8Value();
         if (fontsInfos.find(fontName) == fontsInfos.end())
         {
-            fontsInfos[fontName] = GetFontDataArgument(info, 1, "Canvas.loadTTF");
+            fontsInfos[fontName] = GetFontDataArgument(info, 1, methodName);
         }
     }
 
     // @deprecated: LoadTTFAsync is always synchronous, use LoadTTF instead
     Napi::Value NativeCanvas::LoadTTFAsync(const Napi::CallbackInfo& info)
     {
-        LoadTTF(info);
+        LoadTTFCore(info, "Canvas.loadTTFAsync");
 
         auto deferred{Napi::Promise::Deferred::New(info.Env())};
         deferred.Resolve(info.Env().Undefined());

--- a/Polyfills/Canvas/Source/Canvas.h
+++ b/Polyfills/Canvas/Source/Canvas.h
@@ -94,6 +94,9 @@ namespace Babylon::Polyfills::Internal
         Napi::Value GetCanvasTexture(const Napi::CallbackInfo& info);
         static void LoadTTF(const Napi::CallbackInfo& info);
         static Napi::Value LoadTTFAsync(const Napi::CallbackInfo& info);
+        // Both entry points share this; each passes its own name so the diagnostics name the
+        // method the caller actually invoked rather than the one it happens to delegate to.
+        static void LoadTTFCore(const Napi::CallbackInfo& info, const char* methodName);
         static Napi::Value ParseColor(const Napi::CallbackInfo& info);
         void Remove(const Napi::CallbackInfo& info);
         void Dispose(const Napi::CallbackInfo& info);

--- a/Polyfills/Canvas/Source/Colors.h
+++ b/Polyfills/Canvas/Source/Colors.h
@@ -1,5 +1,8 @@
 #pragma once
 #include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
 #include <regex>
 #include <string>
 #include "nanovg/nanovg.h"
@@ -227,17 +230,34 @@ namespace Babylon::Polyfills::Internal
 
             // Component group indices: value/percent pairs at 1-2, 3-4, 5-6 and
             // the optional alpha at 7-8.
-            const auto channel = [](const std::smatch& match, size_t index) {
-                const float value = std::stof(match[index]);
+            //
+            // Parsed with strtof rather than std::stof: the regex above accepts a digit string of
+            // any length, and std::stof throws std::out_of_range for one that does not fit a
+            // float. That exception is not a Napi::Error, so it would escape this callback and
+            // terminate the host instead of producing a color. strtof cannot throw -- it
+            // saturates to +/-HUGE_VALF on overflow and returns zero on underflow -- and the
+            // infinities are folded back to finite extremes so the clamps below stay well
+            // defined (fmodf of an infinity, which nvgHSLA does to the hue, would be NaN).
+            const auto toFloat = [](const std::ssub_match& match) {
+                const std::string text{match.str()};
+                const float value = std::strtof(text.c_str(), nullptr);
+                if (std::isfinite(value))
+                {
+                    return value;
+                }
+                return value < 0.0f ? std::numeric_limits<float>::lowest() : std::numeric_limits<float>::max();
+            };
+            const auto channel = [&toFloat](const std::smatch& match, size_t index) {
+                const float value = toFloat(match[index]);
                 const float scaled = match[index + 1].matched && match[index + 1].length() > 0 ? value * 255.0f / 100.0f : value;
                 return static_cast<unsigned char>(std::clamp(scaled, 0.0f, 255.0f) + 0.5f);
             };
-            const auto alpha = [](const std::smatch& match, size_t index) {
+            const auto alpha = [&toFloat](const std::smatch& match, size_t index) {
                 if (!match[index].matched)
                 {
                     return static_cast<unsigned char>(255);
                 }
-                const float value = std::stof(match[index]);
+                const float value = toFloat(match[index]);
                 const float normalized = match[index + 1].matched && match[index + 1].length() > 0 ? value / 100.0f : value;
                 return static_cast<unsigned char>(std::clamp(normalized, 0.0f, 1.0f) * 255.0f + 0.5f);
             };
@@ -257,9 +277,9 @@ namespace Babylon::Polyfills::Internal
                 // Hue is an angle in degrees; nvgHSLA wraps it internally but
                 // expects turns. Saturation and lightness are percentages
                 // whether or not the '%' is spelled out.
-                const float hue = std::stof(hslMatch[1]) / 360.0f;
-                const float saturation = std::clamp(std::stof(hslMatch[3]) / 100.0f, 0.0f, 1.0f);
-                const float lightness = std::clamp(std::stof(hslMatch[5]) / 100.0f, 0.0f, 1.0f);
+                const float hue = toFloat(hslMatch[1]) / 360.0f;
+                const float saturation = std::clamp(toFloat(hslMatch[3]) / 100.0f, 0.0f, 1.0f);
+                const float lightness = std::clamp(toFloat(hslMatch[5]) / 100.0f, 0.0f, 1.0f);
                 return nvgHSLA(hue, saturation, lightness, alpha(hslMatch, 7));
             }
         }

--- a/Polyfills/Canvas/Source/Colors.h
+++ b/Polyfills/Canvas/Source/Colors.h
@@ -1,5 +1,7 @@
 #pragma once
+#include <algorithm>
 #include <regex>
+#include <string>
 #include "nanovg/nanovg.h"
 
 namespace Babylon::Polyfills::Internal
@@ -211,22 +213,54 @@ namespace Babylon::Polyfills::Internal
                 return nvgRGBA((color >> 16), (color >> 8) & 0xFF, (color & 0xFF), 0xFF);
             }
 
-            // matches strings of the form rgb(#,#,#) or rgba(#,#,#,#)
-            static const std::regex rgbRegex("rgba?\\(\\s*(-?\\d{1,3})\\s*,\\s*(-?\\d{1,3})\\s*,\\s*(-?\\d{1,3})\\s*(?:,\\s*(-?\\d{1,3}))?\\s*\\)");
+            // CSS colour functions. The components are matched as generic CSS
+            // numbers with an optional '%' suffix rather than as 1-3 digit
+            // integers: the old integer-only pattern silently failed to match
+            // any fractional value, so a perfectly ordinary rgba(0, 0, 0, 0.5)
+            // fell through to the "Unable to parse color" throw.
+            static const std::string number{R"((-?(?:\d+(?:\.\d*)?|\.\d+))(%?))"};
+            static const std::string separator{R"((?:\s*,\s*|\s+))"};
+            static const std::string alphaSeparator{R"((?:\s*,\s*|\s*/\s*))"};
+            static const std::string components{
+                R"(\(\s*)" + number + separator + number + separator + number +
+                "(?:" + alphaSeparator + number + R"()?\s*\))"};
+
+            // Component group indices: value/percent pairs at 1-2, 3-4, 5-6 and
+            // the optional alpha at 7-8.
+            const auto channel = [](const std::smatch& match, size_t index) {
+                const float value = std::stof(match[index]);
+                const float scaled = match[index + 1].matched && match[index + 1].length() > 0 ? value * 255.0f / 100.0f : value;
+                return static_cast<unsigned char>(std::clamp(scaled, 0.0f, 255.0f) + 0.5f);
+            };
+            const auto alpha = [](const std::smatch& match, size_t index) {
+                if (!match[index].matched)
+                {
+                    return static_cast<unsigned char>(255);
+                }
+                const float value = std::stof(match[index]);
+                const float normalized = match[index + 1].matched && match[index + 1].length() > 0 ? value / 100.0f : value;
+                return static_cast<unsigned char>(std::clamp(normalized, 0.0f, 1.0f) * 255.0f + 0.5f);
+            };
+
+            static const std::regex rgbRegex("rgba?" + components);
             std::smatch rgbMatch;
             if (std::regex_match(str, rgbMatch, rgbRegex))
             {
-                if (rgbMatch.size() == 5)
-                {
-                    if (rgbMatch[4].matched)
-                    {
-                        return nvgRGBA(std::clamp(std::stoi(rgbMatch[1]), 0, 255), std::clamp(std::stoi(rgbMatch[2]), 0, 255), std::clamp(std::stoi(rgbMatch[3]), 0, 255), std::clamp(std::stoi(rgbMatch[4]), 0, 255));
-                    }
-                    else
-                    {
-                        return nvgRGB(std::clamp(std::stoi(rgbMatch[1]), 0, 255), std::clamp(std::stoi(rgbMatch[2]), 0, 255), std::clamp(std::stoi(rgbMatch[3]), 0, 255));
-                    }
-                }
+                return nvgRGBA(channel(rgbMatch, 1), channel(rgbMatch, 3), channel(rgbMatch, 5), alpha(rgbMatch, 7));
+            }
+
+            // hsl()/hsla(). Babylon GUI's ColorPicker emits these.
+            static const std::regex hslRegex("hsla?" + components);
+            std::smatch hslMatch;
+            if (std::regex_match(str, hslMatch, hslRegex))
+            {
+                // Hue is an angle in degrees; nvgHSLA wraps it internally but
+                // expects turns. Saturation and lightness are percentages
+                // whether or not the '%' is spelled out.
+                const float hue = std::stof(hslMatch[1]) / 360.0f;
+                const float saturation = std::clamp(std::stof(hslMatch[3]) / 100.0f, 0.0f, 1.0f);
+                const float lightness = std::clamp(std::stof(hslMatch[5]) / 100.0f, 0.0f, 1.0f);
+                return nvgHSLA(hue, saturation, lightness, alpha(hslMatch, 7));
             }
         }
         throw Napi::Error::New(env, std::string{"Unable to parse color: "} + str);

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -890,10 +890,14 @@ namespace Babylon::Polyfills::Internal
 
         // The dirty rectangle is optional and, per spec, may be given with
         // negative extents, which flips it rather than drawing nothing.
-        int32_t dirtyX{0};
-        int32_t dirtyY{0};
-        int32_t dirtyWidth{srcWidthInt};
-        int32_t dirtyHeight{srcHeightInt};
+        // Normalized in int64_t: the values arrive from JS as arbitrary int32s, and negating
+        // INT32_MIN or adding two INT32_MINs together is signed overflow (undefined behavior).
+        // Every input fits comfortably in int64_t, and the result is clipped to the source
+        // bitmap below, so the values are back in int32 range before they are used.
+        int64_t dirtyX{0};
+        int64_t dirtyY{0};
+        int64_t dirtyWidth{srcWidthInt};
+        int64_t dirtyHeight{srcHeightInt};
         if (info.Length() >= 7)
         {
             dirtyX = info[3].ToNumber().Int32Value();
@@ -914,10 +918,10 @@ namespace Babylon::Polyfills::Internal
         }
 
         // Clip the dirty rectangle to the source bitmap.
-        int32_t x0 = std::max(0, dirtyX);
-        int32_t y0 = std::max(0, dirtyY);
-        int32_t x1 = std::min(srcWidthInt, dirtyX + dirtyWidth);
-        int32_t y1 = std::min(srcHeightInt, dirtyY + dirtyHeight);
+        const int64_t x0 = std::max<int64_t>(0, dirtyX);
+        const int64_t y0 = std::max<int64_t>(0, dirtyY);
+        const int64_t x1 = std::min<int64_t>(srcWidthInt, dirtyX + dirtyWidth);
+        const int64_t y1 = std::min<int64_t>(srcHeightInt, dirtyY + dirtyHeight);
         if (x1 <= x0 || y1 <= y0)
         {
             return;
@@ -933,12 +937,21 @@ namespace Babylon::Polyfills::Internal
         {
             std::memcpy(
                 patch.data() + static_cast<size_t>(row) * copyWidth * 4u,
-                srcPixels + (static_cast<size_t>(y0 + row) * srcWidth + x0) * 4u,
+                srcPixels + (static_cast<size_t>(y0 + row) * srcWidth + static_cast<size_t>(x0)) * 4u,
                 static_cast<size_t>(copyWidth) * 4u);
         }
 
-        const auto destX = static_cast<float>(dx + x0);
-        const auto destY = static_cast<float>(dy + y0);
+        // dx/dy are arbitrary int32s from JS, so offsetting them by the clipped origin is done in
+        // int64_t and saturated back. Anything that saturates is far enough off-canvas that it
+        // clips to nothing downstream regardless.
+        const auto toInt32 = [](int64_t value) {
+            return static_cast<int32_t>(std::clamp<int64_t>(value, std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max()));
+        };
+        const int32_t destLeft = toInt32(static_cast<int64_t>(dx) + x0);
+        const int32_t destTop = toInt32(static_cast<int64_t>(dy) + y0);
+
+        const auto destX = static_cast<float>(destLeft);
+        const auto destY = static_cast<float>(destTop);
         const auto destWidth = static_cast<float>(copyWidth);
         const auto destHeight = static_cast<float>(copyHeight);
 
@@ -967,7 +980,7 @@ namespace Babylon::Polyfills::Internal
 
         // Keep the CPU mirror that getImageData() reads from in sync.
         BlitPixelsToCpu(patch.data(), copyWidth, copyHeight, 0, 0, copyWidth, copyHeight,
-            dx + x0, dy + y0, copyWidth, copyHeight);
+            destLeft, destTop, copyWidth, copyHeight);
 
         // The path now holds just this rect, so clear the non-rect flag: a stale `true` left over
         // from an earlier arc/curve would make a subsequent clip() take the emulated path branch.
@@ -1686,7 +1699,15 @@ namespace Babylon::Polyfills::Internal
         std::smatch letterSpacingMatch;
         if (std::regex_match(letterSpacingOption, letterSpacingMatch, letterSpacingRegex))
         {
-            m_letterSpacing = std::stof(letterSpacingMatch[1]);
+            // std::stof throws a fatal std::out_of_range for a digit run too long for a float,
+            // and the regex bounds neither the length nor the magnitude. strtof cannot throw;
+            // ignore a non-finite result rather than handing it to nanovg.
+            const std::string letterSpacingText{letterSpacingMatch[1].str()};
+            const float letterSpacing = std::strtof(letterSpacingText.c_str(), nullptr);
+            if (std::isfinite(letterSpacing))
+            {
+                m_letterSpacing = letterSpacing;
+            }
         }
         nvgTextLetterSpacing(*m_nvg, m_letterSpacing);
     }

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -178,6 +178,28 @@ namespace Babylon::Polyfills::Internal
         }
     }
 
+    void Context::BindStrokeStyle(const Napi::CallbackInfo& info)
+    {
+        if (std::holds_alternative<std::string>(m_strokeStyle))
+        {
+            const auto& str = std::get<std::string>(m_strokeStyle);
+            // Treat unset/empty strokeStyle as opaque black -- both the Canvas2D default
+            // ("#000000") and nvg's default stroke color -- instead of the transparent black
+            // StringToColor("") would return.
+            const auto color = str.empty() ? nvgRGBA(0, 0, 0, 255) : StringToColor(info.Env(), str);
+            nvgStrokeColor(*m_nvg, color);
+        }
+        else if (std::holds_alternative<CanvasGradient*>(m_strokeStyle))
+        {
+            CanvasGradient* gradient = std::get<CanvasGradient*>(m_strokeStyle);
+            nvgStrokePaint(*m_nvg, gradient->Paint());
+        }
+        else
+        {
+            throw Napi::Error::New(info.Env(), "Strokestyle is not a color string or a gradient.");
+        }
+    }
+
     void Context::SetFilterStack()
     {
         if (m_filter.length())
@@ -242,14 +264,37 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value Context::GetStrokeStyle(const Napi::CallbackInfo&)
     {
-        return Napi::Value::From(Env(), m_strokeStyle);
+        if (std::holds_alternative<std::string>(m_strokeStyle))
+        {
+            return Napi::Value::From(Env(), std::get<std::string>(m_strokeStyle));
+        }
+        else
+        {
+            return Napi::External<CanvasGradient>::New(Env(), std::get<CanvasGradient*>(m_strokeStyle));
+        }
     }
 
     void Context::SetStrokeStyle(const Napi::CallbackInfo& info, const Napi::Value& value)
     {
-        m_strokeStyle = value.As<Napi::String>().Utf8Value();
-        auto color = StringToColor(info.Env(), m_strokeStyle);
-        nvgStrokeColor(*m_nvg, color);
+        // strokeStyle accepts a CanvasGradient just like fillStyle does; GUI controls such as
+        // Line and the border of a Button assign one directly.
+        if (value.IsString())
+        {
+            auto string = value.As<Napi::String>().Utf8Value();
+            const auto color = StringToColor(info.Env(), string);
+            m_strokeStyle = string;
+            nvgStrokeColor(*m_nvg, color);
+        }
+        else if (value.IsObject())
+        {
+            CanvasGradient* canvasGradient = CanvasGradient::Unwrap(value.As<Napi::Object>());
+            m_strokeStyle = canvasGradient;
+        }
+        else
+        {
+            // Per spec, assigning anything that is neither a color string nor a
+            // gradient/pattern leaves strokeStyle unchanged.
+        }
     }
 
     Napi::Value Context::GetLineWidth(const Napi::CallbackInfo&)
@@ -277,6 +322,11 @@ namespace Babylon::Polyfills::Internal
         {
             PlayPath2D(path);
         }
+
+        // Bind the current fillStyle here rather than relying on the nvg state SetFillStyle
+        // leaves behind: assigning a gradient only records the pointer (the paint has to be
+        // rebuilt per draw), and nvgRestore can pop a color set after the last assignment.
+        BindFillStyle(info);
 
         nvgFill(*m_nvg);
     }
@@ -466,6 +516,7 @@ namespace Babylon::Polyfills::Internal
         const auto height = info[3].As<Napi::Number>().FloatValue();
 
         nvgRect(*m_nvg, left, top, width, height);
+        BindStrokeStyle(info);
         SetFilterStack();
         nvgStroke(*m_nvg);
     }
@@ -556,6 +607,7 @@ namespace Babylon::Polyfills::Internal
             PlayPath2D(path);
         }
 
+        BindStrokeStyle(info);
         SetFilterStack();
         nvgStroke(*m_nvg);
     }
@@ -1433,6 +1485,7 @@ namespace Babylon::Polyfills::Internal
 
         if (SetFontFaceId())
         {
+            BindStrokeStyle(info);
             nvgStrokeText(*m_nvg, x, y, text.c_str(), nullptr);
         }
     }

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -2,6 +2,8 @@
 #include <map>
 #include <algorithm>
 #include <cassert>
+#include <cmath>
+#include <cstdio>
 #include <cstring>
 #include <limits>
 #include <optional>
@@ -74,6 +76,7 @@ namespace Babylon::Polyfills::Internal
                 InstanceMethod("getImageData", &Context::GetImageData),
                 InstanceMethod("createImageData", &Context::CreateImageData),
                 InstanceMethod("setLineDash", &Context::SetLineDash),
+                InstanceMethod("getLineDash", &Context::GetLineDash),
                 InstanceMethod("fillText", &Context::FillText),
                 InstanceMethod("strokeText", &Context::StrokeText),
                 InstanceMethod("createLinearGradient", &Context::CreateLinearGradient),
@@ -786,9 +789,137 @@ namespace Babylon::Polyfills::Internal
         }
     }
 
-    void Context::PutImageData(const Napi::CallbackInfo&)
+    void Context::PutImageData(const Napi::CallbackInfo& info)
     {
-        throw std::runtime_error{"Context2D.putImageData: not implemented"};
+        Napi::Env env = info.Env();
+
+        if (info.Length() < 3 || !info[0].IsObject())
+        {
+            throw Napi::TypeError::New(env, "Context2D.putImageData requires at least 3 arguments (imageData, dx, dy).");
+        }
+
+        // Read width/height/data as ordinary properties rather than unwrapping an ImageData:
+        // napi_unwrap on an object that was never wrapped dereferences garbage, and callers
+        // legitimately pass plain {data,width,height} objects.
+        Napi::Object imageData = info[0].As<Napi::Object>();
+        Napi::Value dataValue = imageData.Get("data");
+        if (!dataValue.IsTypedArray())
+        {
+            throw Napi::TypeError::New(env, "Context2D.putImageData: the first argument is not an ImageData.");
+        }
+
+        const auto widthValue = imageData.Get("width");
+        const auto heightValue = imageData.Get("height");
+        if (!widthValue.IsNumber() || !heightValue.IsNumber())
+        {
+            throw Napi::TypeError::New(env, "Context2D.putImageData: the first argument is not an ImageData (missing numeric 'width'/'height').");
+        }
+
+        const auto srcWidthInt = widthValue.As<Napi::Number>().Int32Value();
+        const auto srcHeightInt = heightValue.As<Napi::Number>().Int32Value();
+        if (srcWidthInt <= 0 || srcHeightInt <= 0)
+        {
+            return;
+        }
+
+        const auto srcWidth = static_cast<uint32_t>(srcWidthInt);
+        const auto srcHeight = static_cast<uint32_t>(srcHeightInt);
+
+        const auto typedArray = dataValue.As<Napi::TypedArray>();
+        const uint64_t requiredBytes = static_cast<uint64_t>(srcWidth) * srcHeight * 4u;
+        if (typedArray.ByteLength() < requiredBytes)
+        {
+            throw Napi::TypeError::New(env, "Context2D.putImageData: the ImageData buffer is smaller than width*height*4.");
+        }
+        const auto* srcPixels = static_cast<const uint8_t*>(typedArray.ArrayBuffer().Data()) + typedArray.ByteOffset();
+
+        const auto dx = info[1].ToNumber().Int32Value();
+        const auto dy = info[2].ToNumber().Int32Value();
+
+        // The dirty rectangle is optional and, per spec, may be given with
+        // negative extents, which flips it rather than drawing nothing.
+        int32_t dirtyX{0};
+        int32_t dirtyY{0};
+        int32_t dirtyWidth{srcWidthInt};
+        int32_t dirtyHeight{srcHeightInt};
+        if (info.Length() >= 7)
+        {
+            dirtyX = info[3].ToNumber().Int32Value();
+            dirtyY = info[4].ToNumber().Int32Value();
+            dirtyWidth = info[5].ToNumber().Int32Value();
+            dirtyHeight = info[6].ToNumber().Int32Value();
+
+            if (dirtyWidth < 0)
+            {
+                dirtyX += dirtyWidth;
+                dirtyWidth = -dirtyWidth;
+            }
+            if (dirtyHeight < 0)
+            {
+                dirtyY += dirtyHeight;
+                dirtyHeight = -dirtyHeight;
+            }
+        }
+
+        // Clip the dirty rectangle to the source bitmap.
+        int32_t x0 = std::max(0, dirtyX);
+        int32_t y0 = std::max(0, dirtyY);
+        int32_t x1 = std::min(srcWidthInt, dirtyX + dirtyWidth);
+        int32_t y1 = std::min(srcHeightInt, dirtyY + dirtyHeight);
+        if (x1 <= x0 || y1 <= y0)
+        {
+            return;
+        }
+
+        const auto copyWidth = static_cast<uint32_t>(x1 - x0);
+        const auto copyHeight = static_cast<uint32_t>(y1 - y0);
+
+        // nvgImagePattern needs a tightly packed image, so extract the dirty
+        // sub-rectangle into its own buffer.
+        std::vector<uint8_t> patch(static_cast<size_t>(copyWidth) * copyHeight * 4u);
+        for (uint32_t row = 0; row < copyHeight; ++row)
+        {
+            std::memcpy(
+                patch.data() + static_cast<size_t>(row) * copyWidth * 4u,
+                srcPixels + (static_cast<size_t>(y0 + row) * srcWidth + x0) * 4u,
+                static_cast<size_t>(copyWidth) * 4u);
+        }
+
+        const auto destX = static_cast<float>(dx + x0);
+        const auto destY = static_cast<float>(dy + y0);
+        const auto destWidth = static_cast<float>(copyWidth);
+        const auto destHeight = static_cast<float>(copyHeight);
+
+        const int imageIndex = nvgCreateImageRGBA(*m_nvg, static_cast<int>(copyWidth), static_cast<int>(copyHeight), 0, patch.data());
+        if (imageIndex == 0)
+        {
+            throw Napi::Error::New(env, "Context2D.putImageData: failed to create the source image.");
+        }
+
+        // putImageData bypasses the transform, the clip region, globalAlpha and
+        // the composite operation, and replaces the destination pixels outright.
+        // nvgReset() clears exactly that state, and NVG_COPY gives the required
+        // replace (rather than blend) semantics.
+        nvgSave(*m_nvg);
+        nvgReset(*m_nvg);
+        nvgGlobalCompositeOperation(*m_nvg, NVG_COPY);
+
+        NVGpaint imagePaint = nvgImagePattern(*m_nvg, destX, destY, destWidth, destHeight, 0.f, imageIndex, 1.f);
+        nvgBeginPath(*m_nvg);
+        nvgRect(*m_nvg, destX, destY, destWidth, destHeight);
+        nvgFillPaint(*m_nvg, imagePaint);
+        nvgFill(*m_nvg);
+
+        nvgRestore(*m_nvg);
+        nvgDeleteImage(*m_nvg, imageIndex);
+
+        // Keep the CPU mirror that getImageData() reads from in sync.
+        BlitPixelsToCpu(patch.data(), copyWidth, copyHeight, 0, 0, copyWidth, copyHeight,
+            dx + x0, dy + y0, copyWidth, copyHeight);
+
+        // The path now holds just this rect, so clear the non-rect flag: a stale `true` left over
+        // from an earlier arc/curve would make a subsequent clip() take the emulated path branch.
+        m_pathHasNonRect = false;
     }
 
     void Context::Arc(const Napi::CallbackInfo& info)
@@ -1230,7 +1361,63 @@ namespace Babylon::Polyfills::Internal
 
     void Context::SetLineDash(const Napi::CallbackInfo& info)
     {
-        throw Napi::Error::New(info.Env(), "Context2D.setLineDash: not implemented");
+        // An empty (or absent) dash list means "solid", which is exactly what we
+        // already draw -- so accept it silently. Babylon GUI's Line and MultiLine
+        // controls call setLineDash(this._dash) unconditionally on every render,
+        // and _dash defaults to [], so throwing here aborted any scene containing
+        // a GUI line even though nothing was actually being asked for.
+        //
+        // A non-empty pattern we genuinely cannot honor: nanovg has no dashed
+        // stroke, and emulating one means splitting every path into segments.
+        // Draw solid and warn once rather than failing the whole scene, and keep
+        // the list so getLineDash() round-trips as the spec requires.
+        m_lineDash.clear();
+
+        if (info.Length() > 0 && info[0].IsArray())
+        {
+            const auto segments = info[0].As<Napi::Array>();
+            for (uint32_t index = 0; index < segments.Length(); ++index)
+            {
+                const auto segment = segments.Get(index);
+                if (!segment.IsNumber())
+                {
+                    // Per spec, a list containing a non-finite or negative value
+                    // is ignored entirely and the previous list is retained; a
+                    // non-numeric entry cannot be interpreted, so ignore it too.
+                    m_lineDash.clear();
+                    return;
+                }
+
+                const double value = segment.As<Napi::Number>().DoubleValue();
+                if (!std::isfinite(value) || value < 0.0)
+                {
+                    m_lineDash.clear();
+                    return;
+                }
+
+                m_lineDash.push_back(value);
+            }
+        }
+
+        if (!m_lineDash.empty())
+        {
+            static bool warned = false;
+            if (!warned)
+            {
+                warned = true;
+                fprintf(stderr, "Context2D.setLineDash: dashed strokes are not supported; drawing solid.\n");
+            }
+        }
+    }
+
+    Napi::Value Context::GetLineDash(const Napi::CallbackInfo& info)
+    {
+        auto segments = Napi::Array::New(info.Env(), m_lineDash.size());
+        for (size_t index = 0; index < m_lineDash.size(); ++index)
+        {
+            segments.Set(static_cast<uint32_t>(index), Napi::Number::New(info.Env(), m_lineDash[index]));
+        }
+        return segments;
     }
 
     void Context::StrokeText(const Napi::CallbackInfo& info)

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -1644,43 +1644,103 @@ namespace Babylon::Polyfills::Internal
         nvgGlobalAlpha(*m_nvg, alpha);
     }
 
+    // nanovg has no shadow primitive, so the shadow attributes are stored and
+    // reported back but not rendered. Throwing was the wrong response: these are
+    // ordinary state attributes, and reading one, or writing the default, asks
+    // for nothing at all. Babylon GUI resets shadowBlur/shadowOffsetX/OffsetY to
+    // 0 after drawing a shadowed control, so the throw killed the scene on the
+    // *reset* path as well as the request path, and any control with a drop
+    // shadow aborted outright rather than drawing without one.
+    //
+    // Storing them keeps the spec-required round trip working and lets content
+    // that saves and restores canvas state continue to function; a shadow that
+    // is genuinely requested warns once instead of failing the scene.
+    void Context::WarnShadowUnsupported()
+    {
+        if (m_shadowBlur == 0.0 && m_shadowOffsetX == 0.0 && m_shadowOffsetY == 0.0)
+        {
+            // Nothing is being asked for: no offset and no blur draws no shadow.
+            return;
+        }
+
+        static bool warned = false;
+        if (!warned)
+        {
+            warned = true;
+            fprintf(stderr, "Context2D: shadows are not supported; drawing without a shadow.\n");
+        }
+    }
+
     Napi::Value Context::GetShadowColor(const Napi::CallbackInfo& info)
     {
-        throw Napi::Error::New(info.Env(), "Context2D.shadowColor (get): not implemented");
+        return Napi::String::New(info.Env(), m_shadowColor);
     }
 
     void Context::SetShadowColor(const Napi::CallbackInfo& info, const Napi::Value& value)
     {
-        throw Napi::Error::New(info.Env(), "Context2D.shadowColor (set): not implemented");
+        // Per spec an unparseable shadowColor is ignored, keeping the old value.
+        const auto color = value.As<Napi::String>().Utf8Value();
+        try
+        {
+            StringToColor(info.Env(), color);
+        }
+        catch (const Napi::Error&)
+        {
+            return;
+        }
+
+        m_shadowColor = color;
     }
 
     Napi::Value Context::GetShadowBlur(const Napi::CallbackInfo& info)
     {
-        throw Napi::Error::New(info.Env(), "Context2D.shadowBlur (get): not implemented");
+        return Napi::Number::New(info.Env(), m_shadowBlur);
     }
 
     void Context::SetShadowBlur(const Napi::CallbackInfo& info, const Napi::Value& value)
     {
-        throw Napi::Error::New(info.Env(), "Context2D.shadowBlur (set): not implemented");
+        // Per spec, negative and non-finite values are ignored.
+        const double blur = value.As<Napi::Number>().DoubleValue();
+        if (!std::isfinite(blur) || blur < 0.0)
+        {
+            return;
+        }
+
+        m_shadowBlur = blur;
+        WarnShadowUnsupported();
     }
 
     Napi::Value Context::GetShadowOffsetX(const Napi::CallbackInfo& info)
     {
-        throw Napi::Error::New(info.Env(), "Context2D.shadowOffsetX (get): not implemented");
+        return Napi::Number::New(info.Env(), m_shadowOffsetX);
     }
 
     void Context::SetShadowOffsetX(const Napi::CallbackInfo& info, const Napi::Value& value)
     {
-        throw Napi::Error::New(info.Env(), "Context2D.shadowOffsetX (set): not implemented");
+        const double offset = value.As<Napi::Number>().DoubleValue();
+        if (!std::isfinite(offset))
+        {
+            return;
+        }
+
+        m_shadowOffsetX = offset;
+        WarnShadowUnsupported();
     }
 
     Napi::Value Context::GetShadowOffsetY(const Napi::CallbackInfo& info)
     {
-        throw Napi::Error::New(info.Env(), "Context2D.shadowOffsetY (get): not implemented");
+        return Napi::Number::New(info.Env(), m_shadowOffsetY);
     }
 
     void Context::SetShadowOffsetY(const Napi::CallbackInfo& info, const Napi::Value& value)
     {
-        throw Napi::Error::New(info.Env(), "Context2D.shadowOffsetY (set): not implemented");
+        const double offset = value.As<Napi::Number>().DoubleValue();
+        if (!std::isfinite(offset))
+        {
+            return;
+        }
+
+        m_shadowOffsetY = offset;
+        WarnShadowUnsupported();
     }
 }

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -192,13 +192,14 @@ namespace Babylon::Polyfills::Internal
         auto width = info[2].As<Napi::Number>().FloatValue();
         auto height = info[3].As<Napi::Number>().FloatValue();
 
-        // Unconditional: Clip() is implemented with nvgScissor, which is path-independent
-        // rather than consuming a path, so suppressing beginPath once a clip
-        // was set only made every later call append to one ever-growing path:
-        // each fill then repainted the union of every rect added since the
-        // clip using the newest paint, which is how a GUI ColorPicker ended up
-        // smearing its saturation gradient over its own colour wheel.
-        nvgBeginPath(*m_nvg);
+        // fillRect neither reads nor modifies the current path per spec, so it
+        // would normally start its own. But Clip() can only express a rectangle
+        // (nvgScissor), so a non-rectangular clip path is emulated by leaving it
+        // in the current path and letting this fill render it. See Clip().
+        if (!m_isClipped)
+        {
+            nvgBeginPath(*m_nvg);
+        }
 
         nvgRect(*m_nvg, left, top, width, height);
 
@@ -289,6 +290,7 @@ namespace Babylon::Polyfills::Internal
     void Context::Restore(const Napi::CallbackInfo&)
     {
         nvgRestore(*m_nvg);
+        m_isClipped = false;
         if (!m_savedStyles.empty())
         {
             const auto& saved = m_savedStyles.back();
@@ -342,6 +344,8 @@ namespace Babylon::Polyfills::Internal
 
     void Context::BeginPath(const Napi::CallbackInfo&)
     {
+        m_isClipped = false;
+        m_pathHasNonRect = false;
         nvgBeginPath(*m_nvg);
     }
 
@@ -431,6 +435,18 @@ namespace Babylon::Polyfills::Internal
 
     void Context::Clip(const Napi::CallbackInfo& /*info*/)
     {
+        // A non-rectangular clip path cannot be expressed as a scissor rectangle.
+        // Emulate it by leaving the path current so the next fill draws it, and
+        // leave any enclosing scissor untouched rather than clipping to a
+        // rectangle this path never described.
+        if (m_pathHasNonRect)
+        {
+            m_isClipped = true;
+            return;
+        }
+
+        m_isClipped = false;
+
         //By default m_rectangleClipping is not set, in this case we use the canvas width and height.
         auto w = m_rectangleClipping.width != 0 ? m_rectangleClipping.width : m_canvas->GetWidth();
         auto h = m_rectangleClipping.height != 0 ? m_rectangleClipping.height : m_canvas->GetHeight();
@@ -453,6 +469,8 @@ namespace Babylon::Polyfills::Internal
 
     void Context::PlayPath2D(const NativeCanvasPath2D* path)
     {
+        m_isClipped = false;
+        m_pathHasNonRect = true;
         nvgBeginPath(*m_nvg);
         for (const auto& command : *path)
         {
@@ -544,6 +562,7 @@ namespace Babylon::Polyfills::Internal
         const auto x = info[0].As<Napi::Number>().FloatValue();
         const auto y = info[1].As<Napi::Number>().FloatValue();
 
+        m_pathHasNonRect = true;
         nvgMoveTo(*m_nvg, x, y);
     }
 
@@ -552,6 +571,7 @@ namespace Babylon::Polyfills::Internal
         const auto x = info[0].As<Napi::Number>().FloatValue();
         const auto y = info[1].As<Napi::Number>().FloatValue();
 
+        m_pathHasNonRect = true;
         nvgLineTo(*m_nvg, x, y);
     }
 
@@ -562,6 +582,7 @@ namespace Babylon::Polyfills::Internal
         const auto x = info[2].As<Napi::Number>().FloatValue();
         const auto y = info[3].As<Napi::Number>().FloatValue();
 
+        m_pathHasNonRect = true;
         nvgBezierTo(*m_nvg, cx, cy, cx, cy, x, y);
     }
 
@@ -778,6 +799,7 @@ namespace Babylon::Polyfills::Internal
         const auto startAngle = static_cast<float>(info[3].As<Napi::Number>().DoubleValue());
         const auto endAngle = static_cast<float>(info[4].As<Napi::Number>().DoubleValue());
         const NVGwinding winding = (info.Length() == 6 && info[5].As<Napi::Boolean>()) ? NVGwinding::NVG_CCW : NVGwinding::NVG_CW;
+        m_pathHasNonRect = true;
         nvgArc(*m_nvg, x, y, radius, startAngle, endAngle, winding);
     }
 
@@ -1113,8 +1135,15 @@ namespace Babylon::Polyfills::Internal
             else if (info.Length() >= 1 && info[0].IsObject())
             {
                 const auto source = info[0].As<Napi::Object>();
-                width = source.Get("width").As<Napi::Number>().Uint32Value();
-                height = source.Get("height").As<Napi::Number>().Uint32Value();
+                const auto w = source.Get("width");
+                const auto h = source.Get("height");
+                if (!w.IsNumber() || !h.IsNumber())
+                {
+                    throw Napi::TypeError::New(info.Env(), "Context2D.createImageData: argument is not an ImageData");
+                }
+
+                width = w.As<Napi::Number>().Uint32Value();
+                height = h.As<Napi::Number>().Uint32Value();
             }
             else
             {

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -43,6 +43,20 @@ namespace Babylon::Polyfills::Internal
 {
     static constexpr auto JS_CONTEXT_CONSTRUCTOR_NAME = "Context";
 
+    namespace
+    {
+        // True only for a finite, non-negative integer that fits in a uint32_t. Used where a
+        // dimension arrives from a duck-typed object and so has not been through WebIDL's
+        // unsigned long conversion; Uint32Value() would silently wrap -1 into 4294967295.
+        bool IsValidExtent(double value)
+        {
+            return std::isfinite(value) &&
+                value >= 0.0 &&
+                value <= static_cast<double>(std::numeric_limits<uint32_t>::max()) &&
+                value == std::trunc(value);
+        }
+    }
+
     void Context::Initialize(Napi::Env env)
     {
         Napi::HandleScope scope{env};
@@ -1367,8 +1381,20 @@ namespace Babylon::Polyfills::Internal
                 throw Napi::TypeError::New(info.Env(), "Context2D.createImageData: argument is not an ImageData");
             }
 
-            width = w.As<Napi::Number>().Uint32Value();
-            height = h.As<Napi::Number>().Uint32Value();
+            // This overload is duck-typed rather than restricted to a real ImageData, so the
+            // dimensions have not been through WebIDL's unsigned long conversion. Uint32Value()
+            // would wrap a negative width to 4294967295, which clears the overflow check below
+            // on 64-bit and turns an invalid source into a ~17 GB allocation. The drawImage and
+            // putImageData extents guard against the same wrap.
+            const auto wNum = w.As<Napi::Number>().DoubleValue();
+            const auto hNum = h.As<Napi::Number>().DoubleValue();
+            if (!IsValidExtent(wNum) || !IsValidExtent(hNum))
+            {
+                throw Napi::RangeError::New(info.Env(), "Context2D.createImageData: source width and height are not valid extents");
+            }
+
+            width = static_cast<uint32_t>(wNum);
+            height = static_cast<uint32_t>(hNum);
         }
         else
         {

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -334,10 +334,13 @@ namespace Babylon::Polyfills::Internal
     void Context::Save(const Napi::CallbackInfo&)
     {
         nvgSave(*m_nvg);
-        // Track our wrapper-side fillStyle/strokeStyle alongside the nvg state stack so that
-        // ctx.restore() correctly rewinds them — otherwise FillText/BindFillStyle would re-bind
-        // a stale color from after a fillStyle change that nvg has since popped.
-        m_savedStyles.push_back({m_fillStyle, m_strokeStyle});
+        // Track the wrapper-side drawing state alongside the nvg state stack so that
+        // ctx.restore() correctly rewinds it — otherwise FillText/BindFillStyle would re-bind
+        // a stale color from after a fillStyle change that nvg has since popped, and every
+        // attribute getter would keep reporting its post-save() value.
+        m_savedStyles.push_back({m_fillStyle, m_strokeStyle, m_lineCap, m_lineJoin, m_lineDash,
+            m_shadowColor, m_shadowBlur, m_shadowOffsetX, m_shadowOffsetY, m_filter, m_direction,
+            m_miterLimit, m_lineWidth, m_globalAlpha, m_letterSpacing});
     }
 
     void Context::Restore(const Napi::CallbackInfo&)
@@ -349,6 +352,19 @@ namespace Babylon::Polyfills::Internal
             const auto& saved = m_savedStyles.back();
             m_fillStyle = saved.fillStyle;
             m_strokeStyle = saved.strokeStyle;
+            m_lineCap = saved.lineCap;
+            m_lineJoin = saved.lineJoin;
+            m_lineDash = saved.lineDash;
+            m_shadowColor = saved.shadowColor;
+            m_shadowBlur = saved.shadowBlur;
+            m_shadowOffsetX = saved.shadowOffsetX;
+            m_shadowOffsetY = saved.shadowOffsetY;
+            m_filter = saved.filter;
+            m_direction = saved.direction;
+            m_miterLimit = saved.miterLimit;
+            m_lineWidth = saved.lineWidth;
+            m_globalAlpha = saved.globalAlpha;
+            m_letterSpacing = saved.letterSpacing;
             m_savedStyles.pop_back();
         }
     }

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -72,6 +72,7 @@ namespace Babylon::Polyfills::Internal
                 InstanceMethod("fill", &Context::Fill),
                 InstanceMethod("drawImage", &Context::DrawImage),
                 InstanceMethod("getImageData", &Context::GetImageData),
+                InstanceMethod("createImageData", &Context::CreateImageData),
                 InstanceMethod("setLineDash", &Context::SetLineDash),
                 InstanceMethod("fillText", &Context::FillText),
                 InstanceMethod("strokeText", &Context::StrokeText),
@@ -150,11 +151,9 @@ namespace Babylon::Polyfills::Internal
             nvgDelete(*m_nvg);
             m_nvg = nullptr;
         }
-
-        m_isClipped = false;
     }
 
-    void Context::BindFillStyle(const Napi::CallbackInfo& info, float left, float top, float width, float height)
+    void Context::BindFillStyle(const Napi::CallbackInfo& info)
     {
         if (std::holds_alternative<std::string>(m_fillStyle))
         {
@@ -168,10 +167,7 @@ namespace Babylon::Polyfills::Internal
         else if (std::holds_alternative<CanvasGradient*>(m_fillStyle))
         {
             CanvasGradient* gradient = std::get<CanvasGradient*>(m_fillStyle);
-            gradient->UpdateCache();
-            // TODO: replace left/lop/width/height by context bounds
-            NVGpaint imagePaint = nvgImagePattern(*m_nvg, 0.f, 0.f, width + left, height, 0.f, gradient->CachedImage(), 1.f);
-            nvgFillPaint(*m_nvg, imagePaint);
+            nvgFillPaint(*m_nvg, gradient->Paint());
         }
         else
         {
@@ -196,14 +192,17 @@ namespace Babylon::Polyfills::Internal
         auto width = info[2].As<Napi::Number>().FloatValue();
         auto height = info[3].As<Napi::Number>().FloatValue();
 
-        if (!m_isClipped)
-        {
-            nvgBeginPath(*m_nvg);
-        }
+        // Unconditional: Clip() is implemented with nvgScissor, which is path-independent
+        // rather than consuming a path, so suppressing beginPath once a clip
+        // was set only made every later call append to one ever-growing path:
+        // each fill then repainted the union of every rect added since the
+        // clip using the newest paint, which is how a GUI ColorPicker ended up
+        // smearing its saturation gradient over its own colour wheel.
+        nvgBeginPath(*m_nvg);
 
         nvgRect(*m_nvg, left, top, width, height);
 
-        BindFillStyle(info, left, top, width, height);
+        BindFillStyle(info);
 
         SetFilterStack();
         nvgFill(*m_nvg);
@@ -297,7 +296,6 @@ namespace Babylon::Polyfills::Internal
             m_strokeStyle = saved.strokeStyle;
             m_savedStyles.pop_back();
         }
-        m_isClipped = false;
     }
 
     void Context::ClearRect(const Napi::CallbackInfo& info)
@@ -310,17 +308,12 @@ namespace Babylon::Polyfills::Internal
         nvgSave(*m_nvg);
         nvgGlobalCompositeOperation(*m_nvg, NVG_COPY);
 
-        if (!m_isClipped)
-        {
-            nvgBeginPath(*m_nvg);
-        }
+        // See FillRect: clipping is a scissor, so the path must always be reset.
+        nvgBeginPath(*m_nvg);
 
         nvgRect(*m_nvg, x, y, width, height);
 
-        if (!m_isClipped)
-        {
-            nvgClosePath(*m_nvg);
-        }
+        nvgClosePath(*m_nvg);
 
         nvgFillColor(*m_nvg, TRANSPARENT_BLACK);
         nvgFill(*m_nvg);
@@ -438,8 +431,6 @@ namespace Babylon::Polyfills::Internal
 
     void Context::Clip(const Napi::CallbackInfo& /*info*/)
     {
-        m_isClipped = true;
-
         //By default m_rectangleClipping is not set, in this case we use the canvas width and height.
         auto w = m_rectangleClipping.width != 0 ? m_rectangleClipping.width : m_canvas->GetWidth();
         auto h = m_rectangleClipping.height != 0 ? m_rectangleClipping.height : m_canvas->GetHeight();
@@ -641,7 +632,7 @@ namespace Babylon::Polyfills::Internal
 
         if (SetFontFaceId())
         {
-            BindFillStyle(info, 0.f, 0.f, x, y);
+            BindFillStyle(info);
 
             if (m_filter.length())
             {
@@ -1006,12 +997,14 @@ namespace Babylon::Polyfills::Internal
             const auto dx = static_cast<float>(info[1].As<Napi::Number>().Int32Value());
             const auto dy = static_cast<float>(info[2].As<Napi::Number>().Int32Value());
 
-            NVGpaint imagePaint = nvgImagePattern(*m_nvg, 0.f, 0.f, imgWidth, imgHeight, 0.f, imageIndex, 1.f);
+            // Anchor the pattern at the destination, not the canvas origin: the
+            // rect below is drawn at (dx,dy), so a pattern based at (0,0) makes
+            // it sample from outside the image and clamp to the edge texels,
+            // which silently draws nothing for any dx/dy other than (0,0).
+            NVGpaint imagePaint = nvgImagePattern(*m_nvg, dx, dy, imgWidth, imgHeight, 0.f, imageIndex, 1.f);
 
-            if (!m_isClipped)
-            {
-                nvgBeginPath(*m_nvg);
-            }
+            // See FillRect: clipping is a scissor, so the path must always be reset.
+            nvgBeginPath(*m_nvg);
 
             nvgRect(*m_nvg, dx, dy, imgWidth, imgHeight);
             nvgFillPaint(*m_nvg, imagePaint);
@@ -1042,10 +1035,8 @@ namespace Babylon::Polyfills::Internal
 
             NVGpaint imagePaint = nvgImagePattern(*m_nvg, dx, dy, dWidth, dHeight, 0.f, imageIndex, 1.f);
 
-            if (!m_isClipped)
-            {
-                nvgBeginPath(*m_nvg);
-            }
+            // See FillRect: clipping is a scissor, so the path must always be reset.
+            nvgBeginPath(*m_nvg);
 
             nvgRect(*m_nvg, dx, dy, dWidth, dHeight);
             nvgFillPaint(*m_nvg, imagePaint);
@@ -1080,10 +1071,8 @@ namespace Babylon::Polyfills::Internal
 
             NVGpaint imagePaint = nvgImagePattern(*m_nvg, dx, dy, dWidth, dHeight, 0.f, imageIndex, 1.f);
 
-            if (!m_isClipped)
-            {
-                nvgBeginPath(*m_nvg);
-            }
+            // See FillRect: clipping is a scissor, so the path must always be reset.
+            nvgBeginPath(*m_nvg);
 
             nvgRect(*m_nvg, dx, dy, dWidth, dHeight);
             nvgFillPaint(*m_nvg, imagePaint);
@@ -1097,6 +1086,61 @@ namespace Babylon::Polyfills::Internal
         {
             throw Napi::Error::New(info.Env(), "Invalid number of parameters for DrawImage");
         }
+    }
+
+    namespace
+    {
+        // createImageData has two overloads: (width, height) and (imagedata). Both produce a
+        // blank, transparent-black buffer -- only the dimensions differ in how they are sourced.
+        void ParseCreateImageDataArgs(const Napi::CallbackInfo& info, uint32_t& width, uint32_t& height)
+        {
+            if (info.Length() >= 2 && info[0].IsNumber() && info[1].IsNumber())
+            {
+                const auto wInt = info[0].As<Napi::Number>().Int32Value();
+                const auto hInt = info[1].As<Napi::Number>().Int32Value();
+
+                // The spec takes the magnitude of each extent, so a negative size is legal.
+                // INT32_MIN has no positive counterpart and would negate into itself, so it is
+                // rejected rather than wrapped into a huge unsigned extent.
+                if (wInt == std::numeric_limits<int32_t>::min() || hInt == std::numeric_limits<int32_t>::min())
+                {
+                    throw Napi::RangeError::New(info.Env(), "Context2D.createImageData: requested size is too large.");
+                }
+
+                width = static_cast<uint32_t>(wInt < 0 ? -wInt : wInt);
+                height = static_cast<uint32_t>(hInt < 0 ? -hInt : hInt);
+            }
+            else if (info.Length() >= 1 && info[0].IsObject())
+            {
+                const auto source = info[0].As<Napi::Object>();
+                width = source.Get("width").As<Napi::Number>().Uint32Value();
+                height = source.Get("height").As<Napi::Number>().Uint32Value();
+            }
+            else
+            {
+                throw Napi::TypeError::New(info.Env(), "Context2D.createImageData: invalid arguments");
+            }
+
+            if (width == 0 || height == 0)
+            {
+                throw Napi::RangeError::New(info.Env(), "Context2D.createImageData: width and height must be non-zero");
+            }
+
+            // Backs a width*height*4 allocation, so reject sizes that would overflow size_t.
+            if (static_cast<uint64_t>(width) * height > std::numeric_limits<size_t>::max() / 4)
+            {
+                throw Napi::RangeError::New(info.Env(), "Context2D.createImageData: requested size is too large.");
+            }
+        }
+    }
+
+    Napi::Value Context::CreateImageData(const Napi::CallbackInfo& info)
+    {
+        uint32_t width{}, height{};
+        ParseCreateImageDataArgs(info, width, height);
+        // A null context means "do not read back the framebuffer", so the ImageData is
+        // left as the transparent black the spec requires.
+        return ImageData::CreateInstance(info.Env(), nullptr, 0, 0, width, height);
     }
 
     Napi::Value Context::GetImageData(const Napi::CallbackInfo& info)

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -1452,7 +1452,11 @@ namespace Babylon::Polyfills::Internal
         // stroke, and emulating one means splitting every path into segments.
         // Draw solid and warn once rather than failing the whole scene, and keep
         // the list so getLineDash() round-trips as the spec requires.
-        m_lineDash.clear();
+        //
+        // Parsed into a temporary and committed only once every segment
+        // validates, because the spec keeps the previous list when the argument
+        // is rejected -- clearing m_lineDash up front would destroy it first.
+        std::vector<double> parsed;
 
         if (info.Length() > 0 && info[0].IsArray())
         {
@@ -1465,20 +1469,20 @@ namespace Babylon::Polyfills::Internal
                     // Per spec, a list containing a non-finite or negative value
                     // is ignored entirely and the previous list is retained; a
                     // non-numeric entry cannot be interpreted, so ignore it too.
-                    m_lineDash.clear();
                     return;
                 }
 
                 const double value = segment.As<Napi::Number>().DoubleValue();
                 if (!std::isfinite(value) || value < 0.0)
                 {
-                    m_lineDash.clear();
                     return;
                 }
 
-                m_lineDash.push_back(value);
+                parsed.push_back(value);
             }
         }
+
+        m_lineDash = std::move(parsed);
 
         if (!m_lineDash.empty())
         {

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -167,9 +167,9 @@ namespace Babylon::Polyfills::Internal
             const auto color = str.empty() ? nvgRGBA(255, 255, 255, 255) : StringToColor(info.Env(), str);
             nvgFillColor(*m_nvg, color);
         }
-        else if (std::holds_alternative<CanvasGradient*>(m_fillStyle))
+        else if (std::holds_alternative<GradientStyle>(m_fillStyle))
         {
-            CanvasGradient* gradient = std::get<CanvasGradient*>(m_fillStyle);
+            CanvasGradient* gradient = CanvasGradient::Unwrap(std::get<GradientStyle>(m_fillStyle)->Value());
             nvgFillPaint(*m_nvg, gradient->Paint());
         }
         else
@@ -189,9 +189,9 @@ namespace Babylon::Polyfills::Internal
             const auto color = str.empty() ? nvgRGBA(0, 0, 0, 255) : StringToColor(info.Env(), str);
             nvgStrokeColor(*m_nvg, color);
         }
-        else if (std::holds_alternative<CanvasGradient*>(m_strokeStyle))
+        else if (std::holds_alternative<GradientStyle>(m_strokeStyle))
         {
-            CanvasGradient* gradient = std::get<CanvasGradient*>(m_strokeStyle);
+            CanvasGradient* gradient = CanvasGradient::Unwrap(std::get<GradientStyle>(m_strokeStyle)->Value());
             nvgStrokePaint(*m_nvg, gradient->Paint());
         }
         else
@@ -242,7 +242,9 @@ namespace Babylon::Polyfills::Internal
         }
         else
         {
-            return Napi::External<CanvasGradient>::New(Env(), std::get<CanvasGradient*>(m_fillStyle));
+            // Return the gradient object that was assigned, as the spec requires, so that
+            // `otherCtx.fillStyle = ctx.fillStyle` round-trips.
+            return std::get<GradientStyle>(m_fillStyle)->Value();
         }
     }
 
@@ -260,7 +262,7 @@ namespace Babylon::Polyfills::Internal
         }
         else if (CanvasGradient::IsInstance(info.Env(), value))
         {
-            m_fillStyle = CanvasGradient::Unwrap(value.As<Napi::Object>());
+            m_fillStyle = std::make_shared<Napi::ObjectReference>(Napi::Persistent(value.As<Napi::Object>()));
         }
         // Anything else leaves fillStyle unchanged, as the spec requires.
     }
@@ -273,7 +275,7 @@ namespace Babylon::Polyfills::Internal
         }
         else
         {
-            return Napi::External<CanvasGradient>::New(Env(), std::get<CanvasGradient*>(m_strokeStyle));
+            return std::get<GradientStyle>(m_strokeStyle)->Value();
         }
     }
 
@@ -290,7 +292,7 @@ namespace Babylon::Polyfills::Internal
         }
         else if (CanvasGradient::IsInstance(info.Env(), value))
         {
-            m_strokeStyle = CanvasGradient::Unwrap(value.As<Napi::Object>());
+            m_strokeStyle = std::make_shared<Napi::ObjectReference>(Napi::Persistent(value.As<Napi::Object>()));
         }
         // Per spec, assigning anything that is neither a color string nor a
         // gradient/pattern leaves strokeStyle unchanged.

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -248,6 +248,9 @@ namespace Babylon::Polyfills::Internal
 
     void Context::SetFillStyle(const Napi::CallbackInfo& info, const Napi::Value& value)
     {
+        // Per spec the setter takes (DOMString or CanvasGradient or CanvasPattern); anything
+        // else stringifies, fails color parsing and is ignored. Test for the gradient rather
+        // than for "is an object", so `ctx.fillStyle = {}` cannot reach Unwrap.
         if (value.IsString())
         {
             auto string = value.As<Napi::String>().Utf8Value();
@@ -255,11 +258,11 @@ namespace Babylon::Polyfills::Internal
             m_fillStyle = string;
             nvgFillColor(*m_nvg, color);
         }
-        else
+        else if (CanvasGradient::IsInstance(info.Env(), value))
         {
-            CanvasGradient* canvasGradient = CanvasGradient::Unwrap(info[0].As<Napi::Object>());
-            m_fillStyle = canvasGradient;
+            m_fillStyle = CanvasGradient::Unwrap(value.As<Napi::Object>());
         }
+        // Anything else leaves fillStyle unchanged, as the spec requires.
     }
 
     Napi::Value Context::GetStrokeStyle(const Napi::CallbackInfo&)
@@ -285,16 +288,12 @@ namespace Babylon::Polyfills::Internal
             m_strokeStyle = string;
             nvgStrokeColor(*m_nvg, color);
         }
-        else if (value.IsObject())
+        else if (CanvasGradient::IsInstance(info.Env(), value))
         {
-            CanvasGradient* canvasGradient = CanvasGradient::Unwrap(value.As<Napi::Object>());
-            m_strokeStyle = canvasGradient;
+            m_strokeStyle = CanvasGradient::Unwrap(value.As<Napi::Object>());
         }
-        else
-        {
-            // Per spec, assigning anything that is neither a color string nor a
-            // gradient/pattern leaves strokeStyle unchanged.
-        }
+        // Per spec, assigning anything that is neither a color string nor a
+        // gradient/pattern leaves strokeStyle unchanged.
     }
 
     Napi::Value Context::GetLineWidth(const Napi::CallbackInfo&)
@@ -340,7 +339,7 @@ namespace Babylon::Polyfills::Internal
         // attribute getter would keep reporting its post-save() value.
         m_savedStyles.push_back({m_fillStyle, m_strokeStyle, m_lineCap, m_lineJoin, m_lineDash,
             m_shadowColor, m_shadowBlur, m_shadowOffsetX, m_shadowOffsetY, m_filter, m_direction,
-            m_miterLimit, m_lineWidth, m_globalAlpha, m_letterSpacing});
+            m_miterLimit, m_lineWidth, m_globalAlpha, m_letterSpacing, m_font, m_currentFontId});
     }
 
     void Context::Restore(const Napi::CallbackInfo&)
@@ -365,6 +364,8 @@ namespace Babylon::Polyfills::Internal
             m_lineWidth = saved.lineWidth;
             m_globalAlpha = saved.globalAlpha;
             m_letterSpacing = saved.letterSpacing;
+            m_font = saved.font;
+            m_currentFontId = saved.currentFontId;
             m_savedStyles.pop_back();
         }
     }
@@ -379,8 +380,10 @@ namespace Babylon::Polyfills::Internal
         nvgSave(*m_nvg);
         nvgGlobalCompositeOperation(*m_nvg, NVG_COPY);
 
-        // See FillRect: clipping is a scissor, so the path must always be reset.
-        nvgBeginPath(*m_nvg);
+        // See FillRect: clipping is a scissor, so the path must always be reset. Resetting it
+        // invalidates the emulated clip, which points at a path that no longer exists, and the
+        // nvgRestore below only pops ctx->states -- it does not put the old path back.
+        ResetPathState();
 
         nvgRect(*m_nvg, x, y, width, height);
 
@@ -413,6 +416,11 @@ namespace Babylon::Polyfills::Internal
 
     void Context::BeginPath(const Napi::CallbackInfo&)
     {
+        ResetPathState();
+    }
+
+    void Context::ResetPathState()
+    {
         m_isClipped = false;
         m_pathHasNonRect = false;
         nvgBeginPath(*m_nvg);
@@ -441,7 +449,6 @@ namespace Babylon::Polyfills::Internal
         const auto width = info[2].As<Napi::Number>().FloatValue();
         const auto height = info[3].As<Napi::Number>().FloatValue();
         const auto radii = info[4];
-
         if (radii.IsNumber())
         {
             const auto radius = radii.As<Napi::Number>().FloatValue();
@@ -460,7 +467,6 @@ namespace Babylon::Polyfills::Internal
             {
                 const auto topLeftBottomRight = radiiArray[0u].As<Napi::Number>().FloatValue();
                 const auto topRightBottomLeft = radiiArray[1u].As<Napi::Number>().FloatValue();
-
                 nvgRoundedRectVarying(*m_nvg, x, y, width, height, topLeftBottomRight, topRightBottomLeft, topLeftBottomRight, topRightBottomLeft);
             }
             else if (radiiArrayLength == 3)
@@ -468,7 +474,6 @@ namespace Babylon::Polyfills::Internal
                 const auto topLeft = radiiArray[0u].As<Napi::Number>().FloatValue();
                 const auto topRightBottomLeft = radiiArray[1u].As<Napi::Number>().FloatValue();
                 const auto bottomRight = radiiArray[2u].As<Napi::Number>().FloatValue();
-
                 nvgRoundedRectVarying(*m_nvg, x, y, width, height, topLeft, topRightBottomLeft, bottomRight, topRightBottomLeft);
             }
             else if (radiiArrayLength == 4)
@@ -477,7 +482,6 @@ namespace Babylon::Polyfills::Internal
                 const auto topRight = radiiArray[1u].As<Napi::Number>().FloatValue();
                 const auto bottomRight = radiiArray[2u].As<Napi::Number>().FloatValue();
                 const auto bottomLeft = radiiArray[3u].As<Napi::Number>().FloatValue();
-
                 nvgRoundedRectVarying(*m_nvg, x, y, width, height, topLeft, topRight, bottomRight, bottomLeft);
             }
             else
@@ -500,6 +504,17 @@ namespace Babylon::Polyfills::Internal
         }
 
         m_rectangleClipping = {x, y, width, height};
+
+        // Deliberately does not set m_pathHasNonRect, even though rounded corners are not
+        // something nvgScissor can express. Clip()'s emulation for a non-rectangular path is
+        // to leave the path current and let the next fill draw it, and nanovg fills the union
+        // of the subpaths, not their intersection -- so `roundRect(); clip(); fillRect()` would
+        // paint the whole fillRect rather than the rounded region. Measured on the "Native
+        // Canvas" visual test: routing roundRect into the emulation takes the pixel difference
+        // from 1.850% to 20.980%, where the scissor's square bounding box stays at 1.850%.
+        // Dropping the radii is wrong, but it is the far smaller error of the two, and a
+        // correct fix needs real path clipping (a stencil pass in nanovg) rather than this
+        // union trick.
     }
 
     void Context::Clip(const Napi::CallbackInfo& /*info*/)
@@ -986,7 +1001,7 @@ namespace Babylon::Polyfills::Internal
         nvgGlobalCompositeOperation(*m_nvg, NVG_COPY);
 
         NVGpaint imagePaint = nvgImagePattern(*m_nvg, destX, destY, destWidth, destHeight, 0.f, imageIndex, 1.f);
-        nvgBeginPath(*m_nvg);
+        ResetPathState();
         nvgRect(*m_nvg, destX, destY, destWidth, destHeight);
         nvgFillPaint(*m_nvg, imagePaint);
         nvgFill(*m_nvg);
@@ -997,10 +1012,6 @@ namespace Babylon::Polyfills::Internal
         // Keep the CPU mirror that getImageData() reads from in sync.
         BlitPixelsToCpu(patch.data(), copyWidth, copyHeight, 0, 0, copyWidth, copyHeight,
             destLeft, destTop, copyWidth, copyHeight);
-
-        // The path now holds just this rect, so clear the non-rect flag: a stale `true` left over
-        // from an earlier arc/curve would make a subsequent clip() take the emulated path branch.
-        m_pathHasNonRect = false;
     }
 
     void Context::Arc(const Napi::CallbackInfo& info)
@@ -1238,7 +1249,7 @@ namespace Babylon::Polyfills::Internal
             NVGpaint imagePaint = nvgImagePattern(*m_nvg, dx, dy, imgWidth, imgHeight, 0.f, imageIndex, 1.f);
 
             // See FillRect: clipping is a scissor, so the path must always be reset.
-            nvgBeginPath(*m_nvg);
+            ResetPathState();
 
             nvgRect(*m_nvg, dx, dy, imgWidth, imgHeight);
             nvgFillPaint(*m_nvg, imagePaint);
@@ -1270,7 +1281,7 @@ namespace Babylon::Polyfills::Internal
             NVGpaint imagePaint = nvgImagePattern(*m_nvg, dx, dy, dWidth, dHeight, 0.f, imageIndex, 1.f);
 
             // See FillRect: clipping is a scissor, so the path must always be reset.
-            nvgBeginPath(*m_nvg);
+            ResetPathState();
 
             nvgRect(*m_nvg, dx, dy, dWidth, dHeight);
             nvgFillPaint(*m_nvg, imagePaint);
@@ -1306,7 +1317,7 @@ namespace Babylon::Polyfills::Internal
             NVGpaint imagePaint = nvgImagePattern(*m_nvg, dx, dy, dWidth, dHeight, 0.f, imageIndex, 1.f);
 
             // See FillRect: clipping is a scissor, so the path must always be reset.
-            nvgBeginPath(*m_nvg);
+            ResetPathState();
 
             nvgRect(*m_nvg, dx, dy, dWidth, dHeight);
             nvgFillPaint(*m_nvg, imagePaint);
@@ -1322,63 +1333,57 @@ namespace Babylon::Polyfills::Internal
         }
     }
 
-    namespace
+    Napi::Value Context::CreateImageData(const Napi::CallbackInfo& info)
     {
-        // createImageData has two overloads: (width, height) and (imagedata). Both produce a
-        // blank, transparent-black buffer -- only the dimensions differ in how they are sourced.
-        void ParseCreateImageDataArgs(const Napi::CallbackInfo& info, uint32_t& width, uint32_t& height)
+        // Two overloads: (width, height) and (imagedata). Both produce a blank,
+        // transparent-black buffer -- only the dimensions differ in how they are sourced.
+        uint32_t width{}, height{};
+
+        if (info.Length() >= 2 && info[0].IsNumber() && info[1].IsNumber())
         {
-            if (info.Length() >= 2 && info[0].IsNumber() && info[1].IsNumber())
-            {
-                const auto wInt = info[0].As<Napi::Number>().Int32Value();
-                const auto hInt = info[1].As<Napi::Number>().Int32Value();
+            const auto wInt = info[0].As<Napi::Number>().Int32Value();
+            const auto hInt = info[1].As<Napi::Number>().Int32Value();
 
-                // The spec takes the magnitude of each extent, so a negative size is legal.
-                // INT32_MIN has no positive counterpart and would negate into itself, so it is
-                // rejected rather than wrapped into a huge unsigned extent.
-                if (wInt == std::numeric_limits<int32_t>::min() || hInt == std::numeric_limits<int32_t>::min())
-                {
-                    throw Napi::RangeError::New(info.Env(), "Context2D.createImageData: requested size is too large.");
-                }
-
-                width = static_cast<uint32_t>(wInt < 0 ? -wInt : wInt);
-                height = static_cast<uint32_t>(hInt < 0 ? -hInt : hInt);
-            }
-            else if (info.Length() >= 1 && info[0].IsObject())
-            {
-                const auto source = info[0].As<Napi::Object>();
-                const auto w = source.Get("width");
-                const auto h = source.Get("height");
-                if (!w.IsNumber() || !h.IsNumber())
-                {
-                    throw Napi::TypeError::New(info.Env(), "Context2D.createImageData: argument is not an ImageData");
-                }
-
-                width = w.As<Napi::Number>().Uint32Value();
-                height = h.As<Napi::Number>().Uint32Value();
-            }
-            else
-            {
-                throw Napi::TypeError::New(info.Env(), "Context2D.createImageData: invalid arguments");
-            }
-
-            if (width == 0 || height == 0)
-            {
-                throw Napi::RangeError::New(info.Env(), "Context2D.createImageData: width and height must be non-zero");
-            }
-
-            // Backs a width*height*4 allocation, so reject sizes that would overflow size_t.
-            if (static_cast<uint64_t>(width) * height > std::numeric_limits<size_t>::max() / 4)
+            // The spec takes the magnitude of each extent, so a negative size is legal.
+            // INT32_MIN has no positive counterpart and would negate into itself, so it is
+            // rejected rather than wrapped into a huge unsigned extent.
+            if (wInt == std::numeric_limits<int32_t>::min() || hInt == std::numeric_limits<int32_t>::min())
             {
                 throw Napi::RangeError::New(info.Env(), "Context2D.createImageData: requested size is too large.");
             }
-        }
-    }
 
-    Napi::Value Context::CreateImageData(const Napi::CallbackInfo& info)
-    {
-        uint32_t width{}, height{};
-        ParseCreateImageDataArgs(info, width, height);
+            width = static_cast<uint32_t>(wInt < 0 ? -wInt : wInt);
+            height = static_cast<uint32_t>(hInt < 0 ? -hInt : hInt);
+        }
+        else if (info.Length() >= 1 && info[0].IsObject())
+        {
+            const auto source = info[0].As<Napi::Object>();
+            const auto w = source.Get("width");
+            const auto h = source.Get("height");
+            if (!w.IsNumber() || !h.IsNumber())
+            {
+                throw Napi::TypeError::New(info.Env(), "Context2D.createImageData: argument is not an ImageData");
+            }
+
+            width = w.As<Napi::Number>().Uint32Value();
+            height = h.As<Napi::Number>().Uint32Value();
+        }
+        else
+        {
+            throw Napi::TypeError::New(info.Env(), "Context2D.createImageData: invalid arguments");
+        }
+
+        if (width == 0 || height == 0)
+        {
+            throw Napi::RangeError::New(info.Env(), "Context2D.createImageData: width and height must be non-zero");
+        }
+
+        // Backs a width*height*4 allocation, so reject sizes that would overflow size_t.
+        if (static_cast<uint64_t>(width) * height > std::numeric_limits<size_t>::max() / 4)
+        {
+            throw Napi::RangeError::New(info.Env(), "Context2D.createImageData: requested size is too large.");
+        }
+
         // A null context means "do not read back the framebuffer", so the ImageData is
         // left as the transparent black the spec requires.
         return ImageData::CreateInstance(info.Env(), nullptr, 0, 0, width, height);
@@ -1458,8 +1463,17 @@ namespace Babylon::Polyfills::Internal
         // is rejected -- clearing m_lineDash up front would destroy it first.
         std::vector<double> parsed;
 
-        if (info.Length() > 0 && info[0].IsArray())
+        if (info.Length() > 0)
         {
+            if (!info[0].IsArray())
+            {
+                // Present but not a list: the spec rejects the call, which leaves the
+                // previous list in place. Committing the empty temporary here would clear
+                // it instead, so setLineDash("x") would wipe a list that setLineDash([-1])
+                // correctly keeps.
+                return;
+            }
+
             const auto segments = info[0].As<Napi::Array>();
             for (uint32_t index = 0; index < segments.Length(); ++index)
             {

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -107,7 +107,7 @@ namespace Babylon::Polyfills::Internal
 
         Font m_font;
         std::variant<std::string, CanvasGradient*> m_fillStyle{};
-        std::string m_strokeStyle{};
+        std::variant<std::string, CanvasGradient*> m_strokeStyle{};
         std::string m_lineCap{};  // 'butt', 'round', 'square'
         std::string m_lineJoin{}; // 'round', 'bevel', 'miter'
 
@@ -135,7 +135,7 @@ namespace Babylon::Polyfills::Internal
         struct SavedStyle
         {
             std::variant<std::string, CanvasGradient*> fillStyle;
-            std::string strokeStyle;
+            std::variant<std::string, CanvasGradient*> strokeStyle;
         };
         std::vector<SavedStyle> m_savedStyles;
 
@@ -156,6 +156,7 @@ namespace Babylon::Polyfills::Internal
 
         std::unordered_map<const NativeCanvasImage*, int> m_nvgImageIndices;
         void BindFillStyle(const Napi::CallbackInfo& info);
+        void BindStrokeStyle(const Napi::CallbackInfo& info);
         void FlushGraphicResources() override;
         void PlayPath2D(const NativeCanvasPath2D* path);
         void SetFilterStack();

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -58,6 +58,7 @@ namespace Babylon::Polyfills::Internal
         Napi::Value GetImageData(const Napi::CallbackInfo&);
         Napi::Value CreateImageData(const Napi::CallbackInfo&);
         void SetLineDash(const Napi::CallbackInfo&);
+        Napi::Value GetLineDash(const Napi::CallbackInfo&);
         void StrokeText(const Napi::CallbackInfo&);
         Napi::Value CreateLinearGradient(const Napi::CallbackInfo&);
         Napi::Value CreateRadialGradient(const Napi::CallbackInfo&);
@@ -108,6 +109,10 @@ namespace Babylon::Polyfills::Internal
         std::string m_strokeStyle{};
         std::string m_lineCap{};  // 'butt', 'round', 'square'
         std::string m_lineJoin{}; // 'round', 'bevel', 'miter'
+
+        // Dash pattern from setLineDash. Retained only so getLineDash() round-trips;
+        // strokes are always drawn solid (nanovg has no dashed stroke).
+        std::vector<double> m_lineDash{};
         std::string m_filter{};
         std::string m_direction{"ltr"}; // 'ltr', 'rtl'
         float m_miterLimit{0.f};

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -95,6 +95,7 @@ namespace Babylon::Polyfills::Internal
         void SetShadowOffsetX(const Napi::CallbackInfo&, const Napi::Value& value);
         Napi::Value GetShadowOffsetY(const Napi::CallbackInfo&);
         void SetShadowOffsetY(const Napi::CallbackInfo&, const Napi::Value& value);
+        void WarnShadowUnsupported();
         void Dispose(const Napi::CallbackInfo&);
         void Dispose();
         bool SetFontFaceId();
@@ -113,6 +114,14 @@ namespace Babylon::Polyfills::Internal
         // Dash pattern from setLineDash. Retained only so getLineDash() round-trips;
         // strokes are always drawn solid (nanovg has no dashed stroke).
         std::vector<double> m_lineDash{};
+
+        // Shadow attributes from shadowColor/shadowBlur/shadowOffsetX/shadowOffsetY.
+        // Retained only so the getters round-trip; nanovg has no shadow primitive,
+        // so nothing is ever drawn from them. Defaults are the spec's.
+        std::string m_shadowColor{"rgba(0, 0, 0, 0)"};
+        double m_shadowBlur{0.0};
+        double m_shadowOffsetX{0.0};
+        double m_shadowOffsetY{0.0};
         std::string m_filter{};
         std::string m_direction{"ltr"}; // 'ltr', 'rtl'
         float m_miterLimit{0.f};

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -136,6 +136,25 @@ namespace Babylon::Polyfills::Internal
         {
             std::variant<std::string, CanvasGradient*> fillStyle;
             std::variant<std::string, CanvasGradient*> strokeStyle;
+
+            // The rest of the wrapper-side drawing state. nvgSave/nvgRestore rewinds
+            // nanovg's own copy of the attributes it knows about, but never these C++
+            // mirrors, so without them a getter keeps reporting the post-save() value
+            // after restore(). The shadow/dash/filter/direction fields have no nanovg
+            // counterpart at all, so they would otherwise never be rewound.
+            std::string lineCap;
+            std::string lineJoin;
+            std::vector<double> lineDash;
+            std::string shadowColor;
+            double shadowBlur;
+            double shadowOffsetX;
+            double shadowOffsetY;
+            std::string filter;
+            std::string direction;
+            float miterLimit;
+            float lineWidth;
+            float globalAlpha;
+            float letterSpacing;
         };
         std::vector<SavedStyle> m_savedStyles;
 

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -132,6 +132,11 @@ namespace Babylon::Polyfills::Internal
             float left, top, width, height;
         } m_rectangleClipping{};
 
+        // Set once the current path contains anything nvgScissor cannot express.
+        bool m_pathHasNonRect{false};
+        // Set when clip() had such a path and had to fall back to path emulation.
+        bool m_isClipped{false};
+
         std::shared_ptr<arcana::cancellation_source> m_cancellationSource{};
         JsRuntimeScheduler m_runtimeScheduler;
 

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -10,6 +10,7 @@
 #include <variant>
 #include <vector>
 #include <cstdint>
+#include <memory>
 
 struct NVGcontext;
 
@@ -106,8 +107,15 @@ namespace Babylon::Polyfills::Internal
         std::shared_ptr<NVGcontext*> m_nvg;
 
         Font m_font;
-        std::variant<std::string, CanvasGradient*> m_fillStyle{};
-        std::variant<std::string, CanvasGradient*> m_strokeStyle{};
+        // A gradient style holds the assigned JavaScript object, not a bare CanvasGradient*.
+        // CanvasGradient is an ObjectWrap, so its native instance is deleted by the wrapper's
+        // finalizer; `ctx.fillStyle = ctx.createLinearGradient(...)` leaves no other reference,
+        // and the pointer dangles as soon as the collector runs. shared_ptr rather than a bare
+        // Napi::ObjectReference because SavedStyle copies these on save()/restore() and a
+        // reference is move-only -- the copies share one strong reference to the same object.
+        using GradientStyle = std::shared_ptr<Napi::ObjectReference>;
+        std::variant<std::string, GradientStyle> m_fillStyle{};
+        std::variant<std::string, GradientStyle> m_strokeStyle{};
         std::string m_lineCap{};  // 'butt', 'round', 'square'
         std::string m_lineJoin{}; // 'round', 'bevel', 'miter'
 
@@ -134,8 +142,8 @@ namespace Babylon::Polyfills::Internal
 
         struct SavedStyle
         {
-            std::variant<std::string, CanvasGradient*> fillStyle;
-            std::variant<std::string, CanvasGradient*> strokeStyle;
+            std::variant<std::string, GradientStyle> fillStyle;
+            std::variant<std::string, GradientStyle> strokeStyle;
 
             // The rest of the wrapper-side drawing state. nvgSave/nvgRestore rewinds
             // nanovg's own copy of the attributes it knows about, but never these C++

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -56,6 +56,7 @@ namespace Babylon::Polyfills::Internal
         void Arc(const Napi::CallbackInfo&);
         void DrawImage(const Napi::CallbackInfo&);
         Napi::Value GetImageData(const Napi::CallbackInfo&);
+        Napi::Value CreateImageData(const Napi::CallbackInfo&);
         void SetLineDash(const Napi::CallbackInfo&);
         void StrokeText(const Napi::CallbackInfo&);
         Napi::Value CreateLinearGradient(const Napi::CallbackInfo&);
@@ -126,8 +127,6 @@ namespace Babylon::Polyfills::Internal
 
         Graphics::DeviceContext& m_graphicsContext;
 
-        bool m_isClipped{false};
-
         struct RectangleClipping
         {
             float left, top, width, height;
@@ -137,7 +136,7 @@ namespace Babylon::Polyfills::Internal
         JsRuntimeScheduler m_runtimeScheduler;
 
         std::unordered_map<const NativeCanvasImage*, int> m_nvgImageIndices;
-        void BindFillStyle(const Napi::CallbackInfo& info, float left, float top, float width, float height);
+        void BindFillStyle(const Napi::CallbackInfo& info);
         void FlushGraphicResources() override;
         void PlayPath2D(const NativeCanvasPath2D* path);
         void SetFilterStack();

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -155,6 +155,12 @@ namespace Babylon::Polyfills::Internal
             float lineWidth;
             float globalAlpha;
             float letterSpacing;
+
+            // font is worse than the getter-only cases above: m_currentFontId is what the
+            // text draw path binds, so without it the wrong face actually renders after a
+            // restore(). nvgRestore rewinds the size it set, but not either of these.
+            Font font;
+            int currentFontId;
         };
         std::vector<SavedStyle> m_savedStyles;
 
@@ -179,6 +185,14 @@ namespace Babylon::Polyfills::Internal
         void FlushGraphicResources() override;
         void PlayPath2D(const NativeCanvasPath2D* path);
         void SetFilterStack();
+
+        // Start a fresh nanovg path and drop the clip state that described the old one.
+        // clip() emulates a non-rectangular path by leaving it current and letting the next
+        // fill draw it, so any operation that resets the path invalidates that emulation:
+        // leaving m_isClipped set makes FillRect skip its own nvgBeginPath and append to a
+        // path that no longer exists, and leaving m_pathHasNonRect set makes a later clip()
+        // take the emulated branch on what is now a plain rect.
+        void ResetPathState();
 
         // CPU-side RGBA8 mirror of the canvas, sized to the canvas, populated by DrawImage so that
         // getImageData can return the exact decoded pixels (the GPU nanovg framebuffer is not read back).

--- a/Polyfills/Canvas/Source/Font.cpp
+++ b/Polyfills/Canvas/Source/Font.cpp
@@ -1,6 +1,8 @@
 #include <regex>
 #include <sstream>
 
+#include <cstring>
+
 #include "Font.h"
 
 namespace
@@ -10,10 +12,95 @@ namespace
     auto SIZE_REGEX = std::regex(R"(^\s*((?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?)px\s)");
     auto FAMILY_IDENT_REGEX = std::regex(R"(^\s*((?:[\w-]|\\.)+))");
     auto FAMILY_STRING_REGEX = std::regex(R"(^\s*(["'])((?:[^\\]|\\.)*?)\1)");
+
+    std::string DescribeValue(const Napi::Value& value)
+    {
+        if (value.IsUndefined()) return "undefined";
+        if (value.IsNull()) return "null";
+        if (value.IsString()) return "a string";
+        if (value.IsNumber()) return "a number";
+        if (value.IsBoolean()) return "a boolean";
+        if (value.IsArray()) return "an array";
+        if (value.IsFunction()) return "a function";
+        if (value.IsPromise()) return "a promise";
+        if (value.IsObject()) return "an object";
+        return "an unsupported value";
+    }
 }
 
 namespace Babylon::Polyfills::Internal
 {
+    std::vector<uint8_t> GetFontDataArgument(const Napi::CallbackInfo& info, size_t index, const char* methodName)
+    {
+        const auto env = info.Env();
+
+        if (info.Length() <= index)
+        {
+            throw Napi::TypeError::New(env, std::string{methodName} + " expects the font data as argument " +
+                std::to_string(index + 1) + ", but only " + std::to_string(info.Length()) + " argument(s) were passed.");
+        }
+
+        const auto value = info[index];
+
+        const uint8_t* data{};
+        size_t byteLength{};
+
+        if (value.IsArrayBuffer())
+        {
+            const auto buffer = value.As<Napi::ArrayBuffer>();
+            data = static_cast<const uint8_t*>(buffer.Data());
+            byteLength = buffer.ByteLength();
+        }
+        else if (value.IsTypedArray())
+        {
+            const auto view = value.As<Napi::TypedArray>();
+            data = static_cast<const uint8_t*>(view.ArrayBuffer().Data()) + view.ByteOffset();
+            byteLength = view.ByteLength();
+        }
+        else if (value.IsDataView())
+        {
+            // Deliberately NOT via Napi::DataView: the Chakra Node-API implementation backs
+            // napi_get_dataview_info with JsGetExternalData, which only succeeds for DataViews
+            // created natively through napi_create_dataview. A DataView constructed in JS fails
+            // with napi_invalid_arg even though napi_is_dataview reports true. Reading the
+            // standard buffer/byteOffset/byteLength properties works on every engine.
+            const auto view = value.As<Napi::Object>();
+            const auto bufferValue = view.Get("buffer");
+            if (!bufferValue.IsArrayBuffer())
+            {
+                throw Napi::TypeError::New(env, std::string{methodName} + " was given a DataView whose 'buffer' is not an ArrayBuffer.");
+            }
+
+            const auto buffer = bufferValue.As<Napi::ArrayBuffer>();
+            const auto byteOffset = static_cast<size_t>(view.Get("byteOffset").As<Napi::Number>().Int64Value());
+            byteLength = static_cast<size_t>(view.Get("byteLength").As<Napi::Number>().Int64Value());
+
+            if (byteOffset > buffer.ByteLength() || byteLength > buffer.ByteLength() - byteOffset)
+            {
+                throw Napi::RangeError::New(env, std::string{methodName} + " was given a DataView that extends past the end of its buffer.");
+            }
+
+            data = static_cast<const uint8_t*>(buffer.Data()) + byteOffset;
+        }
+        else
+        {
+            throw Napi::TypeError::New(env, std::string{methodName} + " expects the font data to be an ArrayBuffer or "
+                "an ArrayBuffer view, but got " + DescribeValue(value) + ". If the font was fetched with "
+                "Tools.LoadFileAsync, request it as binary -- the signature is LoadFileAsync(url, useArrayBuffer), "
+                "and a text response decodes the font to an unusable string.");
+        }
+
+        if (byteLength == 0)
+        {
+            throw Napi::TypeError::New(env, std::string{methodName} + " was given an empty font buffer. The font file "
+                "was most likely fetched as text rather than binary, or the request returned no data.");
+        }
+
+        std::vector<uint8_t> fontBuffer(byteLength);
+        std::memcpy(fontBuffer.data(), data, byteLength);
+        return fontBuffer;
+    }
+
     std::optional<Font> Font::Parse(const std::string& fontString)
     {
         Font font;
@@ -43,8 +130,16 @@ namespace Babylon::Polyfills::Internal
                 {
                     font.m_weight = BOLD_WEIGHT;
                 }
-                else
+                else if (match[1] != "normal")
                 {
+                    // WEIGHT_REGEX also accepts the "normal" keyword, which is
+                    // simply the default weight. Passing it to std::stoi throws
+                    // std::invalid_argument, and because that is not a
+                    // Napi::Error it escapes the N-API callback and terminates
+                    // the process instead of surfacing as a JS exception.
+                    // Babylon GUI composes exactly this string
+                    // ("normal normal 18px Arial") from its default font style
+                    // and weight.
                     font.m_weight = std::stoi(match[1]);
                 }
             }

--- a/Polyfills/Canvas/Source/Font.cpp
+++ b/Polyfills/Canvas/Source/Font.cpp
@@ -1,6 +1,8 @@
 #include <regex>
 #include <sstream>
-
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
 #include <cstring>
 
 #include "Font.h"
@@ -140,7 +142,12 @@ namespace Babylon::Polyfills::Internal
                     // Babylon GUI composes exactly this string
                     // ("normal normal 18px Arial") from its default font style
                     // and weight.
-                    font.m_weight = std::stoi(match[1]);
+                    //
+                    // std::stoi throws std::out_of_range just as fatally for a digit run too
+                    // long for an int, and WEIGHT_REGEX bounds neither the length nor the
+                    // magnitude, so parse without exceptions and clamp to the CSS 1-1000 range.
+                    const std::string weightText{match[1].str()};
+                    font.m_weight = static_cast<int>(std::clamp(std::strtol(weightText.c_str(), nullptr, 10), 1L, 1000L));
                 }
             }
             else
@@ -154,7 +161,16 @@ namespace Babylon::Polyfills::Internal
             return std::nullopt;
         }
         begin = match[0].second;
-        font.m_size = std::stof(match[1]);
+        // SIZE_REGEX accepts an exponent, so "18e999px" parses as a valid size that std::stof
+        // would reject with a fatal std::out_of_range. strtof saturates to infinity instead;
+        // reject a non-finite size outright rather than handing it to nanovg.
+        const std::string sizeText{match[1].str()};
+        const float size = std::strtof(sizeText.c_str(), nullptr);
+        if (!std::isfinite(size))
+        {
+            return std::nullopt;
+        }
+        font.m_size = size;
 
         if (std::regex_search(begin, end, match, FAMILY_IDENT_REGEX))
         {

--- a/Polyfills/Canvas/Source/Font.cpp
+++ b/Polyfills/Canvas/Source/Font.cpp
@@ -87,9 +87,8 @@ namespace Babylon::Polyfills::Internal
         else
         {
             throw Napi::TypeError::New(env, std::string{methodName} + " expects the font data to be an ArrayBuffer or "
-                "an ArrayBuffer view, but got " + DescribeValue(value) + ". If the font was fetched with "
-                "Tools.LoadFileAsync, request it as binary -- the signature is LoadFileAsync(url, useArrayBuffer), "
-                "and a text response decodes the font to an unusable string.");
+                "an ArrayBuffer view, but got " + DescribeValue(value) + ". A font fetched as text rather than "
+                "binary decodes to an unusable string and arrives this way.");
         }
 
         if (byteLength == 0)

--- a/Polyfills/Canvas/Source/Font.h
+++ b/Polyfills/Canvas/Source/Font.h
@@ -1,10 +1,24 @@
 #pragma once
 
+#include <napi/napi.h>
+
+#include <cstdint>
 #include <string>
 #include <optional>
+#include <vector>
 
 namespace Babylon::Polyfills::Internal
 {
+    // Extracts the font file bytes from the second argument of Canvas.loadTTF / loadTTFAsync.
+    //
+    // Accepts an ArrayBuffer or any ArrayBuffer view (typed array / DataView), matching what
+    // callers actually have on hand. Anything else throws a Napi::TypeError naming the method,
+    // the argument and what was received, instead of the bare "Invalid argument" that an
+    // unchecked As<Napi::ArrayBuffer>() cast produces -- that message gives no clue which call
+    // failed or why, and in practice it is almost always a caller that fetched the font as text
+    // rather than binary.
+    std::vector<uint8_t> GetFontDataArgument(const Napi::CallbackInfo& info, size_t index, const char* methodName);
+
     enum class FontStyle
     {
         Normal,

--- a/Polyfills/Canvas/Source/Gradient.cpp
+++ b/Polyfills/Canvas/Source/Gradient.cpp
@@ -22,7 +22,10 @@
 namespace Babylon::Polyfills::Internal
 {
     static const int GRADIENT_SAMPLES_L = 256;
-    static const int GRADIENT_SAMPLES_R = 256;
+    // The radial field is baked over the bounding box of both circles, which can be much larger
+    // than the shape being filled, so it needs more samples than the 1D linear ramp to stay
+    // smooth after nanovg's bilinear stretch.
+    static const int GRADIENT_SAMPLES_R = 512;
 
     typedef struct LVGColorTransform
     {
@@ -38,6 +41,25 @@ namespace Babylon::Polyfills::Internal
 
     float clampf(float a, float mn, float mx) { return a < mn ? mn : (a > mx ? mx : a); }
 
+    // Canvas2D interpolates gradient stops in premultiplied sRGBA space. Interpolating the
+    // straight (unpremultiplied) components instead bleeds a transparent stop's RGB into the
+    // ramp: "#ff0000ff" -> "#00000000" darkens through maroon to black rather than staying red
+    // and only losing alpha.
+    NVGcolor premultiply(NVGcolor c)
+    {
+        return nvgRGBAf(c.r * c.a, c.g * c.a, c.b * c.a, c.a);
+    }
+
+    NVGcolor unpremultiply(NVGcolor c)
+    {
+        if (c.a <= 0.0f)
+        {
+            return nvgRGBAf(0.f, 0.f, 0.f, 0.f);
+        }
+        const float inv = 1.0f / c.a;
+        return nvgRGBAf(clampf(c.r * inv, 0.f, 1.f), clampf(c.g * inv, 0.f, 1.f), clampf(c.b * inv, 0.f, 1.f), clampf(c.a, 0.f, 1.f));
+    }
+
     void gradientSpan(uint32_t* dst, NVGcolor color0, NVGcolor color1, float offset0, float offset1)
     {
         float s0o = clampf(offset0, 0.0f, 1.0f);
@@ -50,17 +72,21 @@ namespace Babylon::Polyfills::Internal
         {
             return;
         }
-        float r = color0.rgba[0];
-        float g = color0.rgba[1];
-        float b = color0.rgba[2];
-        float a = color0.rgba[3];
-        float dr = (color1.rgba[0] - r) / (e - s);
-        float dg = (color1.rgba[1] - g) / (e - s);
-        float db = (color1.rgba[2] - b) / (e - s);
-        float da = (color1.rgba[3] - a) / (e - s);
+        const NVGcolor p0 = premultiply(color0);
+        const NVGcolor p1 = premultiply(color1);
+        float r = p0.rgba[0];
+        float g = p0.rgba[1];
+        float b = p0.rgba[2];
+        float a = p0.rgba[3];
+        float dr = (p1.rgba[0] - r) / (e - s);
+        float dg = (p1.rgba[1] - g) / (e - s);
+        float db = (p1.rgba[2] - b) / (e - s);
+        float da = (p1.rgba[3] - a) / (e - s);
         for (unsigned i = s; i < e; i++)
         {
-            unsigned ur = (unsigned)(r * 255); unsigned ug = (unsigned)(g * 255); unsigned ub = (unsigned)(b * 255); unsigned ua = (unsigned)(a * 255);
+            // The baked image is sampled as straight alpha, so undo the premultiplication here.
+            const NVGcolor straight = unpremultiply(nvgRGBAf(r, g, b, a));
+            unsigned ur = (unsigned)(straight.r * 255); unsigned ug = (unsigned)(straight.g * 255); unsigned ub = (unsigned)(straight.b * 255); unsigned ua = (unsigned)(straight.a * 255);
             dst[i] = (ua << 24) | (ub << 16) | (ug << 8) | ur;
             r += dr; g += dg; b += db; a += da;
         }
@@ -193,12 +219,15 @@ namespace Babylon::Polyfills::Internal
 
     NVGcolor lerpColor(NVGcolor color0, NVGcolor color1, float offset0, float offset1, float g)
     {
+        // See gradientSpan: stops are interpolated premultiplied, then converted back to the
+        // straight alpha the baked image is sampled with.
+        const NVGcolor p0 = premultiply(color0);
+        const NVGcolor p1 = premultiply(color1);
         NVGcolor dst;
         float den = std::max(0.00001f, offset1 - offset0);
         for (int i = 0; i < 4; i++)
-            dst.rgba[i] = color0.rgba[i] + (color1.rgba[i] - color0.rgba[i]) * (g - offset0) / den;
-        dst = nvgRGBAf(std::max(0.0f, std::min(dst.r, 1.0f)), std::max(0.0f, std::min(dst.g, 1.0f)), std::max(0.0f, std::min(dst.b, 1.0f)), std::max(0.0f, std::min(dst.a, 1.0f)));
-        return dst;
+            dst.rgba[i] = p0.rgba[i] + (p1.rgba[i] - p0.rgba[i]) * (g - offset0) / den;
+        return unpremultiply(dst);
     }
 
     void calcStops(const std::vector<ColorStop>& gradient, LVGColorTransform* x, NVGcolor* color0, NVGcolor* color1, float* stop0, float* stop1, float g)
@@ -233,120 +262,128 @@ namespace Babylon::Polyfills::Internal
         *stop1 = s1[0];
     }
 
+    // Solves the Canvas2D radial gradient equation at a point: finds the largest offset w for
+    // which the point lies on the circle interpolated between (x0,y0,r0) and (x1,y1,r1), i.e.
+    // |p - (c0 + w*cd)| == r0 + w*dr with a non-negative radius. Returns false when no such
+    // circle exists, in which case the spec leaves the point unpainted.
+    static bool solveRadialOffset(float px, float py, float x0, float y0, float r0, float x1, float y1, float r1, float& offset)
+    {
+        const float cdx = x1 - x0;
+        const float cdy = y1 - y0;
+        const float dr = r1 - r0;
+        const float pdx = px - x0;
+        const float pdy = py - y0;
+
+        const float a = cdx * cdx + cdy * cdy - dr * dr;
+        const float b = pdx * cdx + pdy * cdy + r0 * dr;
+        const float c = pdx * pdx + pdy * pdy - r0 * r0;
+
+        // 'a' is a difference of squared lengths, so it has to be tested relative to their
+        // magnitude: an absolute epsilon would miss the degenerate case entirely once the
+        // coordinates are in the hundreds.
+        const float scale = cdx * cdx + cdy * cdy + dr * dr;
+        if (std::fabs(a) <= 1e-6f * std::max(scale, 1.0f))
+        {
+            // The two circles are tangent, so the quadratic collapses to a linear equation.
+            // This is not an exotic edge case: createRadialGradient(100,100,150, 250,100,300)
+            // lands here.
+            if (b == 0.0f)
+            {
+                return false;
+            }
+            offset = c / (2.0f * b);
+            return (r0 + offset * dr) >= 0.0f;
+        }
+
+        const float discriminant = b * b - a * c;
+        if (discriminant < 0.0f)
+        {
+            return false;
+        }
+        const float root = std::sqrt(discriminant);
+        const float larger = std::max((b + root) / a, (b - root) / a);
+        const float smaller = std::min((b + root) / a, (b - root) / a);
+        // The spec paints the circles in increasing offset order, so the largest solution with
+        // a non-negative radius is the one visible at this point.
+        if ((r0 + larger * dr) >= 0.0f)
+        {
+            offset = larger;
+            return true;
+        }
+        if ((r0 + smaller * dr) >= 0.0f)
+        {
+            offset = smaller;
+            return true;
+        }
+        return false;
+    }
+
     int CanvasGradient::RadialGradientStops(LVGColorTransform* cxform)
     {
-        const int width = GRADIENT_SAMPLES_R, height = GRADIENT_SAMPLES_R;
-        uint32_t* image = (unsigned int*)malloc(width * height * sizeof(uint32_t));
-        static const int SPREAD_PAD = 0;
-        static const int SPREAD_REPEAT = 1;
-        static const int SPREAD_REFLECT = 2;
+        const size_t nstops = colors.size();
+        if (!nstops)
+        {
+            return 0;
+        }
 
-        size_t nstops = colors.size();
-        int stopIndex{};
         std::vector<ColorStop> colorStops(nstops);
+        int stopIndex{};
         for (auto& stop : colors)
         {
             colorStops[stopIndex++] = { stop.first, stop.second };
         }
-        int spreadMode = 0;
 
-        float fxn = width / 2;
-        float fyn = height / 2;
-        float fxp = 0;
-        float fyp = 0;
-        float rn = width / 2 - 1.0001f;
-        float denominator = (rn * rn) - (fxp * fxp + fyp * fyp);
+        // A radial gradient is defined by two independently positioned circles, so the field
+        // cannot be baked as a centered disc: bake it over the bounding box that encloses both
+        // circles and evaluate the real two-circle equation per texel. Every point on that box's
+        // border lies outside both circles, so the ramp has already padded out to an end stop
+        // there and nanovg's clamp-to-edge sampling extends that same color across the rest of
+        // whatever shape is being filled -- exactly the "pad" behavior the spec requires.
+        imageX = std::min(x0 - r0, x1 - r1);
+        imageY = std::min(y0 - r0, y1 - r1);
+        imageW = std::max(std::max(x0 + r0, x1 + r1) - imageX, 1e-4f);
+        imageH = std::max(std::max(y0 + r0, y1 + r1) - imageY, 1e-4f);
 
-        for (int x = 0; x < width; x++)
+        const int width = GRADIENT_SAMPLES_R;
+        const int height = GRADIENT_SAMPLES_R;
+        std::vector<uint32_t> image(static_cast<size_t>(width) * static_cast<size_t>(height));
+
+        for (int y = 0; y < height; y++)
         {
-            float dx = x - fxn;
-            for (int y = 0; y < height; y++)
+            const float py = imageY + (static_cast<float>(y) + 0.5f) * imageH / static_cast<float>(height);
+            for (int x = 0; x < width; x++)
             {
-                float dy = y - fyn;
+                const float px = imageX + (static_cast<float>(x) + 0.5f) * imageW / static_cast<float>(width);
 
-                float numerator = (dx * fxp + dy * fyp);
-                float df = dx * fyp - dy * fxp;
-                numerator += std::sqrt((rn * rn) * (dx * dx + dy * dy) - (df * df));
-                float g = numerator / denominator;
-
-                // color = c0 + (c1 - c0)(g - x0)/(x1 - x0)
-                // where c0 = stop color 0, c1 = stop color 1
-                // where x0 = stop offset 0, x1 = stop offset 1
                 NVGcolor finalcolor;
-                float stop0, stop1;
-                NVGcolor color0, color1;
-
-                if (spreadMode == SPREAD_PAD)
+                float g{};
+                if (!solveRadialOffset(px, py, x0, y0, r0, x1, y1, r1, g))
                 {
-                    if (g < 0.0f)
-                    {
-                        finalcolor = transformColor(colorStops[0].color, cxform);
-                    }
-                    else if (g > 1.0f)
-                    {
-                        finalcolor = transformColor(colorStops[nstops - 1].color, cxform);
-                    }
-                    else
-                    {
-                        calcStops(colorStops, cxform, &color0, &color1, &stop0, &stop1, g);
-                        finalcolor = lerpColor(color0, color1, stop0, stop1, g);
-                    }
+                    finalcolor = nvgRGBAf(0.f, 0.f, 0.f, 0.f);
+                }
+                else if (g <= 0.0f)
+                {
+                    finalcolor = transformColor(colorStops[0].color, cxform);
+                }
+                else if (g >= 1.0f)
+                {
+                    finalcolor = transformColor(colorStops[nstops - 1].color, cxform);
                 }
                 else
                 {
-                    int w = (int)std::fabs(g);
-                    if (spreadMode == SPREAD_REPEAT)
-                    {
-                        if (g < 0)
-                        {
-                            g = 1 - (std::fabs(g) - w);
-                        }
-                        else
-                        {
-                            g = g - w;
-                        }
-                    }
-                    else if (spreadMode == SPREAD_REFLECT)
-                    {
-                        if (g < 0)
-                        {
-                            if (w % 2 == 0)
-                            {   // even
-                                g = (std::fabs(g) - w);
-                            }
-                            else
-                            {   // odd
-                                g = (1 - (std::fabs(g) - w));
-                            }
-                        }
-                        else
-                        {
-                            if (w % 2 == 0)
-                            {   // even
-                                g = g - w;
-                            }
-                            else
-                            {   // odd
-                                g = 1 - (g - w);
-                            }
-                        }
-                    }
-                    // clamp
-                    if (g > 1)
-                        g = 1;
-                    if (g < 0)
-                        g = 0;
+                    float stop0, stop1;
+                    NVGcolor color0, color1;
                     calcStops(colorStops, cxform, &color0, &color1, &stop0, &stop1, g);
                     finalcolor = lerpColor(color0, color1, stop0, stop1, g);
                 }
-                uint32_t color = ((uint32_t)(finalcolor.a * 255) << 24) | ((uint32_t)(finalcolor.b * 255) << 16) |
+
+                image[(static_cast<size_t>(y) * static_cast<size_t>(width)) + static_cast<size_t>(x)] =
+                    ((uint32_t)(finalcolor.a * 255) << 24) | ((uint32_t)(finalcolor.b * 255) << 16) |
                     ((uint32_t)(finalcolor.g * 255) << 8) | (uint32_t)(finalcolor.r * 255);
-                image[(y * width) + x] = color;
             }
         }
-        int img = nvgCreateImageRGBA(*context.lock(), width, height, 0, (unsigned char*)image);
-        free(image);
-        return img;
+
+        return nvgCreateImageRGBA(*context.lock(), width, height, 0, (unsigned char*)image.data());
     }
 
     NVGpaint CanvasGradient::Paint()
@@ -382,10 +419,9 @@ namespace Babylon::Polyfills::Internal
             return nvgImagePattern(*nvg, x0, y0, length, length, std::atan2(dy, dx), cachedImage, 1.f);
         }
 
-        // The radial ramp is baked into a square image whose inscribed circle is the r1
-        // isoline, so map that image onto the bounding box of the outer circle.
-        const float radius = std::max(r1, 1e-4f);
-        return nvgImagePattern(*nvg, x1 - radius, y1 - radius, 2.f * radius, 2.f * radius, 0.f, cachedImage, 1.f);
+        // The radial ramp is baked over the bounding box of both circles (see
+        // RadialGradientStops), so map the image straight back onto that box in user space.
+        return nvgImagePattern(*nvg, imageX, imageY, std::max(imageW, 1e-4f), std::max(imageH, 1e-4f), 0.f, cachedImage, 1.f);
     }
 
     void CanvasGradient::UpdateCache()

--- a/Polyfills/Canvas/Source/Gradient.cpp
+++ b/Polyfills/Canvas/Source/Gradient.cpp
@@ -163,9 +163,11 @@ namespace Babylon::Polyfills::Internal
     {
         if (cachedImage >= 0)
         {
-            if (context.lock())
+            // Lock once and keep the result: calling context.lock() a second time could observe
+            // an expired context and dereference an empty shared_ptr.
+            if (auto nvg = context.lock(); nvg && *nvg != nullptr)
             {
-                nvgDeleteImage(*context.lock(), cachedImage);
+                nvgDeleteImage(*nvg, cachedImage);
             }
             cachedImage = -1;
         }
@@ -181,7 +183,7 @@ namespace Babylon::Polyfills::Internal
         dirty = true;
     }
 
-    int CanvasGradient::LinearGradientStops(LVGColorTransform* x)
+    int CanvasGradient::LinearGradientStops(NVGcontext& nvg, LVGColorTransform* x)
     {
         size_t nstops = colors.size();
         if (!nstops)
@@ -214,7 +216,7 @@ namespace Babylon::Polyfills::Internal
             NVGcolor s0 = transformColor(colorStops[nstops - 1].color, x);
             gradientSpan(data, s0, s0, colorStops[nstops - 1].offset, 1.0f);
         }
-        return nvgCreateImageRGBA(*context.lock(), GRADIENT_SAMPLES_L, 1, 0, (unsigned char*)data);
+        return nvgCreateImageRGBA(&nvg, GRADIENT_SAMPLES_L, 1, 0, (unsigned char*)data);
     }
 
     NVGcolor lerpColor(NVGcolor color0, NVGcolor color1, float offset0, float offset1, float g)
@@ -318,7 +320,7 @@ namespace Babylon::Polyfills::Internal
         return false;
     }
 
-    int CanvasGradient::RadialGradientStops(LVGColorTransform* cxform)
+    int CanvasGradient::RadialGradientStops(NVGcontext& nvg, LVGColorTransform* cxform)
     {
         const size_t nstops = colors.size();
         if (!nstops)
@@ -383,7 +385,7 @@ namespace Babylon::Polyfills::Internal
             }
         }
 
-        return nvgCreateImageRGBA(*context.lock(), width, height, 0, (unsigned char*)image.data());
+        return nvgCreateImageRGBA(&nvg, width, height, 0, (unsigned char*)image.data());
     }
 
     NVGpaint CanvasGradient::Paint()
@@ -391,9 +393,10 @@ namespace Babylon::Polyfills::Internal
         UpdateCache();
 
         auto nvg = context.lock();
-        if (!nvg)
+        if (!nvg || *nvg == nullptr || cachedImage < 0)
         {
-            // The owning context is gone; there is nothing sensible to paint with.
+            // The owning context is gone, or the ramp could not be baked; there is nothing
+            // sensible to paint with.
             return NVGpaint{};
         }
 
@@ -430,11 +433,25 @@ namespace Babylon::Polyfills::Internal
         {
             return;
         }
+
+        // Lock the context once and hold it for the whole update. Baking a ramp deletes the old
+        // nanovg image and creates a new one, so re-locking inside each step would let the
+        // context expire between them and leave a dangling dereference behind.
+        auto nvg = context.lock();
+        if (!nvg || *nvg == nullptr)
+        {
+            // The owning context is gone. Stay dirty and leave cachedImage alone: Dispose()
+            // already skips deleting images whose context has expired, and Paint() returns an
+            // empty paint in this state.
+            return;
+        }
+
         if (cachedImage >= 0)
         {
-            nvgDeleteImage(*context.lock(), cachedImage);
+            nvgDeleteImage(*nvg, cachedImage);
+            cachedImage = -1;
         }
-        cachedImage = gradientType == GradientType::Linear ? LinearGradientStops(nullptr) : RadialGradientStops(nullptr);
+        cachedImage = gradientType == GradientType::Linear ? LinearGradientStops(**nvg, nullptr) : RadialGradientStops(**nvg, nullptr);
         dirty = false;
     }
 }

--- a/Polyfills/Canvas/Source/Gradient.cpp
+++ b/Polyfills/Canvas/Source/Gradient.cpp
@@ -44,6 +44,12 @@ namespace Babylon::Polyfills::Internal
         float s1o = clampf(offset1, 0.0f, 1.0f);
         unsigned s = static_cast<unsigned>(s0o * static_cast<float>(GRADIENT_SAMPLES_L));
         unsigned e = static_cast<unsigned>(s1o * static_cast<float>(GRADIENT_SAMPLES_L));
+        // Coincident stops produce an empty span; the per-sample deltas below would divide
+        // by zero and write NaNs into the ramp.
+        if (e <= s)
+        {
+            return;
+        }
         float r = color0.rgba[0];
         float g = color0.rgba[1];
         float b = color0.rgba[2];
@@ -156,7 +162,9 @@ namespace Babylon::Polyfills::Internal
         {
             return 0;
         }
-        uint32_t data[GRADIENT_SAMPLES_L];
+        // Zero-initialize: the spans below only cover the range the stops span, so any
+        // sample left untouched would otherwise be read from uninitialized stack memory.
+        uint32_t data[GRADIENT_SAMPLES_L]{};
         int stopIndex{};
         std::vector<ColorStop> colorStops(nstops);
         for (auto& stop : colors)
@@ -339,6 +347,36 @@ namespace Babylon::Polyfills::Internal
         int img = nvgCreateImageRGBA(*context.lock(), width, height, 0, (unsigned char*)image);
         free(image);
         return img;
+    }
+
+    NVGpaint CanvasGradient::Paint()
+    {
+        UpdateCache();
+
+        auto nvg = context.lock();
+        if (gradientType == GradientType::Linear)
+        {
+            // The linear ramp is baked into a GRADIENT_SAMPLES_L x 1 image, so orient the
+            // pattern along (x0,y0)->(x1,y1) and let it span exactly that distance. The
+            // vertical extent is irrelevant (the image is one texel tall and clamps), but it
+            // must be non-zero. Sampling outside the extent clamps to the edge texel, which
+            // is precisely the "pad" behavior the spec requires beyond the end stops.
+            const float dx = x1 - x0;
+            const float dy = y1 - y0;
+            float length = std::sqrt(dx * dx + dy * dy);
+            if (length < 1e-4f)
+            {
+                // A zero-length gradient would divide by zero in the shader; keep it finite so
+                // the whole shape clamps to a single stop instead of rendering garbage.
+                length = 1e-4f;
+            }
+            return nvgImagePattern(*nvg, x0, y0, length, length, std::atan2(dy, dx), cachedImage, 1.f);
+        }
+
+        // The radial ramp is baked into a square image whose inscribed circle is the r1
+        // isoline, so map that image onto the bounding box of the outer circle.
+        const float radius = std::max(r1, 1e-4f);
+        return nvgImagePattern(*nvg, x1 - radius, y1 - radius, 2.f * radius, 2.f * radius, 0.f, cachedImage, 1.f);
     }
 
     void CanvasGradient::UpdateCache()

--- a/Polyfills/Canvas/Source/Gradient.cpp
+++ b/Polyfills/Canvas/Source/Gradient.cpp
@@ -41,10 +41,6 @@ namespace Babylon::Polyfills::Internal
 
     float clampf(float a, float mn, float mx) { return a < mn ? mn : (a > mx ? mx : a); }
 
-    // Canvas2D interpolates gradient stops in premultiplied sRGBA space. Interpolating the
-    // straight (unpremultiplied) components instead bleeds a transparent stop's RGB into the
-    // ramp: "#ff0000ff" -> "#00000000" darkens through maroon to black rather than staying red
-    // and only losing alpha.
     NVGcolor premultiply(NVGcolor c)
     {
         return nvgRGBAf(c.r * c.a, c.g * c.a, c.b * c.a, c.a);
@@ -72,6 +68,10 @@ namespace Babylon::Polyfills::Internal
         {
             return;
         }
+        // Canvas2D interpolates gradient stops in premultiplied sRGBA space. Interpolating the
+        // straight (unpremultiplied) components instead bleeds a transparent stop's RGB into the
+        // ramp: "#ff0000ff" -> "#00000000" darkens through maroon to black rather than staying red
+        // and only losing alpha.
         const NVGcolor p0 = premultiply(color0);
         const NVGcolor p1 = premultiply(color1);
         float r = p0.rgba[0];
@@ -116,6 +116,17 @@ namespace Babylon::Polyfills::Internal
                 
             });
         JsRuntime::NativeObject::GetFromJavaScript(env).Set(JS_CANVAS_GRADIENT_CONSTRUCTOR_NAME, func);
+    }
+
+    bool CanvasGradient::IsInstance(Napi::Env env, const Napi::Value& value)
+    {
+        if (!value.IsObject())
+        {
+            return false;
+        }
+
+        const auto constructor = JsRuntime::NativeObject::GetFromJavaScript(env).Get(JS_CANVAS_GRADIENT_CONSTRUCTOR_NAME);
+        return constructor.IsFunction() && value.As<Napi::Object>().InstanceOf(constructor.As<Napi::Function>());
     }
 
     Napi::Object CanvasGradient::CreateLinear(Napi::Env env, const std::shared_ptr<NVGcontext*>& context, float x0, float y0, float x1, float y1)

--- a/Polyfills/Canvas/Source/Gradient.cpp
+++ b/Polyfills/Canvas/Source/Gradient.cpp
@@ -365,8 +365,11 @@ namespace Babylon::Polyfills::Internal
             // The linear ramp is baked into a GRADIENT_SAMPLES_L x 1 image, so orient the
             // pattern along (x0,y0)->(x1,y1) and let it span exactly that distance. The
             // vertical extent is irrelevant (the image is one texel tall and clamps), but it
-            // must be non-zero. Sampling outside the extent clamps to the edge texel, which
-            // is precisely the "pad" behavior the spec requires beyond the end stops.
+            // must be non-zero, and matching it to the length keeps u and v on the same scale
+            // -- nanovg divides the fragment position by the extent, so a small fixed height
+            // against a long gradient would cost float precision. Sampling outside the extent
+            // clamps to the edge texel, which is precisely the "pad" behavior the spec
+            // requires beyond the end stops.
             const float dx = x1 - x0;
             const float dy = y1 - y0;
             float length = std::sqrt(dx * dx + dy * dy);

--- a/Polyfills/Canvas/Source/Gradient.cpp
+++ b/Polyfills/Canvas/Source/Gradient.cpp
@@ -354,6 +354,12 @@ namespace Babylon::Polyfills::Internal
         UpdateCache();
 
         auto nvg = context.lock();
+        if (!nvg)
+        {
+            // The owning context is gone; there is nothing sensible to paint with.
+            return NVGpaint{};
+        }
+
         if (gradientType == GradientType::Linear)
         {
             // The linear ramp is baked into a GRADIENT_SAMPLES_L x 1 image, so orient the

--- a/Polyfills/Canvas/Source/Gradient.h
+++ b/Polyfills/Canvas/Source/Gradient.h
@@ -32,6 +32,8 @@ namespace Babylon::Polyfills::Internal
     protected:
         float x0, y0, x1, y1;
         float r0, r1;
+        // User-space box the radial ramp image is baked over and mapped back onto.
+        float imageX{}, imageY{}, imageW{1e-4f}, imageH{1e-4f};
         std::map<float, NVGcolor> colors;
         int cachedImage{-1};
         std::weak_ptr< NVGcontext*> context;

--- a/Polyfills/Canvas/Source/Gradient.h
+++ b/Polyfills/Canvas/Source/Gradient.h
@@ -45,7 +45,9 @@ namespace Babylon::Polyfills::Internal
         };
         GradientType gradientType;
         void AddColorStop(const Napi::CallbackInfo& info);
-        int LinearGradientStops(LVGColorTransform* x);
-        int RadialGradientStops(LVGColorTransform* cxform);
+        // Both take the context by reference rather than re-locking `context` themselves: the
+        // caller owns the lock for the whole bake, so it cannot expire midway through.
+        int LinearGradientStops(NVGcontext& nvg, LVGColorTransform* x);
+        int RadialGradientStops(NVGcontext& nvg, LVGColorTransform* cxform);
     };
 }

--- a/Polyfills/Canvas/Source/Gradient.h
+++ b/Polyfills/Canvas/Source/Gradient.h
@@ -21,6 +21,12 @@ namespace Babylon::Polyfills::Internal
 
         void UpdateCache();
         int CachedImage() const { return cachedImage; }
+
+        // Builds the nanovg paint that maps the baked color ramp onto this gradient's own
+        // geometry. Callers must not derive the pattern from the shape being filled: per the
+        // Canvas2D spec a gradient is positioned by the coordinates given to
+        // createLinear/RadialGradient, in user space, independently of what it fills.
+        NVGpaint Paint();
         void Dispose();
 
     protected:

--- a/Polyfills/Canvas/Source/Gradient.h
+++ b/Polyfills/Canvas/Source/Gradient.h
@@ -16,6 +16,12 @@ namespace Babylon::Polyfills::Internal
         static Napi::Object CreateLinear(Napi::Env env, const std::shared_ptr<NVGcontext*>& context, float x0, float y0, float x1, float y1);
         static Napi::Object CreateRadial(Napi::Env env, const std::shared_ptr<NVGcontext*>& context, float x0, float y0, float r0, float x1, float y1, float r1);
 
+        // True only for objects this polyfill's own constructor produced. Unwrap() is a
+        // napi_unwrap, which dereferences whatever the object's slot happens to hold, so
+        // callers must establish the type first: `ctx.strokeStyle = {}` is reachable from
+        // script and would otherwise unwrap an object that was never wrapped.
+        static bool IsInstance(Napi::Env env, const Napi::Value& value);
+
         explicit CanvasGradient(const Napi::CallbackInfo& info);
         virtual ~CanvasGradient();
 

--- a/Polyfills/Canvas/Source/Gradient.h
+++ b/Polyfills/Canvas/Source/Gradient.h
@@ -34,7 +34,11 @@ namespace Babylon::Polyfills::Internal
         float r0, r1;
         // User-space box the radial ramp image is baked over and mapped back onto.
         float imageX{}, imageY{}, imageW{1e-4f}, imageH{1e-4f};
-        std::map<float, NVGcolor> colors;
+        // multimap, not map: the Canvas2D spec allows two stops at the same offset, and
+        // uses that to express a hard color transition. std::map::insert() would silently
+        // drop the second one. Equivalent keys keep insertion order, which is the order
+        // the spec resolves them in, and both consumers below just walk this in order.
+        std::multimap<float, NVGcolor> colors;
         int cachedImage{-1};
         std::weak_ptr< NVGcontext*> context;
         bool dirty{};

--- a/Polyfills/Canvas/Source/ImageData.cpp
+++ b/Polyfills/Canvas/Source/ImageData.cpp
@@ -58,11 +58,18 @@ namespace Babylon::Polyfills::Internal
             throw Napi::RangeError::New(info.Env(), "ImageData: requested region is too large.");
         }
 
-        m_pixels.resize(static_cast<size_t>(pixelCount) * 4);
-        if (context != nullptr && !m_pixels.empty())
+        // Uint8ClampedArray, not Uint8Array: the spec clamps out-of-range writes
+        // to 0..255, whereas a plain Uint8Array wraps them modulo 256, so
+        // saturating arithmetic in JS (`data[i] = value + 40`) silently produces
+        // a dark pixel instead of a bright one.
+        const auto byteLength{static_cast<size_t>(pixelCount) * 4};
+        auto data{Napi::Uint8Array::New(info.Env(), byteLength, napi_uint8_clamped_array)};
+        if (context != nullptr && byteLength > 0)
         {
-            context->ReadPixels(sx, sy, m_width, m_height, m_pixels.data());
+            context->ReadPixels(sx, sy, m_width, m_height, data.Data());
         }
+
+        m_data = Napi::Persistent(data);
     }
 
     Napi::Value ImageData::GetWidth(const Napi::CallbackInfo&)
@@ -75,14 +82,8 @@ namespace Babylon::Polyfills::Internal
         return Napi::Value::From(Env(), m_height);
     }
 
-    Napi::Value ImageData::GetData(const Napi::CallbackInfo& info)
+    Napi::Value ImageData::GetData(const Napi::CallbackInfo&)
     {
-        const auto size{m_pixels.size()};
-        auto data{Napi::Uint8Array::New(info.Env(), size)};
-        if (size > 0)
-        {
-            std::memcpy(data.Data(), m_pixels.data(), size);
-        }
-        return Napi::Value::From(info.Env(), data);
+        return m_data.Value();
     }
 }

--- a/Polyfills/Canvas/Source/ImageData.h
+++ b/Polyfills/Canvas/Source/ImageData.h
@@ -20,6 +20,11 @@ namespace Babylon::Polyfills::Internal
 
         uint32_t m_width{};
         uint32_t m_height{};
-        std::vector<uint8_t> m_pixels;
+
+        // The spec requires `data` to be one live buffer that the caller can
+        // mutate in place; handing back a fresh copy per access silently drops
+        // every write, which breaks the standard getImageData/putImageData
+        // round trip. Hold the array itself so each read returns the same one.
+        Napi::Reference<Napi::Uint8Array> m_data;
     };
 }

--- a/Polyfills/Canvas/Source/Path2D.cpp
+++ b/Polyfills/Canvas/Source/Path2D.cpp
@@ -43,6 +43,16 @@ namespace Babylon::Polyfills::Internal
             });
 
         JsRuntime::NativeObject::GetFromJavaScript(env).Set(JS_PATH2D_CONSTRUCTOR_NAME, func);
+
+        // Browsers expose Path2D as a global constructor, and Babylon.js relies on that: the generic
+        // engines call `new Path2D(d)` from AbstractEngine.createCanvasPath2D. Only NativeEngine
+        // overrides that method to use `_native.Path2D`, so without the global any portable browser
+        // code doing `new Path2D(...)` fails with "Path2D is not defined".
+        auto global = env.Global();
+        if (global.Get(JS_PATH2D_CONSTRUCTOR_NAME).IsUndefined())
+        {
+            global.Set(JS_PATH2D_CONSTRUCTOR_NAME, func);
+        }
     }
 
     NativeCanvasPath2D::NativeCanvasPath2D(const Napi::CallbackInfo& info)

--- a/Polyfills/Canvas/Source/Path2D.cpp
+++ b/Polyfills/Canvas/Source/Path2D.cpp
@@ -49,10 +49,13 @@ namespace Babylon::Polyfills::Internal
         // overrides that method to use `_native.Path2D`, so without the global any portable browser
         // code doing `new Path2D(...)` fails with "Path2D is not defined".
         auto global = env.Global();
-        if (global.Get(JS_PATH2D_CONSTRUCTOR_NAME).IsUndefined())
-        {
-            global.Set(JS_PATH2D_CONSTRUCTOR_NAME, func);
-        }
+
+        // Claim the global unconditionally. A Path2D from anywhere else cannot be drawn by this
+        // Context -- Context::Fill unwraps whatever object it is handed as a NativeCanvasPath2D --
+        // so deferring to a foreign constructor would only guarantee that `ctx.fill(new Path2D(d))`
+        // unwraps an object that was never wrapped. Canvas::Initialize calls this while the
+        // polyfill is still installing, so anything already there came from outside it.
+        global.Set(JS_PATH2D_CONSTRUCTOR_NAME, func);
     }
 
     NativeCanvasPath2D::NativeCanvasPath2D(const Napi::CallbackInfo& info)


### PR DESCRIPTION
Fixes #1782.

21 Canvas2D bugs in the shared canvas polyfill. All are backend-agnostic (nanovg / polyfill level), so they affect the existing bgfx path exactly as found — I hit them while bringing up a WebGPU canvas backend, but nothing here is WebGPU-specific.

Most are "the method threw `not implemented` but the caller was asking for nothing", or "the paint was built from the wrong geometry". Several have to land together: 1-4 are all required before the GUI ColorPicker renders at all, and 5-8 before a gradient-stroked GUI control renders at all.

## Correctness

| # | Bug |
| --- | --- |
| 1 | `ImageData.data` returned a fresh copy on every access, so `getImageData` → mutate → `putImageData` silently no-op'd. It is also now the specified `Uint8ClampedArray`; a plain `Uint8Array` wrapped `data[i] = v + 40` modulo 256, turning bright pixels dark |
| 2 | `clip()` suppressed `beginPath()` for every later draw, so each fill repainted the union of every rect since the clip |
| 3 | 3-arg `drawImage(img, dx, dy)` anchored the pattern at `(0,0)` while drawing the rect at `(dx,dy)`, so it drew nothing at any non-zero offset |
| 4 | Gradient paint was built from the shape being filled, not the gradient — every gradient came out horizontal, anchored at the canvas origin, with `(x0,y0)→(x1,y1)` discarded |
| 5 | `strokeStyle` accepted only a color string; a gradient threw `TypeError: A string was expected` and took the whole scene down (GUI `Line`, `Button` border) |
| 6 | Radial gradients discarded the inner circle, so every one came out concentric with `r0 == 0`. Now solves the real two-circle equation. The tangent case (leading coefficient vanishes → linear solve) needs its own branch and is not exotic — the repro's `createRadialGradient(100,100,150, 250,100,300)` lands there |
| 7 | Color stops were interpolated in straight alpha, so `#ff0000ff → #00000000` faded through maroon to black. Now premultiplied as specified |
| 8 | `fill()` never bound the fill style, using whatever color nanovg happened to hold — never a gradient. Every path-filled control (`Ellipse`, `Button` background, `Slider`) filled solid white |
| 9 | `createImageData` was missing entirely |
| 10 | `Path2D` was registered only on `_native`, not as a global, so `AbstractEngine.createCanvasPath2D` threw `ReferenceError` on every engine except `ThinNativeEngine` |
| 11 | `loadTTF` failures surfaced as a bare `Error: Invalid argument`, naming neither method nor argument. Now descriptive, and any ArrayBuffer *view* is accepted — so the usual real cause, `Tools.LoadFileAsync(url)` without `useArrayBuffer`, is named directly |
| 12 | `putImageData` was an unconditional throw. Now writes through a transient nanovg image under `nvgSave`/`nvgReset` with `NVG_COPY`, so it correctly ignores transform, clip, `globalAlpha`, compositing, shadows and filters and replaces rather than blends |
| 13 | `setLineDash` threw — and GUI `Line`/`MultiLine` call it every render with `_dash` defaulting to `[]`, so any scene with a GUI line died on an empty dash list asking for nothing. Empty now means "solid", which is what we already draw |
| 14 | The color regex matched components as 1-3 digit integers, so the very common `rgba(0, 0, 0, 0.5)` failed to parse. Now generic CSS numbers with optional `%`, plus the whitespace-separated and `/ alpha` forms and `hsl()`/`hsla()` — **see the behaviour change below** |
| 15 | All four shadow attributes threw from both getter and setter — and GUI resets `shadowBlur`/`shadowOffset*` to `0` right after drawing, so the throw hit the reset path too and any shadowed control failed outright. nanovg has no shadow primitive, but these are ordinary state attributes, so they are stored and reported |
| 16 | `save()`/`restore()` snapshotted only `fillStyle`/`strokeStyle`, but the wrapper mirrors everything it reprojects or that nanovg cannot report back — so `lineCap`, `lineJoin`, `lineWidth`, `miterLimit`, the dash list, `filter`, `direction`, `letterSpacing`, `globalAlpha` and the shadow attributes were never restored. The getters reported the post-`save()` value forever, and the shadow attributes, re-applied from the mirror on every draw, actually rendered wrong. All fifteen fields are now snapshotted |
| 17 | Coincident color stops were dropped — `std::map::insert()` discarded the second stop at an already-present offset, which is exactly how the spec encodes a hard transition, so a stripe pattern came out as a smooth fade. Now a `std::multimap` |
| 18 | `setLineDash()` cleared the list *before* validating, so `setLineDash([-1])` after `setLineDash([5,10])` left `getLineDash()` returning `[]` |

Two smaller gradient bugs were fixed alongside 4-8: the ramp sample buffer was uninitialized (samples outside the stop range read stack garbage), and `gradientSpan` divided by zero when two stops shared an offset.

## Robustness

Three crash classes found by the Copilot review, all reachable from ordinary script rather than only from a misbehaving embedder:

| # | Bug |
| --- | --- |
| 19 | `fillStyle = "rgb(999…999, 0, 0)"`, `font = "18e999px Arial"` and `letterSpacing = "999…999px"` made `std::stof`/`std::stoi` throw `std::out_of_range`. That is not a `Napi::Error`, so node-addon-api's wrapper did not catch it and it unwound out of the N-API boundary and **terminated the process**. Now `strtof`/`strtol`, with infinities folded to finite extremes so the existing clamps stay well defined (`nvgHSLA` takes `fmodf` of the hue, and `fmodf(inf, 1)` is NaN) |
| 20 | A gradient outliving its context: `UpdateCache()` dereferenced `context.lock()` three times unchecked, so the guard in `Paint()` ran after the crash |
| 21 | `putImageData(img, 0, 0, 0, 0, -2147483648, 1)` normalized negative dirty extents in `int32_t`, making `dirtyX += dirtyWidth` and `-dirtyWidth` signed overflow on caller-controlled input. Now `int64_t`, saturating back after clipping |

19 is confirmed by experiment, not inspection: built without the fix, the unit test binary stops dead inside the `Canvas2D` suite with `[Uncaught Error] Unknown failure` and exit 1, taking the remaining ~20 tests with it. The pre-existing font guard covered only `std::invalid_argument` (the `"normal"` keyword), so `out_of_range` still went through.

## One intentional behaviour change — please look at this closely

The `parseColor` unit test asserted `rgba(16,32,48,64)` → alpha `0x40`, i.e. that alpha is a 0-255 channel like r/g/b. CSS Color defines alpha as 0-1 (or a percentage), so a browser clamps `64` to `1` and paints that colour opaque.

That reading was not a deliberate extension — the old regex matched all four components as 1-3 digit integers and ran `std::stoi` over them, so alpha simply inherited the channel treatment, and the test was written to describe what the implementation happened to do (it arrived with the impl in #1051). It is also the same root cause as bug 14: under a 0-255 alpha, `rgba(0, 0, 0, 0.5)` truncates to `0` and the colour vanishes. Alpha cannot be both, so the test now follows CSS, extended to cover fractional and percentage alpha, the `/ alpha` form, whitespace-separated and percentage components, and `hsl()`/`hsla()`. All ten malformed-input cases still throw.

## Deliberate limitations

- **Non-rectangular `clip()` is approximated.** nanovg's scissor is rectangle-only and no stencil path is available, so the choice is between approximating and throwing; this keeps the rectangular case exact and degrades the other rather than failing the scene.
- **`putImageData()` clobbers the current path** — as do `fillRect`, `clearRect`, `drawImage` and `Path2D` playback, none of which may touch it per spec. nanovg offers no local fix, since `nvgSave`/`nvgRestore` only push and pop `NVGstate` while `nvgBeginPath` clears `ctx->ncommands` and the path cache. A real fix means journaling the path wrapper-side and replaying it; self-contained, and better as a follow-up.

## Validation

Full Playground validation sweep **304/304 PASS, no regressions**; `JavaScript.All` unit tests **36/36**.

Three previously-excluded tests are re-enabled and now pass inside the default 2.5% budget:

| Test | Before | After | Needs |
| --- | --- | --- | --- |
| `GUI Gradient Linear` (`#XCPP9Y#17227`) | `TypeError` — never rendered | **1.14%** | 5, then 8 |
| `GUI Gradient Radial` (`#4Z7EK3`) | 23.6% | **0.62%** | 6 (tangent case) |
| `GUI Gradient Linear with transparency` (`#PFK1Z5`) | 33.8% | **pixel-exact** | 7 |

The `GUI` test went **13.5% → 3.9%** (allowed 4%) across bugs 1-4 — 13.5% → 8.2% (clip) → 6.4% (drawImage origin) → 3.9% (gradients) — because its ColorPicker builds its wheel via `getImageData` + mutate + `putImageData` (1), composites it with a 3-arg `drawImage` at a non-zero offset (3), draws it and its saturation square under one `clip()` (2), and paints that square with two overlaid linear gradients (4). Nine further tests newly pass across the same four fixes.

Bugs 10 and 11 are test-neutral and were verified directly, and new `Canvas2D` unit tests cover the contract that used to throw: both style round-trips, a `CanvasGradient` as `fillStyle` and as `strokeStyle`, a radial gradient from two independent circles, save/restore of a gradient `strokeStyle` and of all fifteen state fields, dash retention on a rejected argument, coincident stops, and three regressions for the out-of-range parse crashes.

One implementation note: `DataView` is read through its `buffer`/`byteOffset`/`byteLength` properties rather than `Napi::DataView`, because Chakra's Node-API backs `napi_get_dataview_info` with `JsGetExternalData`, which only succeeds for natively created DataViews — a JS-constructed one fails with `napi_invalid_arg` even though `napi_is_dataview` returns `true`. That shim inconsistency is a separate JsRuntimeHost issue; this change just avoids depending on it.
