### PR TITLE
Playground validation: finish the sweep instead of stopping at the first failure

### DIFF
--- a/.github/instructions/babylon-native-debugging.instructions.md
+++ b/.github/instructions/babylon-native-debugging.instructions.md
@@ -123,6 +123,9 @@ per flag** (intentional design -- long-name aliases were removed).
 -l, --list                  List configured tests as TSV and exit (0)
     --headless              Don't show window; route all logs to stdout
     --break-on-fail         Trigger debugger break on a failing test
+    --stop-on-first-failure Exit as soon as a test fails; by default the runner
+                            completes the whole suite and reports the full tally
+                            (the exit code is non-zero either way)
     --generate-references   Save rendered images as new reference PNGs
     --once                  Run only the first matching test, then exit
     --include-excluded      Force-run tests with excludeFromAutomaticTesting /

--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -51,10 +51,10 @@
     // snippet server it also notes that assets/fonts arrive over the network, so
     // async load timing is one possible cause -- but it is only one of several,
     // and it is cheap to rule out: a timing flake varies run to run, while a real
-    // regression reproduces with a byte-identical diff. Say that explicitly. The
-    // previous wording called such diffs "often a transient flake", which led to
-    // a genuine, perfectly reproducible motion-blur regression being waved off
-    // for two weeks of nightlies.
+    // regression reproduces with an identical pixel-difference count. Say that
+    // explicitly. The previous wording called such diffs "often a transient flake",
+    // which led to a genuine, perfectly reproducible motion-blur regression being
+    // waved off for two weeks of nightlies.
     function logFailureDiagnostics(test) {
         const outDir = TestUtils.getOutputDirectory();
         if (test.referenceImage) {

--- a/Apps/Playground/Scripts/validation_native.js
+++ b/Apps/Playground/Scripts/validation_native.js
@@ -8,7 +8,7 @@
     const testHeight = 400;
     const generateReferences = !!opts.generateReferences;
     const breakOnFail = !!opts.breakOnFail;
-    const keepGoing = !!opts.keepGoing;
+    const stopOnFirstFailure = !!opts.stopOnFirstFailure;
     const listTests = !!opts.listTests;
     const includeExcluded = !!opts.includeExcluded;
     const testFilters = Array.isArray(opts.testFilters) ? opts.testFilters.map(s => String(s).toLowerCase()) : [];
@@ -47,13 +47,14 @@
     }
 
     // Emitted after a pixel-comparison failure to make triage faster. Prints the
-    // rendered/diff PNG paths and, for scenes fetched from the Babylon snippet
-    // server, a transient-flake hint: those tests pull the GUI library, textures
-    // and web fonts over the network/CDN, so their output depends on async
-    // asset/font-load timing. A pixel diff there is frequently a transient flake
-    // rather than a real regression -- the 'Parse GUI json with unicode' snippet
-    // test is the canonical example (its GUI text renders with the fallback font
-    // until 'droidsans' finishes loading, shifting thousands of glyph pixels).
+    // rendered/diff PNG paths plus a re-run command. For scenes fetched from the
+    // snippet server it also notes that assets/fonts arrive over the network, so
+    // async load timing is one possible cause -- but it is only one of several,
+    // and it is cheap to rule out: a timing flake varies run to run, while a real
+    // regression reproduces with a byte-identical diff. Say that explicitly. The
+    // previous wording called such diffs "often a transient flake", which led to
+    // a genuine, perfectly reproducible motion-blur regression being waved off
+    // for two weeks of nightlies.
     function logFailureDiagnostics(test) {
         const outDir = TestUtils.getOutputDirectory();
         if (test.referenceImage) {
@@ -61,10 +62,10 @@
             console.log(`  Diff overlay:    ${outDir}/Errors/${test.referenceImage}`);
         }
         if (test.playgroundId) {
-            console.log(`  Note: this test loads playgroundId ${test.playgroundId} from the snippet server and pulls GUI/assets/fonts over the network, so a pixel diff is often a transient async asset/font-load timing flake.`);
-            console.log("  Re-run in isolation to confirm a real regression:");
-            console.log(`    Playground --headless --once --test "${test.title || ""}" app:///Scripts/validation_native.js`);
+            console.log(`  Note: this test loads playgroundId ${test.playgroundId} from the snippet server and pulls GUI/assets/fonts over the network, so async asset/font-load timing is one possible cause of a pixel diff.`);
         }
+        console.log("  Re-run in isolation; an identical pixel count on repeat runs means a real regression, not a timing flake:");
+        console.log(`    Playground --headless --once --test "${test.title || ""}" app:///Scripts/validation_native.js`);
     }
 
     // Per-run counters surfaced as a final summary line on exit.
@@ -724,7 +725,7 @@
                         failedTitles.push(currentTitle);
                         // failTest() already triggered the debugger before
                         // reaching this callback; no second `debugger` here.
-                        if (!keepGoing) {
+                        if (stopOnFirstFailure) {
                             logRunSummary();
                             TestUtils.exit(-1);
                             return;

--- a/Apps/Playground/Shared/CommandLine.cpp
+++ b/Apps/Playground/Shared/CommandLine.cpp
@@ -153,13 +153,14 @@ namespace
             "Trigger debugger break on a failing test.", "",
             [](PlaygroundOptions& o, std::string_view, std::string&) { o.BreakOnFail = true; }},
 
-        FlagSpec{"--keep-going", "-k", FlagKind::Boolean, "",
-            "Continue after a failing test instead of",
-            "                              exiting on the first failure. The run still\n"
-            "                              exits non-zero if anything failed. Use this\n"
-            "                              for full sweeps where you want the complete\n"
-            "                              pass/fail tally rather than the first error.\n",
-            [](PlaygroundOptions& o, std::string_view, std::string&) { o.KeepGoing = true; }},
+        FlagSpec{"--stop-on-first-failure", "", FlagKind::Boolean, "",
+            "Exit as soon as a test fails instead of",
+            "                              running the rest of the suite. By default the\n"
+            "                              runner completes every selected test and\n"
+            "                              reports the full tally; the run still exits\n"
+            "                              non-zero if anything failed. Use this to cut\n"
+            "                              a long sweep short while bisecting.\n",
+            [](PlaygroundOptions& o, std::string_view, std::string&) { o.StopOnFirstFailure = true; }},
 
         FlagSpec{"--generate-references", "", FlagKind::Boolean, "",
             "Save rendered images as new reference PNGs.", "",

--- a/Apps/Playground/Shared/CommandLine.h
+++ b/Apps/Playground/Shared/CommandLine.h
@@ -13,7 +13,7 @@ struct PlaygroundOptions
     bool ListTests = false;
     bool Headless = false;
     bool BreakOnFail = false;
-    bool KeepGoing = false;
+    bool StopOnFirstFailure = false;
     bool GenerateReferences = false;
     bool RunOnce = false;
     bool IncludeExcluded = false;

--- a/Apps/Playground/Win32/App.cpp
+++ b/Apps/Playground/Win32/App.cpp
@@ -111,7 +111,7 @@ namespace
             js.Set("listTests",          Napi::Boolean::New(env, playgroundOptions.ListTests));
             js.Set("headless",           Napi::Boolean::New(env, playgroundOptions.Headless));
             js.Set("breakOnFail",        Napi::Boolean::New(env, playgroundOptions.BreakOnFail));
-            js.Set("keepGoing",          Napi::Boolean::New(env, playgroundOptions.KeepGoing));
+            js.Set("stopOnFirstFailure", Napi::Boolean::New(env, playgroundOptions.StopOnFirstFailure));
             js.Set("generateReferences", Napi::Boolean::New(env, playgroundOptions.GenerateReferences));
             js.Set("runOnce",            Napi::Boolean::New(env, playgroundOptions.RunOnce));
             js.Set("includeExcluded",    Napi::Boolean::New(env, playgroundOptions.IncludeExcluded));


### PR DESCRIPTION
## Problem

The validation runner exits on the first failing test. On the nightly the first
failure is **index 322 of 720**, so **398 tests have not run since 2026-07-30** —
the sweep has been reporting `ran=175 skipped=147` instead of the full 720 for
over two weeks.

That is not just lost coverage. The tests immediately after the stopping point
were failing too, and nobody could see it:

```
--test-index=320-325   ->  Thin instances + dynamic buffer resize    FAILED
                           Instances + render self motion blur       FAILED
                           Thin instances + render self motion blur  FAILED
```

Only the first of those three was visible in the nightly log.

## Change

**Continue-on-failure is now the default.** The run completes every selected
test, prints the full tally and the list of failed titles, and still exits
non-zero if anything failed. `--keep-going`/`-k` is replaced by its inverse,
the opt-in `--stop-on-first-failure`, which is the behaviour you actually want
while bisecting a long sweep rather than the default for CI.

**Softens the pixel-comparison failure note.** It previously stated that a diff
on a snippet-server test was *"often a transient async asset/font-load timing
flake"*. That is sometimes true, but phrased that confidently it reads as a
verdict — a fully reproducible regression was waved off on the strength of it
for two weeks of nightlies. It now names network timing as *one possible* cause
and gives the cheap way to tell the two apart: a flake varies run to run, a real
regression repeats with an identical pixel count. The re-run command is now
printed for every failing test, not just snippet-loaded ones.

## Verification

Win32 x64 D3D11, RelWithDebInfo, Babylon.js 9.21.2:

| command | result | exit |
|---|---|---|
| `--test-index=320-325` | `ran=3 passed=0 failed=3` | -1 |
| `--test-index=320-325 --stop-on-first-failure` | `ran=1 passed=0 failed=1` | -1 |
| `--test-index=0-5` | `ran=6 passed=6 failed=0` | 0 |

`--help` output and `.github/instructions/babylon-native-debugging.instructions.md`
updated to match.

## Note for reviewers

**Expect the nightly to get louder before it gets quieter.** Once this lands the
sweep will run all 720 tests and report every failure, so the failure list will
grow — those failures already exist, they were just unreachable. The three above
are motion-blur regressions exposed by #1754 enabling MultiRenderTarget support;
they are fixed in a separate PR.
