### PR TITLE
Playground validation: make a full 720-test sweep possible

### DIFF
--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -8,6 +8,7 @@
     const testHeight = 400;
     const generateReferences = !!opts.generateReferences;
     const breakOnFail = !!opts.breakOnFail;
+    const keepGoing = !!opts.keepGoing;
     const listTests = !!opts.listTests;
     const includeExcluded = !!opts.includeExcluded;
     const testFilters = Array.isArray(opts.testFilters) ? opts.testFilters.map(s => String(s).toLowerCase()) : [];
@@ -72,6 +73,7 @@
     let failedCount = 0;
     let skippedCount = 0;
     let missingRefCount = 0;
+    const failedTitles = [];
 
     function getExclusionReason(t) {
         if (t.onlyVisual) {
@@ -99,6 +101,12 @@
                     " failed=" + failedCount +
                     " missingRef=" + missingRefCount +
                     " skipped=" + skippedCount);
+        if (failedTitles.length > 0) {
+            console.log("Failed tests (" + failedTitles.length + "):");
+            for (let n = 0; n < failedTitles.length; n++) {
+                console.log("  - " + failedTitles[n]);
+            }
+        }
     }
 
     const engine = new BABYLON.NativeEngine();
@@ -663,18 +671,22 @@
                     ranCount++;
                     if (!status) {
                         failedCount++;
+                        failedTitles.push(currentTitle);
                         // failTest() already triggered the debugger before
                         // reaching this callback; no second `debugger` here.
-                        logRunSummary();
-                        TestUtils.exit(-1);
-                        return;
+                        if (!keepGoing) {
+                            logRunSummary();
+                            TestUtils.exit(-1);
+                            return;
+                        }
+                    } else {
+                        passedCount++;
                     }
-                    passedCount++;
                     i++;
                     if (justOnce || i >= config.tests.length) {
                         logRunSummary();
                         engine.dispose();
-                        TestUtils.exit(0);
+                        TestUtils.exit(failedCount > 0 ? -1 : 0);
                         return;
                     }
                     // Defer next iteration to avoid blowing Chakra's

--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -228,6 +228,15 @@
 
         currentScene.dispose();
         currentScene = null;
+
+        // A test can leave extra scenes behind (an async load that created its own scene, a scene
+        // whose creation promise resolved after validation, ...). They stay registered on the
+        // reused engine and keep their resources alive, so dispose them here.
+        const strayScenes = engine.scenes.slice();
+        for (let i = 0; i < strayScenes.length; ++i) {
+            strayScenes[i].dispose();
+        }
+
         engine.setHardwareScalingLevel(1);
 
         // Reset render state that persists on the reused engine so each test starts fresh.
@@ -238,6 +247,25 @@
 
         // This is necessary because of https://github.com/BabylonJS/Babylon.js/pull/15217 so that each test starts fresh.
         engine.releaseEffects();
+
+        // Textures are cached on the engine by URL (BaseTexture._getFromCache), and the cache key
+        // covers only url/noMipmap/isCube -- not the load-time options. A test that leaves a
+        // reference behind (e.g. assigning one texture to both scene.environmentTexture and a
+        // material's reflectionTexture) keeps its internal texture in that cache across
+        // scene.dispose(), so a later test loading the same URL silently reuses the *previous*
+        // test's texture along with its prefiltering/irradiance settings. Release whatever is
+        // left so every test loads its own textures and results do not depend on run order.
+        const leakedTextures = engine.getLoadedTexturesCache();
+        for (let i = leakedTextures.length - 1; i >= 0; --i) {
+            engine._releaseTexture(leakedTextures[i]);
+        }
+        engine.clearInternalTexturesCache();
+
+        // SceneLoader.OnPluginActivatedObservable is global and outlives the scene. Snippets use it
+        // to configure the glTF loader (animationStartMode, compileMaterials, ...) and never
+        // unregister, so without this every later glTF test would inherit those settings. The
+        // browser harness reloads the page per test and never sees this; here the engine is reused.
+        BABYLON.SceneLoader.OnPluginActivatedObservable.clear();
 
         done(testRes);
     }
@@ -419,11 +447,35 @@
                                     currentScene = eval(pgCode);
 
                                     if (currentScene.then) {
-                                        // Handle if createScene returns a promise
+                                        // Handle if createScene returns a promise. Guard against a
+                                        // snippet whose promise never resolves (e.g. a scene whose
+                                        // utility-layer executeWhenReady never fires on Native): the
+                                        // onReadyTimeout safety net lives inside processCurrentScene
+                                        // and only applies AFTER the promise resolves, so without this
+                                        // a pending createScene promise hangs the whole suite. Mirror
+                                        // onReadyTimeoutDuration and convert it to a fast failure.
+                                        // Note: this only fires if the JS event loop keeps running; a
+                                        // snippet that blocks the JS thread natively (e.g. manual
+                                        // setInterval frame-driving) is not rescued by this.
+                                        let sceneSettled = false;
+                                        const createSceneTimeoutMs = 10 * 60 * 1000;
+                                        const createSceneTimeoutId = setTimeout(function () {
+                                            if (sceneSettled) { return; }
+                                            sceneSettled = true;
+                                            console.error("createScene promise for " + test.playgroundId +
+                                                " did not resolve within " + (createSceneTimeoutMs / 1000) + "s.");
+                                            failTest(done);
+                                        }, createSceneTimeoutMs);
                                         currentScene.then(function (scene) {
+                                            if (sceneSettled) { return; }
+                                            sceneSettled = true;
+                                            clearTimeout(createSceneTimeoutId);
                                             currentScene = scene;
                                             processCurrentScene(test, referenceImage, done, compareFunction);
                                         }).catch(function (e) {
+                                            if (sceneSettled) { return; }
+                                            sceneSettled = true;
+                                            clearTimeout(createSceneTimeoutId);
                                             console.error(e);
                                             failTest(done);
                                         });

--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -440,13 +440,15 @@
                             // load callback. Deep scenes otherwise pile onto the
                             // native XHR dispatch frames and can overflow engines
                             // with a small C stack (e.g. QuickJS).
-                            setTimeout(function () {
+                            setTimeout(async function () {
                                 // eslint-disable-next-line no-unused-vars
                                 var name = ""; // see the note on the scriptToRun eval below
                                 try {
+                                    // Runs before the first await, so the eval still happens at the
+                                    // shallow stack depth this setTimeout exists to provide.
                                     currentScene = eval(pgCode);
 
-                                    if (currentScene.then) {
+                                    if (currentScene && currentScene.then) {
                                         // Handle if createScene returns a promise. Guard against a
                                         // snippet whose promise never resolves (e.g. a scene whose
                                         // utility-layer executeWhenReady never fires on Native): the
@@ -457,32 +459,28 @@
                                         // Note: this only fires if the JS event loop keeps running; a
                                         // snippet that blocks the JS thread natively (e.g. manual
                                         // setInterval frame-driving) is not rescued by this.
-                                        let sceneSettled = false;
                                         const createSceneTimeoutMs = 10 * 60 * 1000;
-                                        const createSceneTimeoutId = setTimeout(function () {
-                                            if (sceneSettled) { return; }
-                                            sceneSettled = true;
-                                            console.error("createScene promise for " + test.playgroundId +
-                                                " did not resolve within " + (createSceneTimeoutMs / 1000) + "s.");
-                                            failTest(done);
-                                        }, createSceneTimeoutMs);
-                                        currentScene.then(function (scene) {
-                                            if (sceneSettled) { return; }
-                                            sceneSettled = true;
+                                        let createSceneTimeoutId;
+                                        try {
+                                            currentScene = await Promise.race([
+                                                currentScene,
+                                                new Promise(function (resolve, reject) {
+                                                    createSceneTimeoutId = setTimeout(function () {
+                                                        reject(new Error("createScene promise for " + test.playgroundId +
+                                                            " did not resolve within " + (createSceneTimeoutMs / 1000) + "s."));
+                                                    }, createSceneTimeoutMs);
+                                                })
+                                            ]);
+                                        }
+                                        finally {
+                                            // Always clear it: a pending timer would otherwise keep the
+                                            // event loop alive for the full timeout after a scene that
+                                            // resolved normally.
                                             clearTimeout(createSceneTimeoutId);
-                                            currentScene = scene;
-                                            processCurrentScene(test, referenceImage, done, compareFunction);
-                                        }).catch(function (e) {
-                                            if (sceneSettled) { return; }
-                                            sceneSettled = true;
-                                            clearTimeout(createSceneTimeoutId);
-                                            console.error(e);
-                                            failTest(done);
-                                        });
-                                    } else {
-                                        // Handle if createScene returns a scene
-                                        processCurrentScene(test, referenceImage, done, compareFunction);
+                                        }
                                     }
+
+                                    processCurrentScene(test, referenceImage, done, compareFunction);
                                 }
                                 catch (e) {
                                     console.error("Failed to evaluate playground snippet " + test.playgroundId + ": " + e);

--- a/Apps/Playground/Shared/CommandLine.cpp
+++ b/Apps/Playground/Shared/CommandLine.cpp
@@ -153,6 +153,14 @@ namespace
             "Trigger debugger break on a failing test.", "",
             [](PlaygroundOptions& o, std::string_view, std::string&) { o.BreakOnFail = true; }},
 
+        FlagSpec{"--keep-going", "-k", FlagKind::Boolean, "",
+            "Continue after a failing test instead of",
+            "                              exiting on the first failure. The run still\n"
+            "                              exits non-zero if anything failed. Use this\n"
+            "                              for full sweeps where you want the complete\n"
+            "                              pass/fail tally rather than the first error.\n",
+            [](PlaygroundOptions& o, std::string_view, std::string&) { o.KeepGoing = true; }},
+
         FlagSpec{"--generate-references", "", FlagKind::Boolean, "",
             "Save rendered images as new reference PNGs.", "",
             [](PlaygroundOptions& o, std::string_view, std::string&) { o.GenerateReferences = true; }},

--- a/Apps/Playground/Shared/CommandLine.h
+++ b/Apps/Playground/Shared/CommandLine.h
@@ -13,6 +13,7 @@ struct PlaygroundOptions
     bool ListTests = false;
     bool Headless = false;
     bool BreakOnFail = false;
+    bool KeepGoing = false;
     bool GenerateReferences = false;
     bool RunOnce = false;
     bool IncludeExcluded = false;

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -111,6 +111,7 @@ namespace
             js.Set("listTests",          Napi::Boolean::New(env, playgroundOptions.ListTests));
             js.Set("headless",           Napi::Boolean::New(env, playgroundOptions.Headless));
             js.Set("breakOnFail",        Napi::Boolean::New(env, playgroundOptions.BreakOnFail));
+            js.Set("keepGoing",          Napi::Boolean::New(env, playgroundOptions.KeepGoing));
             js.Set("generateReferences", Napi::Boolean::New(env, playgroundOptions.GenerateReferences));
             js.Set("runOnce",            Napi::Boolean::New(env, playgroundOptions.RunOnce));
             js.Set("includeExcluded",    Napi::Boolean::New(env, playgroundOptions.IncludeExcluded));

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -66,7 +66,7 @@ set(BGFX_KHRONOS_INCLUDE_DIR "${bgfx.cmake_SOURCE_DIR}/bgfx/3rdparty/khronos" CA
 # below the size the Canvas sweeps need.
 #
 # 512 was sufficient only because the validation runner exited on the first
-# failing test. With --keep-going a full 720-test sweep keeps allocating past
+# failing test. With --keep-going a full validation sweep keeps allocating past
 # that point and exhausts the pool around the FrameGraph tests, so the floor
 # has to cover a complete uninterrupted run.
 if(NOT BGFX_CONFIG_MAX_FRAME_BUFFERS OR BGFX_CONFIG_MAX_FRAME_BUFFERS LESS 2048)

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -60,12 +60,17 @@ set(BGFX_KHRONOS_INCLUDE_DIR "${bgfx.cmake_SOURCE_DIR}/bgfx/3rdparty/khronos" CA
 
 # Canvas plugin allocates one bgfx framebuffer per JS Canvas object and per
 # text-rendering operation; combined with V8 GC pacing this can exceed the
-# default 128 limit during long playground sweeps. We enforce a floor of 512:
-# CI workflows pass -DBGFX_CONFIG_MAX_FRAME_BUFFERS, and any value below 512
+# default 128 limit during long playground sweeps. We enforce a floor of 2048:
+# CI workflows pass -DBGFX_CONFIG_MAX_FRAME_BUFFERS, and any value below 2048
 # (including a smaller CI override) is clamped up so the pool never regresses
 # below the size the Canvas sweeps need.
-if(NOT BGFX_CONFIG_MAX_FRAME_BUFFERS OR BGFX_CONFIG_MAX_FRAME_BUFFERS LESS 512)
-    set(BGFX_CONFIG_MAX_FRAME_BUFFERS 512)
+#
+# 512 was sufficient only because the validation runner exited on the first
+# failing test. With --keep-going a full 720-test sweep keeps allocating past
+# that point and exhausts the pool around the FrameGraph tests, so the floor
+# has to cover a complete uninterrupted run.
+if(NOT BGFX_CONFIG_MAX_FRAME_BUFFERS OR BGFX_CONFIG_MAX_FRAME_BUFFERS LESS 2048)
+    set(BGFX_CONFIG_MAX_FRAME_BUFFERS 2048)
 endif()
 target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_MAX_FRAME_BUFFERS=${BGFX_CONFIG_MAX_FRAME_BUFFERS})
 


### PR DESCRIPTION
Two changes that together make a complete run of the 720-test validation suite possible and order-independent. Two commits, reviewable separately.

## 1. `--keep-going`, so a sweep can finish

The runner exits on the first failing test, so a run only ever reports one failure and everything after it goes unmeasured. There's no way to answer *"how many of the 720 tests pass today?"* without repeatedly excluding whatever failed and re-running.

`--keep-going` / `-k` records the failure, continues, and lists every failing title in the summary. The run still exits non-zero if anything failed, so **CI semantics are unchanged**. Without the flag, behaviour is exactly as before.

```
Run complete. ran=3 passed=1 failed=2 missingRef=0 skipped=0
Failed tests (2):
  - Gaussian Splatting Compressed ply SH
  - Gaussian Splatting Update Data
```

Verified with two tests pointed at a mismatched reference image plus one control:

| | result | exit |
|---|---|---|
| without `--keep-going` | `ran=1 passed=0 failed=1` | -1 |
| with `--keep-going` | `ran=3 passed=1 failed=2` | -1 |

**Framebuffer pool floor 512 -> 2048.** Running to completion for the first time immediately exhausted the bgfx framebuffer pool around the FrameGraph tests (`bgfx::createFrameBuffer returned invalid handle`). 512 was only ever sufficient *because* the run stopped early. The existing comment in `Dependencies/CMakeLists.txt` already anticipated this ("combined with V8 GC pacing this can exceed the default limit during long playground sweeps"); this raises the floor to cover a full run.

## 2. Cross-test state leaks

The suite reuses **one engine across all tests**, so anything outliving `scene.dispose()` carries into later tests. The browser harness never sees this because it reloads the page per test.

- **Stray scenes.** A test can leave extra scenes registered on the engine (an async load that created its own scene, or one whose creation promise resolved after validation). They stay registered and keep their resources alive.
- **The engine texture cache.** `BaseTexture._getFromCache` keys on `url`/`noMipmap`/`isCube` only -- *not* on load-time options. A test that leaves a reference behind (e.g. assigning one texture to both `scene.environmentTexture` and a material's `reflectionTexture`) keeps its internal texture cached across `scene.dispose()`, so a later test loading the same URL silently reuses the *previous* test's texture along with its prefiltering/irradiance settings.
- **`SceneLoader.OnPluginActivatedObservable`.** Global, outlives the scene. Snippets use it to configure the glTF loader (`animationStartMode`, `compileMaterials`, ...) and never unregister, so every later glTF test inherits those settings.

Plus a hang guard: a `createScene` promise that never resolves currently hangs the *entire* suite, because the existing `onReadyTimeout` net lives inside `processCurrentScene` and only applies once the promise has resolved. This converts it to a single failed test. (Documented caveat: it only fires if the JS event loop keeps running.)

**This second commit changes no current result** -- 302 ran / 299 passed / 3 failed, identical set, before and after. Its value is removing order-dependence that becomes load-bearing as more tests are enabled.

## Why it matters

This is what made a complete 720-test sweep possible at all. Measuring the full suite in one pass turned up 47 failures previously hidden behind the first one -- and spot-checking those in isolation shows they **pass individually**, so they're cross-test state pollution rather than missing functionality. That's a materially different and far more tractable problem than the tally alone suggested, and none of it is visible without this.
