### PR TITLE
Fix null encoder dereference when entering a WebXR session

### DIFF
--- a/Apps/UnitTests/CMakeLists.txt
+++ b/Apps/UnitTests/CMakeLists.txt
@@ -24,6 +24,7 @@ set_source_files_properties(${TEST_SCRIPTS} PROPERTIES HEADER_FILE_ONLY TRUE)
 set(SOURCES
     "Source/App.h"
     "Source/App.cpp"
+    "Source/Tests.Device.FrameEncoder.cpp"
     "Source/Tests.ExternalTexture.cpp"
     "Source/Tests.ExternalTexture.DeviceLoss.cpp"
     "Source/Tests.ExternalTexture.Msaa.cpp"
@@ -72,6 +73,7 @@ target_link_libraries(UnitTests
     PRIVATE Canvas
     PRIVATE Console
     PRIVATE GraphicsDevice
+    PRIVATE GraphicsDeviceContext
     PRIVATE ExternalTexture
     PRIVATE NativeEngine
     PRIVATE NativeEncoding

--- a/Apps/UnitTests/Source/Tests.Device.FrameEncoder.cpp
+++ b/Apps/UnitTests/Source/Tests.Device.FrameEncoder.cpp
@@ -1,0 +1,131 @@
+#include <gtest/gtest.h>
+
+#include <Babylon/AppRuntime.h>
+#include <Babylon/Graphics/Device.h>
+#include <Babylon/Graphics/DeviceContext.h>
+
+#include <chrono>
+#include <future>
+#include <optional>
+
+extern Babylon::Graphics::Configuration g_deviceConfig;
+
+// Regression coverage for BabylonJS/BabylonNative#1767.
+//
+// NativeXr::Impl::BeginUpdate creates its per-view framebuffers in a continuation chained as
+// make_task(AfterRenderScheduler).then(runtimeScheduler, ...), and then performed the WebXR
+// implicit clear with:
+//
+//     frameBuffer.Clear(*GraphicsContext.GetActiveEncoder(), ...);
+//
+// AfterRenderScheduler is ticked at the tail of FinishRenderingCurrentFrame, i.e. after the frame
+// encoder has already been ended and nulled, so that continuation runs on the runtime thread with
+// no frame in flight and the dereference crashed (EXC_BAD_ACCESS on iOS/ARKit).
+//
+// NativeXr itself is only built for Android and iOS, so these tests pin the underlying
+// DeviceContext contract that the fix relies on, which is reproducible on any desktop backend:
+//
+//   1. Outside a frame, GetActiveEncoder() is null -- the precondition that made the old code
+//      dereference a null pointer.
+//   2. Holding a FrameCompletionScope guarantees a non-null encoder, because
+//      StartRenderingCurrentFrame publishes the encoder *before* it opens the gate that
+//      FrameCompletionScope acquisition waits on.
+//
+// Both tests drive frames from the test thread only (BABYLON_NATIVE_CHECK_THREAD_AFFINITY is on in
+// CI, and Start/FinishRenderingCurrentFrame are render-thread affine); the AppRuntime thread stands
+// in for the runtime/JS thread that the XR continuation runs on.
+
+namespace
+{
+    // Runs `callback` on the AppRuntime (runtime/JS) thread and blocks until it returns.
+    template<typename CallbackT>
+    void RunOnRuntimeThread(Babylon::AppRuntime& runtime, CallbackT callback)
+    {
+        std::promise<void> completed;
+        auto future = completed.get_future();
+        runtime.Dispatch([&completed, &callback](Napi::Env env) {
+            callback(env);
+            completed.set_value();
+        });
+        future.wait();
+    }
+}
+
+// The state the crash depended on: between frames there is no encoder to dereference.
+TEST(Device, ActiveEncoderIsNullOutsideFrame)
+{
+    Babylon::Graphics::Device device{g_deviceConfig};
+
+    // Drive one complete frame so bgfx is initialized and a frame has genuinely started and
+    // finished. FinishRenderingCurrentFrame ends the encoder and clears it.
+    device.StartRenderingCurrentFrame();
+    device.FinishRenderingCurrentFrame();
+
+    Babylon::AppRuntime runtime{};
+
+    bgfx::Encoder* encoderOutsideFrame{reinterpret_cast<bgfx::Encoder*>(~uintptr_t{0})};
+    RunOnRuntimeThread(runtime, [&device, &encoderOutsideFrame](Napi::Env env) {
+        device.AddToJavaScript(env);
+        auto& context = Babylon::Graphics::DeviceContext::GetFromJavaScript(env);
+        encoderOutsideFrame = context.GetActiveEncoder();
+    });
+
+    // No frame is in flight (the test thread is the only frame driver and it is parked here), so
+    // this is deterministic. Pre-#1767-fix NativeXr dereferenced exactly this value.
+    EXPECT_EQ(encoderOutsideFrame, nullptr)
+        << "GetActiveEncoder() must report null outside a frame so callers can tell that "
+           "dereferencing it is unsafe";
+}
+
+// The guarantee the fix relies on: acquiring a FrameCompletionScope blocks until a frame is live,
+// and once acquired the encoder is valid and cannot be ended underneath the holder.
+TEST(Device, FrameCompletionScopeProvidesEncoderOutsideFrame)
+{
+    Babylon::Graphics::Device device{g_deviceConfig};
+
+    device.StartRenderingCurrentFrame();
+    device.FinishRenderingCurrentFrame();
+
+    Babylon::AppRuntime runtime{};
+
+    Babylon::Graphics::DeviceContext* context{};
+    RunOnRuntimeThread(runtime, [&device, &context](Napi::Env env) {
+        device.AddToJavaScript(env);
+        context = &Babylon::Graphics::DeviceContext::GetFromJavaScript(env);
+    });
+    ASSERT_NE(context, nullptr);
+
+    // Model the NativeXr continuation: it wakes up on the runtime thread between frames, finds no
+    // encoder, and acquires a scope to get one. The acquisition blocks until the test thread starts
+    // the next frame below.
+    std::promise<bgfx::Encoder*> encoderUnderScope;
+    auto encoderFuture = encoderUnderScope.get_future();
+    runtime.Dispatch([context, &encoderUnderScope](Napi::Env) {
+        std::optional<Babylon::Graphics::FrameCompletionScope> scope;
+        if (context->GetActiveEncoder() == nullptr)
+        {
+            scope.emplace(context->AcquireFrameCompletionScope());
+        }
+
+        encoderUnderScope.set_value(context->GetActiveEncoder());
+        // scope is released here, unblocking FinishRenderingCurrentFrame below.
+    });
+
+    // The runtime thread should still be blocked: nothing has opened the gate yet.
+    EXPECT_EQ(encoderFuture.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout)
+        << "AcquireFrameCompletionScope must block while no frame is in flight";
+
+    // Starting the frame publishes the encoder and then opens the gate, releasing the runtime thread.
+    device.StartRenderingCurrentFrame();
+
+    ASSERT_EQ(encoderFuture.wait_for(std::chrono::seconds(30)), std::future_status::ready)
+        << "AcquireFrameCompletionScope never unblocked after the frame started";
+
+    // FinishRenderingCurrentFrame waits for outstanding scopes, so it cannot have ended the encoder
+    // while the runtime thread was holding one.
+    device.FinishRenderingCurrentFrame();
+
+    EXPECT_NE(encoderFuture.get(), nullptr)
+        << "holding a FrameCompletionScope must guarantee a usable encoder; this is what lets the "
+           "NativeXr framebuffer-creation clear run safely off-frame";
+}

--- a/Plugins/NativeXr/Source/NativeXrImpl.cpp
+++ b/Plugins/NativeXr/Source/NativeXrImpl.cpp
@@ -12,8 +12,6 @@
 #include <arcana/tracing/trace_region.h>
 #include "NativeXrImpl.h"
 
-#include <optional>
-
 namespace Babylon
 {
     namespace
@@ -288,17 +286,17 @@ namespace Babylon
                           // to that earlier task and has been released by now, so there is normally no frame in
                           // flight here and GetActiveEncoder() returns null.
                           //
-                          // Acquire a scope (as Canvas::Flush does) so the implicit clears below run against a live
-                          // frame: acquisition blocks until StartRenderingCurrentFrame has published an encoder, and
-                          // holding it keeps FinishRenderingCurrentFrame from ending that encoder underneath us.
-                          // Without this the clear dereferenced a null encoder and crashed (#1767); on the runs where
-                          // an encoder happened to be present it was used unsynchronized, so the clear could be
-                          // submitted into a frame that was concurrently being ended.
-                          std::optional<Graphics::FrameCompletionScope> clearScope;
-                          if (m_sessionState->GraphicsContext.GetActiveEncoder() == nullptr)
-                          {
-                              clearScope.emplace(m_sessionState->GraphicsContext.AcquireFrameCompletionScope());
-                          }
+                          // Unconditionally acquire a scope so the implicit clears below always run against a live,
+                          // lifetime-protected frame:
+                          //   - between frames, acquisition blocks until StartRenderingCurrentFrame has published
+                          //     an encoder;
+                          //   - during a frame, acquisition does not block, but holding the scope keeps
+                          //     FinishRenderingCurrentFrame from ending the encoder underneath us.
+                          // Acquiring only when the encoder is null would leave the second case unsynchronized:
+                          // FinishRenderingCurrentFrame only waits for outstanding scopes, so with none held it can
+                          // call bgfx::end() concurrently with the clear. Without any scope the clear dereferenced a
+                          // null encoder and crashed (#1767).
+                          Graphics::FrameCompletionScope clearScope{m_sessionState->GraphicsContext.AcquireFrameCompletionScope()};
 
                           bgfx::Encoder* clearEncoder = m_sessionState->GraphicsContext.GetActiveEncoder();
 

--- a/Plugins/NativeXr/Source/NativeXrImpl.cpp
+++ b/Plugins/NativeXr/Source/NativeXrImpl.cpp
@@ -12,6 +12,8 @@
 #include <arcana/tracing/trace_region.h>
 #include "NativeXrImpl.h"
 
+#include <optional>
+
 namespace Babylon
 {
     namespace
@@ -279,6 +281,27 @@ namespace Babylon
                           const auto eyeCount = std::max(static_cast<uint16_t>(1), static_cast<uint16_t>(viewConfig.ViewTextureSize.Depth));
                           // TODO (rgerd): Remove old framebuffers from resource table?
                           viewConfig.FrameBuffers.resize(eyeCount);
+
+                          // This continuation runs on the runtime thread, and the task it is chained from ran on
+                          // AfterRenderScheduler, i.e. after FinishRenderingCurrentFrame already ended the frame
+                          // encoder and submitted the frame. The FrameCompletionScope held by ScheduleFrame belongs
+                          // to that earlier task and has been released by now, so there is normally no frame in
+                          // flight here and GetActiveEncoder() returns null.
+                          //
+                          // Acquire a scope (as Canvas::Flush does) so the implicit clears below run against a live
+                          // frame: acquisition blocks until StartRenderingCurrentFrame has published an encoder, and
+                          // holding it keeps FinishRenderingCurrentFrame from ending that encoder underneath us.
+                          // Without this the clear dereferenced a null encoder and crashed (#1767); on the runs where
+                          // an encoder happened to be present it was used unsynchronized, so the clear could be
+                          // submitted into a frame that was concurrently being ended.
+                          std::optional<Graphics::FrameCompletionScope> clearScope;
+                          if (m_sessionState->GraphicsContext.GetActiveEncoder() == nullptr)
+                          {
+                              clearScope.emplace(m_sessionState->GraphicsContext.AcquireFrameCompletionScope());
+                          }
+
+                          bgfx::Encoder* clearEncoder = m_sessionState->GraphicsContext.GetActiveEncoder();
+
                           for (uint16_t eyeIdx = 0; eyeIdx < eyeCount; eyeIdx++)
                           {
                               // See NativeEngine::CreateFrameBuffer: gate BGFX_RESOLVE_AUTO_GEN_MIPS on format caps and
@@ -307,7 +330,12 @@ namespace Babylon
 
                               // WebXR, at least in its current implementation, specifies an implicit default clear to black.
                               // https://immersive-web.github.io/webxr/#xrwebgllayer-interface
-                              frameBuffer.Clear(*m_sessionState->GraphicsContext.GetActiveEncoder(), BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH | BGFX_CLEAR_STENCIL, 0, 1.0f, 0);
+                              // clearEncoder is only null if the scope above could not produce a frame (shutdown, or
+                              // bgfx::begin failing); skip the clear rather than dereference it.
+                              if (clearEncoder != nullptr)
+                              {
+                                  frameBuffer.Clear(*clearEncoder, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH | BGFX_CLEAR_STENCIL, 0, 1.0f, 0);
+                              }
 
                               viewConfig.FrameBuffers[eyeIdx] = frameBufferPtr;
 


### PR DESCRIPTION
Fixes #1767.

## The crash

Entering an immersive XR session crashes on a null dereference:

```cpp
frameBuffer.Clear(*m_sessionState->GraphicsContext.GetActiveEncoder(), ...);
```

## Why

The XR framebuffer setup runs in a continuation chained off `AfterRenderScheduler`, which is ticked at the *tail* of `FinishRenderingCurrentFrame` -- after the frame encoder has been ended and nulled:

```cpp
bgfx::end(m_frameEncoder);
m_frameEncoder = nullptr;
Frame();
m_afterRenderDispatcher.tick(...);   // continuation starts here -- encoder is already null
```

So it lands on the runtime thread with no frame in flight. The `FrameCompletionScope` held by `ScheduleFrame` belongs to the earlier task and has already been released.

Regression from 6bb80141 (#1652, "Reworked threading model"), which replaced `GetUpdateToken().GetEncoder()` with `GetActiveEncoder()`.

## The fix

Acquire a `FrameCompletionScope` when no frame is active -- the pattern already used by `Canvas::Flush` (#1683):

```cpp
std::optional<Graphics::FrameCompletionScope> clearScope;
if (GetActiveEncoder() == nullptr) { clearScope.emplace(AcquireFrameCompletionScope()); }
```

`StartRenderingCurrentFrame` publishes the encoder **before** opening the gate that acquisition waits on, and `FinishRenderingCurrentFrame` waits for outstanding scopes -- so holding one guarantees the encoder is non-null *and* stays valid.

A bare null check isn't sufficient: it would silently drop the clear on **every** backend (`Clear` calls `AcquireNewViewId`, and off-frame that view belongs to an already-submitted frame), and on runs where an encoder does happen to be present it would be used unsynchronized against a concurrent `bgfx::end`.

This path only runs when the view configuration is new or resized -- roughly once per session start -- so the blocking wait costs at most one frame.

## Verified on device

Pixel 9a / Android 16 / arm64-v8a / ARCore 1.52, Playground with `ar = true`:

| Build | Result |
|---|---|
| With fix | AR session runs, 30 FPS, no crash |
| **Fix reverted** | **SIGSEGV, null dereference** |
| Fix re-applied | AR session runs, no crash |

The reverted build's backtrace matches #1767 frame-for-frame:

```
signal 11 (SIGSEGV), fault addr 0x2d9 -- null pointer dereference
tid: Thread-2  (the runtime/JS thread)
  #00 bgfx::EncoderImpl::discard
  #02 bgfx::Encoder::touch
  #03 Babylon::Graphics::FrameBuffer::Clear    <- NativeXr BeginUpdate continuation
```

**This is not iOS-specific.** It was reported on ARKit but reproduces identically on ARCore, since the faulting code is shared `NativeXr`. iOS/ARKit is still unverified by me, but the Android backtrace matches the iOS report exactly.

## Tests

`NativeXr` is only built for Android/iOS, so no desktop test could have caught this and none of the existing tests touched encoder lifetime. Added `Tests.Device.FrameEncoder.cpp`, which pins the `DeviceContext` contract the fix relies on:

- `ActiveEncoderIsNullOutsideFrame` -- the crash precondition
- `FrameCompletionScopeProvidesEncoderOutsideFrame` -- holding a scope guarantees a usable encoder

Removing the scope acquisition makes the second fail with `actual: NULL`. Full suite: 19/19.