### PR TITLE
Drop the dead BGFX_CONFIG_MAX_FRAME_BUFFERS=256 overrides and stop clamping the pool

### DIFF
--- a/.github/workflows/build-win32-shader.yml
+++ b/.github/workflows/build-win32-shader.yml
@@ -29,7 +29,6 @@ jobs:
             -A ${{ inputs.platform }} ^
             -D BX_CONFIG_DEBUG=ON ^
             -D GRAPHICS_API=D3D11 ^
-            -D BGFX_CONFIG_MAX_FRAME_BUFFERS=256 ^
             -D BABYLON_DEBUG_TRACE=ON ^
             -D BABYLON_NATIVE_PLUGIN_NATIVEENGINE_COMPILESHADERS=OFF
 

--- a/.github/workflows/build-win32.yml
+++ b/.github/workflows/build-win32.yml
@@ -65,7 +65,6 @@ jobs:
             ${{ steps.vars.outputs.js_define }} ^
             -D BX_CONFIG_DEBUG=ON ^
             -D GRAPHICS_API=${{ inputs.graphics-api }} ^
-            -D BGFX_CONFIG_MAX_FRAME_BUFFERS=256 ^
             -D BABYLON_DEBUG_TRACE=ON ^
             -D BABYLON_NATIVE_PLUGIN_NATIVEDRACO=ON ^
             -D BABYLON_NATIVE_PLUGIN_NATIVEMESHOPT=ON ^

--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -58,18 +58,10 @@ target_compile_definitions(bgfx PUBLIC BGFX_PLATFORM_SUPPORTS_WGSL=0)
 # Expose the path so the OpenGL backends of our own targets can use it.
 set(BGFX_KHRONOS_INCLUDE_DIR "${bgfx.cmake_SOURCE_DIR}/bgfx/3rdparty/khronos" CACHE INTERNAL "")
 
-# Canvas plugin allocates one bgfx framebuffer per JS Canvas object and per
-# text-rendering operation; combined with V8 GC pacing this can exceed the
-# default 128 limit during long playground sweeps. We enforce a floor of 2048:
-# CI workflows pass -DBGFX_CONFIG_MAX_FRAME_BUFFERS, and any value below 2048
-# (including a smaller CI override) is clamped up so the pool never regresses
-# below the size the Canvas sweeps need.
-#
-# 512 was sufficient only because the validation runner exited on the first
-# failing test. With --keep-going a full validation sweep keeps allocating past
-# that point and exhausts the pool around the FrameGraph tests, so the floor
-# has to cover a complete uninterrupted run.
-if(NOT BGFX_CONFIG_MAX_FRAME_BUFFERS OR BGFX_CONFIG_MAX_FRAME_BUFFERS LESS 2048)
+# The Canvas polyfill holds a bgfx framebuffer per JS Canvas object and per
+# text-rendering operation, releasing them only on GC finalize, so a long
+# playground sweep exceeds bgfx's default of 128.
+if(NOT BGFX_CONFIG_MAX_FRAME_BUFFERS)
     set(BGFX_CONFIG_MAX_FRAME_BUFFERS 2048)
 endif()
 target_compile_definitions(bgfx PRIVATE BGFX_CONFIG_MAX_FRAME_BUFFERS=${BGFX_CONFIG_MAX_FRAME_BUFFERS})

--- a/nightly.yml
+++ b/nightly.yml
@@ -21,7 +21,7 @@ jobs:
   - checkout: self
 
   - script: |
-      cmake -G "Visual Studio 17 2022" -B build -A x64 -D BX_CONFIG_DEBUG=ON -D BGFX_CONFIG_MAX_FRAME_BUFFERS=256 -D BABYLON_DEBUG_TRACE=ON
+      cmake -G "Visual Studio 17 2022" -B build -A x64 -D BX_CONFIG_DEBUG=ON -D BABYLON_DEBUG_TRACE=ON
     displayName: 'Generate solution'
 
   - script: |


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

## Context

The pool floor added in #1715 (512) and raised in #1830 (2048) clamps any smaller value upward, so the three CI workflows passing `-D BGFX_CONFIG_MAX_FRAME_BUFFERS=256` have had no effect since June while reading as deliberate coverage of a 256-slot pool.

The clamp is also wrong on its own terms: an embedder that deliberately picks a smaller pool is overridden with no diagnostic.

## Worth a look

- Both changes are in one commit because the ordering is a constraint, not a preference. Relaxing the clamp on its own would make CI's `=256` take effect and reintroduce the pool exhaustion #1830 fixed, since `build-win32.yml` and `nightly.yml` run the validation sweep the larger pool exists for.
- `build-win32-shader.yml` builds only `PrecompiledShaderTest`, where the value never mattered.
- #1807 replaces this block with a general default-if-unset macro across every `BGFX_CONFIG_` setting. It predates #1830 and still carries 512, so its merge from master needs to keep 2048.

## Verification

Configured Win32 x64 D3D11 both ways: with no flag bgfx still compiles with `BGFX_CONFIG_MAX_FRAME_BUFFERS=2048`, so CI is unchanged, and `-D BGFX_CONFIG_MAX_FRAME_BUFFERS=256` now reaches the compile line instead of being clamped up.
