### PR TITLE
Graphics: opt-in RenderDoc capture via BABYLON_NATIVE_RENDERDOC

### DIFF
--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -6,6 +6,7 @@
 #include <Babylon/JsRuntime.h>
 #include <arcana/tracing/trace_region.h>
 #include <cmath>
+#include <cstdlib>
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
@@ -39,6 +40,29 @@ namespace Babylon::Graphics
 
         auto& init = m_state.Bgfx.InitState;
         init.callback = &m_bgfxCallback;
+
+        // Opt-in debug device: bgfx only loads RenderDoc (enabling the
+        // BGFX_FRAME_DEBUG_CAPTURE trigger used by --capture) when init.debug
+        // is set. Release builds default this to false, so gate it behind an
+        // env var that is only set when a GPU capture is requested.
+        {
+#if defined(_WIN32)
+            char* renderDocEnv = nullptr;
+            size_t renderDocEnvLen = 0;
+            if (_dupenv_s(&renderDocEnv, &renderDocEnvLen, "BABYLON_NATIVE_RENDERDOC") == 0 &&
+                renderDocEnv != nullptr && renderDocEnv[0] != '\0' && renderDocEnv[0] != '0')
+            {
+                init.debug = true;
+            }
+            free(renderDocEnv);
+#else
+            if (const char* renderDocEnv = std::getenv("BABYLON_NATIVE_RENDERDOC");
+                renderDocEnv != nullptr && renderDocEnv[0] != '\0' && renderDocEnv[0] != '0')
+            {
+                init.debug = true;
+            }
+#endif
+        }
 
         // Use the noop renderer if the configuration has no window and no size.
         if (config.Window == WindowT{} && config.Width == 0 && config.Height == 0)

--- a/Core/Graphics/Source/DeviceImpl.cpp
+++ b/Core/Graphics/Source/DeviceImpl.cpp
@@ -7,6 +7,7 @@
 #include <arcana/tracing/trace_region.h>
 #include <cmath>
 #include <cstdlib>
+#include <cstring>
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
@@ -25,6 +26,14 @@ namespace
     bool FuzzyEqual(float a, float b, float epsilon = std::numeric_limits<float>::epsilon())
     {
         return std::abs(a - b) < epsilon;
+    }
+
+    // An environment variable counts as set unless it is absent, empty, or exactly "0".
+    // Compared in full rather than by first character so that values like "01" or "0x1"
+    // enable rather than disable.
+    bool IsEnvironmentFlagSet(const char* value)
+    {
+        return value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0;
     }
 }
 
@@ -50,14 +59,13 @@ namespace Babylon::Graphics
             char* renderDocEnv = nullptr;
             size_t renderDocEnvLen = 0;
             if (_dupenv_s(&renderDocEnv, &renderDocEnvLen, "BABYLON_NATIVE_RENDERDOC") == 0 &&
-                renderDocEnv != nullptr && renderDocEnv[0] != '\0' && renderDocEnv[0] != '0')
+                IsEnvironmentFlagSet(renderDocEnv))
             {
                 init.debug = true;
             }
             free(renderDocEnv);
 #else
-            if (const char* renderDocEnv = std::getenv("BABYLON_NATIVE_RENDERDOC");
-                renderDocEnv != nullptr && renderDocEnv[0] != '\0' && renderDocEnv[0] != '0')
+            if (IsEnvironmentFlagSet(std::getenv("BABYLON_NATIVE_RENDERDOC")))
             {
                 init.debug = true;
             }


### PR DESCRIPTION
## Problem

bgfx only loads RenderDoc — and therefore only arms the `BGFX_FRAME_DEBUG_CAPTURE` trigger that Playground's existing `--capture` flag relies on — when `init.debug` is set. Release builds leave that `false`, so **you can't take a GPU capture from a normal build without recompiling**.

## Change

Gate `init.debug` behind an environment variable that's only set when a capture is actually wanted:

```
set BABYLON_NATIVE_RENDERDOC=1
Playground.exe --capture=30 app:///Scripts/validation_native.js
```

Any value other than absent, empty or exactly `"0"` enables it (compared in full, so `01` and `0x1` enable too). When unset, the code path is identical to today.

`_dupenv_s` on MSVC / `std::getenv` elsewhere, so no CRT deprecation warning on Win32.

## Verification

| | result |
|---|---|
| variable unset | run unchanged, test passes |
| `BABYLON_NATIVE_RENDERDOC=1` | debug device created successfully, test still passes |

Worth noting explicitly: enabling `init.debug` turns on the D3D11 debug layer, which can fail device creation on machines without the SDK layers installed. That's why this is opt-in per-run rather than, say, defaulted on in Debug builds — an unset variable can never affect anyone.

## Why

Chasing rendering-parity bugs against Babylon.js repeatedly needed a frame capture, and every time it meant a custom rebuild. This makes `--capture` usable as shipped.

