### PR TITLE
Build: enable /OPT:REF for MSVC RelWithDebInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,6 +373,29 @@ if(MSVC)
 
     # Enable multiprocessor compilation for faster builds
     add_compile_options(/MP)
+
+    # Strip unreferenced code from RelWithDebInfo binaries.
+    #
+    # MSVC turns /OPT:REF and /OPT:ICF off whenever /DEBUG is passed, and CMake's
+    # default RelWithDebInfo link flags are "/debug /INCREMENTAL". The effect is that
+    # RelWithDebInfo keeps every unreferenced COMDAT that made it into the static
+    # libraries.
+    #
+    # /OPT:REF alone captures the entire win (/OPT:ICF measured zero additional
+    # bytes), so identical functions are left unfolded and stack traces stay
+    # unambiguous. Incremental linking must be off because it is incompatible with
+    # /OPT:REF. Debug is left untouched, and Release/MinSizeRel already get /OPT:REF
+    # implicitly because they do not link with /DEBUG.
+    foreach(BABYLON_NATIVE_LINKER_FLAGS
+        CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO
+        CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO
+        CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO)
+        set(BABYLON_NATIVE_FLAGS "${${BABYLON_NATIVE_LINKER_FLAGS}}")
+        string(REPLACE "/INCREMENTAL:NO" "" BABYLON_NATIVE_FLAGS "${BABYLON_NATIVE_FLAGS}")
+        string(REPLACE "/INCREMENTAL" "" BABYLON_NATIVE_FLAGS "${BABYLON_NATIVE_FLAGS}")
+        string(REPLACE "/OPT:REF" "" BABYLON_NATIVE_FLAGS "${BABYLON_NATIVE_FLAGS}")
+        set(${BABYLON_NATIVE_LINKER_FLAGS} "${BABYLON_NATIVE_FLAGS} /INCREMENTAL:NO /OPT:REF")
+    endforeach()
 endif()
 
 if(NOT ENABLE_RTTI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,16 +386,7 @@ if(MSVC)
     # unambiguous. Incremental linking must be off because it is incompatible with
     # /OPT:REF. Debug is left untouched, and Release/MinSizeRel already get /OPT:REF
     # implicitly because they do not link with /DEBUG.
-    foreach(BABYLON_NATIVE_LINKER_FLAGS
-        CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO
-        CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO
-        CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO)
-        set(BABYLON_NATIVE_FLAGS "${${BABYLON_NATIVE_LINKER_FLAGS}}")
-        string(REPLACE "/INCREMENTAL:NO" "" BABYLON_NATIVE_FLAGS "${BABYLON_NATIVE_FLAGS}")
-        string(REPLACE "/INCREMENTAL" "" BABYLON_NATIVE_FLAGS "${BABYLON_NATIVE_FLAGS}")
-        string(REPLACE "/OPT:REF" "" BABYLON_NATIVE_FLAGS "${BABYLON_NATIVE_FLAGS}")
-        set(${BABYLON_NATIVE_LINKER_FLAGS} "${BABYLON_NATIVE_FLAGS} /INCREMENTAL:NO /OPT:REF")
-    endforeach()
+    add_link_options($<$<CONFIG:RelWithDebInfo>:/INCREMENTAL:NO> $<$<CONFIG:RelWithDebInfo>:/OPT:REF>)
 endif()
 
 if(NOT ENABLE_RTTI)


### PR DESCRIPTION
RelWithDebInfo is an optimized configuration, but on MSVC it currently keeps every unreferenced function that made it into the static libraries.

The reason is that MSVC turns `/OPT:REF` and `/OPT:ICF` **off** whenever `/DEBUG` is passed, and CMake's default RelWithDebInfo link flags are `/debug /INCREMENTAL`. So nothing gets stripped.

Turning incremental linking off and `/OPT:REF` on fixes that:

| Playground.exe, RelWithDebInfo | Size |
| --- | --- |
| before | 11,212,800 bytes |
| after | 4,562,432 bytes |
| | **−59.3%** |

## Notes

- **`/OPT:ICF` is deliberately left off.** It measured zero additional bytes on top of `/OPT:REF`, and folding identical functions makes stack traces ambiguous — the opposite of what RelWithDebInfo is for.
- **`/INCREMENTAL:NO` is required**, not incidental: incremental linking is incompatible with `/OPT:REF`.
- **Debug is untouched.** Release and MinSizeRel already get `/OPT:REF` implicitly because they do not link with `/DEBUG`.
- Debuggability is unaffected — `/DEBUG` stays on and the PDB is still produced.

## Verification

Confirmed through the generated `Playground.vcxproj` that `OptimizeReferences` is `true` for RelWithDebInfo only, and that `EnableCOMDATFolding` stays false in every configuration.

The stripped binary was then run through the full visual test suite headless, to confirm nothing that is actually reachable got removed:

```
Run complete. ran=304 passed=304 failed=0 missingRef=0 skipped=416
Playground: Finished in 4m 11.952s. (exit 0)
```

The flags are applied with `add_link_options()` and a `$<$<CONFIG:RelWithDebInfo>:...>` generator expression, so CMake owns the tokenization and folds them into the structured project properties rather than raw `AdditionalOptions` text:

| | Debug | Release | MinSizeRel | RelWithDebInfo |
|---|---|---|---|---|
| `OptimizeReferences` | — | — | — | **true** |
| `LinkIncremental` | true | false | false | **false** |

