### PR TITLE
Playground validation: remove cross-test state leaks from the reused engine

### DIFF
--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -8,6 +8,7 @@
     const testHeight = 400;
     const generateReferences = !!opts.generateReferences;
     const breakOnFail = !!opts.breakOnFail;
+    const keepGoing = !!opts.keepGoing;
     const listTests = !!opts.listTests;
     const includeExcluded = !!opts.includeExcluded;
     const testFilters = Array.isArray(opts.testFilters) ? opts.testFilters.map(s => String(s).toLowerCase()) : [];
@@ -72,6 +73,7 @@
     let failedCount = 0;
     let skippedCount = 0;
     let missingRefCount = 0;
+    const failedTitles = [];
 
     function getExclusionReason(t) {
         if (t.onlyVisual) {
@@ -99,6 +101,12 @@
                     " failed=" + failedCount +
                     " missingRef=" + missingRefCount +
                     " skipped=" + skippedCount);
+        if (failedTitles.length > 0) {
+            console.log("Failed tests (" + failedTitles.length + "):");
+            for (let n = 0; n < failedTitles.length; n++) {
+                console.log("  - " + failedTitles[n]);
+            }
+        }
     }
 
     const engine = new BABYLON.NativeEngine();
@@ -663,18 +671,22 @@
                     ranCount++;
                     if (!status) {
                         failedCount++;
+                        failedTitles.push(currentTitle);
                         // failTest() already triggered the debugger before
                         // reaching this callback; no second `debugger` here.
-                        logRunSummary();
-                        TestUtils.exit(-1);
-                        return;
+                        if (!keepGoing) {
+                            logRunSummary();
+                            TestUtils.exit(-1);
+                            return;
+                        }
+                    } else {
+                        passedCount++;
                     }
-                    passedCount++;
                     i++;
                     if (justOnce || i >= config.tests.length) {
                         logRunSummary();
                         engine.dispose();
-                        TestUtils.exit(0);
+                        TestUtils.exit(failedCount > 0 ? -1 : 0);
                         return;
                     }
                     // Defer next iteration to avoid blowing Chakra's

--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -228,6 +228,15 @@
 
         currentScene.dispose();
         currentScene = null;
+
+        // A test can leave extra scenes behind (an async load that created its own scene, a scene
+        // whose creation promise resolved after validation, ...). They stay registered on the
+        // reused engine and keep their resources alive, so dispose them here.
+        const strayScenes = engine.scenes.slice();
+        for (let i = 0; i < strayScenes.length; ++i) {
+            strayScenes[i].dispose();
+        }
+
         engine.setHardwareScalingLevel(1);
 
         // Reset render state that persists on the reused engine so each test starts fresh.
@@ -238,6 +247,25 @@
 
         // This is necessary because of https://github.com/BabylonJS/Babylon.js/pull/15217 so that each test starts fresh.
         engine.releaseEffects();
+
+        // Textures are cached on the engine by URL (BaseTexture._getFromCache), and the cache key
+        // covers only url/noMipmap/isCube -- not the load-time options. A test that leaves a
+        // reference behind (e.g. assigning one texture to both scene.environmentTexture and a
+        // material's reflectionTexture) keeps its internal texture in that cache across
+        // scene.dispose(), so a later test loading the same URL silently reuses the *previous*
+        // test's texture along with its prefiltering/irradiance settings. Release whatever is
+        // left so every test loads its own textures and results do not depend on run order.
+        const leakedTextures = engine.getLoadedTexturesCache();
+        for (let i = leakedTextures.length - 1; i >= 0; --i) {
+            engine._releaseTexture(leakedTextures[i]);
+        }
+        engine.clearInternalTexturesCache();
+
+        // SceneLoader.OnPluginActivatedObservable is global and outlives the scene. Snippets use it
+        // to configure the glTF loader (animationStartMode, compileMaterials, ...) and never
+        // unregister, so without this every later glTF test would inherit those settings. The
+        // browser harness reloads the page per test and never sees this; here the engine is reused.
+        BABYLON.SceneLoader.OnPluginActivatedObservable.clear();
 
         done(testRes);
     }
@@ -419,11 +447,35 @@
                                     currentScene = eval(pgCode);
 
                                     if (currentScene.then) {
-                                        // Handle if createScene returns a promise
+                                        // Handle if createScene returns a promise. Guard against a
+                                        // snippet whose promise never resolves (e.g. a scene whose
+                                        // utility-layer executeWhenReady never fires on Native): the
+                                        // onReadyTimeout safety net lives inside processCurrentScene
+                                        // and only applies AFTER the promise resolves, so without this
+                                        // a pending createScene promise hangs the whole suite. Mirror
+                                        // onReadyTimeoutDuration and convert it to a fast failure.
+                                        // Note: this only fires if the JS event loop keeps running; a
+                                        // snippet that blocks the JS thread natively (e.g. manual
+                                        // setInterval frame-driving) is not rescued by this.
+                                        let sceneSettled = false;
+                                        const createSceneTimeoutMs = 10 * 60 * 1000;
+                                        const createSceneTimeoutId = setTimeout(function () {
+                                            if (sceneSettled) { return; }
+                                            sceneSettled = true;
+                                            console.error("createScene promise for " + test.playgroundId +
+                                                " did not resolve within " + (createSceneTimeoutMs / 1000) + "s.");
+                                            failTest(done);
+                                        }, createSceneTimeoutMs);
                                         currentScene.then(function (scene) {
+                                            if (sceneSettled) { return; }
+                                            sceneSettled = true;
+                                            clearTimeout(createSceneTimeoutId);
                                             currentScene = scene;
                                             processCurrentScene(test, referenceImage, done, compareFunction);
                                         }).catch(function (e) {
+                                            if (sceneSettled) { return; }
+                                            sceneSettled = true;
+                                            clearTimeout(createSceneTimeoutId);
                                             console.error(e);
                                             failTest(done);
                                         });

--- a/Apps/Playground/Shared/CommandLine.cpp
+++ b/Apps/Playground/Shared/CommandLine.cpp
@@ -153,6 +153,14 @@ namespace
             "Trigger debugger break on a failing test.", "",
             [](PlaygroundOptions& o, std::string_view, std::string&) { o.BreakOnFail = true; }},
 
+        FlagSpec{"--keep-going", "-k", FlagKind::Boolean, "",
+            "Continue after a failing test instead of",
+            "                              exiting on the first failure. The run still\n"
+            "                              exits non-zero if anything failed. Use this\n"
+            "                              for full sweeps where you want the complete\n"
+            "                              pass/fail tally rather than the first error.\n",
+            [](PlaygroundOptions& o, std::string_view, std::string&) { o.KeepGoing = true; }},
+
         FlagSpec{"--generate-references", "", FlagKind::Boolean, "",
             "Save rendered images as new reference PNGs.", "",
             [](PlaygroundOptions& o, std::string_view, std::string&) { o.GenerateReferences = true; }},

--- a/Apps/Playground/Shared/CommandLine.h
+++ b/Apps/Playground/Shared/CommandLine.h
@@ -13,6 +13,7 @@ struct PlaygroundOptions
     bool ListTests = false;
     bool Headless = false;
     bool BreakOnFail = false;
+    bool KeepGoing = false;
     bool GenerateReferences = false;
     bool RunOnce = false;
     bool IncludeExcluded = false;

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -111,6 +111,7 @@ namespace
             js.Set("listTests",          Napi::Boolean::New(env, playgroundOptions.ListTests));
             js.Set("headless",           Napi::Boolean::New(env, playgroundOptions.Headless));
             js.Set("breakOnFail",        Napi::Boolean::New(env, playgroundOptions.BreakOnFail));
+            js.Set("keepGoing",          Napi::Boolean::New(env, playgroundOptions.KeepGoing));
             js.Set("generateReferences", Napi::Boolean::New(env, playgroundOptions.GenerateReferences));
             js.Set("runOnce",            Napi::Boolean::New(env, playgroundOptions.RunOnce));
             js.Set("includeExcluded",    Napi::Boolean::New(env, playgroundOptions.IncludeExcluded));

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -60,12 +60,17 @@ set(BGFX_KHRONOS_INCLUDE_DIR "${bgfx.cmake_SOURCE_DIR}/bgfx/3rdparty/khronos" CA
 
 # Canvas plugin allocates one bgfx framebuffer per JS Canvas object and per
 # text-rendering operation; combined with V8 GC pacing this can exceed the
-# default 128 limit during long playground sweeps. We enforce a floor of 512:
-# CI workflows pass -DBGFX_CONFIG_MAX_FRAME_BUFFERS, and any value below 512
+# default 128 limit during long playground sweeps. We enforce a floor of 2048:
+# CI workflows pass -DBGFX_CONFIG_MAX_FRAME_BUFFERS, and any value below 2048
 # (including a smaller CI override) is clamped up so the pool never regresses
 # below the size the Canvas sweeps need.
-if(NOT BGFX_CONFIG_MAX_FRAME_BUFFERS OR BGFX_CONFIG_MAX_FRAME_BUFFERS LESS 512)
-    set(BGFX_CONFIG_MAX_FRAME_BUFFERS 512)
+#
+# 512 was sufficient only because the validation runner exited on the first
+# failing test. With --keep-going a full 720-test sweep keeps allocating past
+# that point and exhausts the pool around the FrameGraph tests, so the floor
+# has to cover a complete uninterrupted run.
+if(NOT BGFX_CONFIG_MAX_FRAME_BUFFERS OR BGFX_CONFIG_MAX_FRAME_BUFFERS LESS 2048)
+    set(BGFX_CONFIG_MAX_FRAME_BUFFERS 2048)
 endif()
 target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_MAX_FRAME_BUFFERS=${BGFX_CONFIG_MAX_FRAME_BUFFERS})
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #1830 — review that one first. This PR's diff is the single `validation_native.js` commit on top.

## Problem

The suite reuses **one engine across all 720 tests**, so anything outliving `scene.dispose()` silently carries into later tests. The browser harness never sees this because it reloads the page per test.

## The three leaks

**1. Stray scenes.** A test can leave extra scenes registered on the engine — an async load that created its own scene, or a scene whose creation promise resolved after validation finished. They stay registered and keep their resources alive.

**2. The engine texture cache.** `BaseTexture._getFromCache` keys on `url`/`noMipmap`/`isCube` only — **not** on load-time options. A test that leaves a reference behind (e.g. assigning one texture to both `scene.environmentTexture` and a material's `reflectionTexture`) keeps its internal texture cached across `scene.dispose()`. A later test loading the same URL then silently reuses the *previous* test's texture, along with its prefiltering/irradiance settings.

**3. `SceneLoader.OnPluginActivatedObservable`.** Global, outlives the scene. Snippets use it to configure the glTF loader (`animationStartMode`, `compileMaterials`, …) and never unregister, so every later glTF test inherits those settings.

## Also: a hang guard

A `createScene` promise that never resolves currently hangs the **entire suite**. The existing `onReadyTimeout` safety net lives inside `processCurrentScene` and only applies *after* the promise resolves. This converts it to a single failed test.

(Caveat documented in-code: this only fires if the JS event loop keeps running. A snippet that blocks the JS thread natively isn't rescued by it.)

## Impact — deliberately none today

| | ran | passed | failed |
|---|---|---|---|
| before | 302 | 299 | 3 |
| after | 302 | 299 | 3 |

Same three failures, identical set. **This PR changes no current result.** Its value is removing order-dependence that becomes load-bearing as more tests get enabled — leak #2 in particular produces failures that only reproduce in sequence and pass in isolation, which is exactly the class of bug that's most expensive to debug later.

I'm raising it now rather than bundled with a test-enablement PR so the mechanism can be reviewed on its own.
