### PR TITLE
Diagnostics: report the message of an uncaught C++ exception

### DIFF
--- a/Apps/Playground/Shared/Diagnostics.cpp
+++ b/Apps/Playground/Shared/Diagnostics.cpp
@@ -43,8 +43,10 @@ namespace
 
     // Recover the message of the exception that is currently propagating, if
     // any. Returns an empty string when no exception is in flight. Valid inside
-    // a terminate handler and inside the SIGABRT handler that terminate() ends
-    // up calling, because the exception stays current until the handler returns.
+    // a terminate handler, and inside the MSVC SIGABRT handler that terminate()
+    // ends up calling, because the exception stays current until the handler
+    // returns. Allocates, so it must not be called from a signal handler that
+    // can fire asynchronously (see OnSignalAbort on non-MSVC).
     std::string DescribeCurrentException()
     {
         if (std::current_exception() == nullptr)
@@ -137,9 +139,20 @@ namespace
 #else
     void OnSignalAbort(int /*signal*/)
     {
-        const std::string detail = DescribeCurrentException();
-        Diagnostics::DumpFailure("ABORT", nullptr, 0, 1, "SIGABRT raised.%s%s",
-            detail.empty() ? "" : "\n", detail.c_str());
+        // Deliberately does not call DescribeCurrentException(). Outside the
+        // Microsoft CRT std::set_terminate() is global, and OnTerminate() below
+        // ends in std::_Exit(), so an uncaught exception is fully reported there
+        // and never reaches abort(). Everything that does land here -- a direct
+        // abort(), a libc assertion, raise(SIGABRT), kill -ABRT -- has no C++
+        // exception in flight, so recovering one would return an empty string
+        // anyway.
+        //
+        // That matters because this is a real signal handler: std::current_exception()
+        // and std::string allocate, and abort() is frequently raised from inside
+        // the allocator (heap corruption, a glibc malloc assertion). Allocating
+        // here would deadlock against the allocator's own lock in exactly the
+        // cases where the diagnostic is most needed.
+        Diagnostics::DumpFailure("ABORT", nullptr, 0, 1, "SIGABRT raised.");
         Diagnostics::SetExitCode(3);
         Diagnostics::PrintFinishLine();
         std::_Exit(3);

--- a/Apps/Playground/Shared/Diagnostics.cpp
+++ b/Apps/Playground/Shared/Diagnostics.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <string>
 
 #if defined(_MSC_VER)
@@ -39,6 +40,31 @@ namespace
     std::chrono::steady_clock::time_point s_startTime{};
 
     bool s_ansiEnabled{false};
+
+    // Recover the message of the exception that is currently propagating, if
+    // any. Returns an empty string when no exception is in flight. Valid inside
+    // a terminate handler and inside the SIGABRT handler that terminate() ends
+    // up calling, because the exception stays current until the handler returns.
+    std::string DescribeCurrentException()
+    {
+        if (std::current_exception() == nullptr)
+        {
+            return {};
+        }
+
+        try
+        {
+            std::rethrow_exception(std::current_exception());
+        }
+        catch (const std::exception& e)
+        {
+            return std::string{"uncaught std::exception: "} + e.what();
+        }
+        catch (...)
+        {
+            return "uncaught non-std exception.";
+        }
+    }
 
 #if defined(_MSC_VER)
     void __cdecl OnInvalidParameter(
@@ -71,7 +97,13 @@ namespace
 
     void OnSignalAbort(int /*signal*/)
     {
-        Diagnostics::DumpFailure("ABORT", nullptr, 0, 1, "SIGABRT raised.");
+        // abort() is where std::terminate() ends up, among other paths. On MSVC
+        // std::set_terminate() is per-thread, so a terminate on a worker thread
+        // never reaches OnTerminate below and lands here instead; recover the
+        // exception message either way.
+        const std::string detail = DescribeCurrentException();
+        Diagnostics::DumpFailure("ABORT", nullptr, 0, 1, "SIGABRT raised.%s%s",
+            detail.empty() ? "" : "\n", detail.c_str());
         if (::IsDebuggerPresent())
         {
             bx::debugBreak();
@@ -105,7 +137,9 @@ namespace
 #else
     void OnSignalAbort(int /*signal*/)
     {
-        Diagnostics::DumpFailure("ABORT", nullptr, 0, 1, "SIGABRT raised.");
+        const std::string detail = DescribeCurrentException();
+        Diagnostics::DumpFailure("ABORT", nullptr, 0, 1, "SIGABRT raised.%s%s",
+            detail.empty() ? "" : "\n", detail.c_str());
         Diagnostics::SetExitCode(3);
         Diagnostics::PrintFinishLine();
         std::_Exit(3);
@@ -162,6 +196,27 @@ namespace
         Diagnostics::PrintFinishLine();
         std::_Exit(3);
     }
+
+    void OnTerminate()
+    {
+        // An uncaught C++ exception otherwise reaches abort() with nothing but
+        // "SIGABRT raised.", which says nothing about what actually went wrong.
+        //
+        // This only covers the thread that installed it on Windows: the standard
+        // says the terminate handler is global, but the Microsoft CRT keeps it
+        // per-thread. OnSignalAbort() above repeats the same reporting so
+        // worker-thread terminations stay diagnosable there.
+        std::string detail = DescribeCurrentException();
+        if (detail.empty())
+        {
+            detail = "terminate called without an active exception.";
+        }
+
+        Diagnostics::DumpFailure("TERMINATE", nullptr, 0, 1, "%s", detail.c_str());
+        Diagnostics::SetExitCode(3);
+        Diagnostics::PrintFinishLine();
+        std::_Exit(3);
+    }
 }
 
 namespace Diagnostics
@@ -179,6 +234,9 @@ namespace Diagnostics
         // Route bx asserts + the SEH top-level exception filter to DumpFailure
         // (stderr-visible) instead of bx's OutputDebugString-only default.
         bx::setAssertHandler(&OnBxAssert);
+
+        // Report the message of an uncaught exception before abort() swallows it.
+        std::set_terminate(&OnTerminate);
 
 #if defined(_MSC_VER)
         // Route assert() to stderr instead of UCRT's modal dialog. Covers the


### PR DESCRIPTION
An uncaught C++ exception currently produces this, and nothing more:

```
--- BN: ABORT ---
SIGABRT raised.
```

The report never says what actually failed. The exception that is still propagating is now described:

```
--- BN: ABORT ---
SIGABRT raised.
uncaught std::exception: synthetic uncaught exception on a worker thread
```

## Why it is reported from two handlers

The reporting is done from both the terminate handler and the SIGABRT handler on purpose.

The standard says `std::set_terminate()` is global, but **the Microsoft CRT keeps the terminate handler per-thread**. A terminate on a worker thread therefore never reaches a handler installed on the main thread — it goes straight to `abort()` and lands in the SIGABRT handler. Handling both keeps worker-thread failures diagnosable on Windows, and still uses the terminate handler on platforms where it is genuinely global.

I found this the hard way: the first version of this PR only installed a terminate handler, and it silently never fired.

## What changed since the first revision

This PR originally also carried an ad-hoc dbghelp symbolizer for callstacks. That has been **dropped** — the unresolved frames were a bug in bx's own resolver, not something Babylon Native should work around locally. Two bx bugs are responsible:

1. `DbgHelpSymbolResolve::resolve()` requires `SymFromAddr` **and** `SymGetLineFromAddr` to both succeed. Modules that ship public symbols only (every system DLL) have a perfectly good function name but no line info, so the name was thrown away and the frame printed as `<Unknown?>`.
2. `write(WriterI*, const void*, ...)` in `string.cpp` casts through `uint32_t`, so **every** pointer printed via bx's `%p` loses its top 32 bits on a 64-bit build. Callstack PCs came out as `0x115cc3f6` instead of `0x00007ff9115cc3f6`, which cannot be fed back into a debugger.

With both fixed in bx, the same crash goes from 15 of 23 frames unresolved to all 23 resolved, with full-width addresses, and no Babylon Native change is needed:

```
	 0: ... 0x7ff90ef349da  RaiseException
	 4: ... 0x7ff794bccc29  WndProc                    (Apps/Playground/Win32/App.cpp:425)
	 5: ... 0x7ff9115cc3f6  CallWindowProcW
	 6: ... 0x7ff9115cb703  SendMessageW
	16: ... 0x7ff911ba4cb4  KiUserCallbackDispatcherContinue
```

So this PR is now just the uncaught-exception message.

## Scope

Cross-platform; no new dependencies. Verified on Windows by throwing from a worker thread and confirming the message appears and the exit code stays 3.
