### PR TITLE
Correct gl_FragCoord Y orientation on D3D, Metal and Vulkan

### DIFF
--- a/Apps/UnitTests/CMakeLists.txt
+++ b/Apps/UnitTests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SOURCES
     "Source/Tests.NativeEngine.Teardown.cpp"
     "Source/Tests.ShaderCache.cpp"
     "Source/Tests.ShaderCompilation.cpp"
+    "Source/Tests.ShaderCompilation.FragCoord.cpp"
     "Source/Tests.UniformPadding.cpp"
     "Source/Helpers.h"
     "Source/Helpers.${GRAPHICS_API}.${BABYLON_NATIVE_PLATFORM_IMPL_EXT}")

--- a/Apps/UnitTests/Source/Tests.ShaderCompilation.FragCoord.cpp
+++ b/Apps/UnitTests/Source/Tests.ShaderCompilation.FragCoord.cpp
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 extern Babylon::Graphics::Configuration g_deviceConfig;
@@ -261,10 +262,14 @@ namespace
     }
 }
 
-// gl_FragCoord.y must follow the GL convention of increasing upwards, so the top
-// row of the image (row 0 in memory) has to hold the largest value. Without the
-// gl_FragCoord correction the ramp comes out upside down on D3D/Metal/Vulkan.
-TEST(ShaderCompilation, FragCoordYIncreasesUpwards)
+// gl_FragCoord.y must increase towards +Y in clip space, like the interpolated vUV.y
+// the quad supplies. Without the correction the two ramps become mirror images.
+//
+// Two channels of a single render are compared rather than absolute row indices
+// because Helpers::ReadPixels returns the bottom scanline first on OpenGL and the top
+// first on D3D11; an absolute check would encode one backend's readback convention
+// instead of the shading language rule under test.
+TEST(ShaderCompilation, FragCoordYMatchesInterpolatedUV)
 {
 #if defined(SKIP_EXTERNAL_TEXTURE_TESTS) || defined(SKIP_RENDER_TESTS)
     GTEST_SKIP();
@@ -275,36 +280,47 @@ TEST(ShaderCompilation, FragCoordYIncreasesUpwards)
     const std::string vertexShader =
         "precision highp float;\n"
         "attribute vec3 position;\n"
-        "void main(void) { gl_Position = vec4(position, 1.0); }\n";
+        "attribute vec2 uv;\n"
+        "varying vec2 vUV;\n"
+        "void main(void) { vUV = uv; gl_Position = vec4(position, 1.0); }\n";
 
     const std::string fragmentShader =
         "precision highp float;\n"
         "uniform vec2 targetSize;\n"
+        "varying vec2 vUV;\n"
         "void main(void) {\n"
-        "    gl_FragColor = vec4(gl_FragCoord.y / targetSize.y, 0.0, 0.0, 1.0);\n"
+        "    gl_FragColor = vec4(gl_FragCoord.y / targetSize.y, vUV.y, 0.0, 1.0);\n"
         "}\n";
 
     auto pixels = RenderFullScreenQuad(WIDTH, HEIGHT, vertexShader, fragmentShader, false);
     ASSERT_EQ(pixels.size(), static_cast<size_t>(WIDTH) * HEIGHT * 4);
 
-    const auto red = [&pixels](uint32_t row) {
-        return static_cast<int>(pixels[static_cast<size_t>(row) * WIDTH * 4]);
+    const auto texel = [&pixels](uint32_t row) {
+        const size_t offset = static_cast<size_t>(row) * WIDTH * 4;
+        return std::make_pair(static_cast<int>(pixels[offset]), static_cast<int>(pixels[offset + 1]));
     };
 
-    std::cout << "row 0 red=" << red(0)
-              << ", row " << (HEIGHT / 2) << " red=" << red(HEIGHT / 2)
-              << ", row " << (HEIGHT - 1) << " red=" << red(HEIGHT - 1) << std::endl;
+    const auto first = texel(0);
+    const auto middle = texel(HEIGHT / 2);
+    const auto last = texel(HEIGHT - 1);
+    std::cout << "row 0 fragCoord=" << first.first << " uv=" << first.second
+              << ", row " << (HEIGHT / 2) << " fragCoord=" << middle.first << " uv=" << middle.second
+              << ", row " << (HEIGHT - 1) << " fragCoord=" << last.first << " uv=" << last.second
+              << std::endl;
 
-    // The ramp must run bright at the top to dark at the bottom.
-    EXPECT_GT(red(0), 200) << "top row should hold the largest gl_FragCoord.y";
-    EXPECT_LT(red(HEIGHT - 1), 55) << "bottom row should hold the smallest gl_FragCoord.y";
+    // Guard against a vacuous pass: the reference ramp must actually sweep the range.
+    ASSERT_GT(std::abs(first.second - last.second), 200)
+        << "vUV.y reference ramp did not vary across the target";
 
-    // Monotonicity is checked instead of exact values so the test stays valid
-    // under any monotonic transfer function the backend may apply.
-    for (uint32_t row = 1; row < HEIGHT; ++row)
+    // Both channels come from the same fragment invocation, so they must agree row by
+    // row whichever end of the image the readback starts at. The tolerance absorbs
+    // interpolation and 8-bit quantization only.
+    for (uint32_t row = 0; row < HEIGHT; ++row)
     {
-        ASSERT_LE(red(row), red(row - 1))
-            << "gl_FragCoord.y ramp is not monotonically decreasing at row " << row;
+        const auto values = texel(row);
+        ASSERT_LE(std::abs(values.first - values.second), 6)
+            << "gl_FragCoord.y disagrees with the interpolated vUV.y at row " << row
+            << " (gl_FragCoord=" << values.first << ", vUV=" << values.second << ")";
     }
 #endif
 }

--- a/Apps/UnitTests/Source/Tests.ShaderCompilation.FragCoord.cpp
+++ b/Apps/UnitTests/Source/Tests.ShaderCompilation.FragCoord.cpp
@@ -74,7 +74,7 @@ namespace
 
                 globalThis.startup = function (outputNativeTexture, width, height) {
                     var engine = new BABYLON.NativeEngine();
-                    delete engine.getCaps().parallelShaderCompile;
+                    engine.getCaps().parallelShaderCompile = null;
                     var scene = new BABYLON.Scene(engine);
                     scene.autoClear = true;
                     scene.clearColor = new BABYLON.Color4(0, 0, 0, 1);

--- a/Apps/UnitTests/Source/Tests.ShaderCompilation.FragCoord.cpp
+++ b/Apps/UnitTests/Source/Tests.ShaderCompilation.FragCoord.cpp
@@ -1,0 +1,376 @@
+#include <gtest/gtest.h>
+
+#include <Babylon/AppRuntime.h>
+#include <Babylon/Graphics/Device.h>
+#include <Babylon/Polyfills/Console.h>
+#include <Babylon/Polyfills/Window.h>
+#include <Babylon/Plugins/NativeEngine.h>
+#include <Babylon/Plugins/ExternalTexture.h>
+#include <Babylon/ScriptLoader.h>
+
+#include "Helpers.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <future>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+extern Babylon::Graphics::Configuration g_deviceConfig;
+
+// These tests pin down the orientation of gl_FragCoord.y.
+//
+// D3D, Metal and Vulkan rasterize with a top-left origin while GL uses bottom-left,
+// and Babylon Native does not flip geometry, so gl_FragCoord.y arrives mirrored and
+// is corrected by the shader compiler (FragCoordYFlipTraverser).
+namespace
+{
+    // Renders a full-screen quad into a width x height render target, returning RGBA8
+    // pixels in memory order. The fragment shader may declare `uniform vec2 targetSize`
+    // and, when withInputTexture is set, `uniform sampler2D inputSampler` bound to a
+    // texture whose row y holds makeRow(y).
+    std::vector<uint8_t> RenderFullScreenQuad(
+        uint32_t width,
+        uint32_t height,
+        const std::string& vertexShader,
+        const std::string& fragmentShader,
+        bool withInputTexture)
+    {
+        Babylon::Graphics::Device device{g_deviceConfig};
+        device.StartRenderingCurrentFrame();
+
+        auto outputTexture = Helpers::CreateTexture(
+            device.GetPlatformInfo().Device, width, height, 1, true);
+        Babylon::Plugins::ExternalTexture outputExternalTexture{outputTexture};
+
+        Babylon::AppRuntime::Options options{};
+        options.UnhandledExceptionHandler = [](const Napi::Error& error) {
+            std::cerr << "[Uncaught Error] " << Napi::GetErrorString(error) << std::endl;
+            std::cerr.flush();
+        };
+
+        Babylon::AppRuntime runtime{options};
+        runtime.Dispatch([&device](Napi::Env env) {
+            env.Global().Set("globalThis", env.Global());
+            device.AddToJavaScript(env);
+
+            Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
+                std::cout << message << std::endl;
+            });
+            Babylon::Polyfills::Window::Initialize(env);
+            Babylon::Plugins::NativeEngine::Initialize(env);
+        });
+
+        Babylon::ScriptLoader loader{runtime};
+        loader.LoadScript("app:///Assets/babylon.max.js");
+
+        const std::string script = R"(
+            (function () {
+                var vertexShader = VERTEX_SHADER_SOURCE;
+
+                var fragmentShader = FRAGMENT_SHADER_SOURCE;
+
+                globalThis.startup = function (outputNativeTexture, width, height) {
+                    var engine = new BABYLON.NativeEngine();
+                    delete engine.getCaps().parallelShaderCompile;
+                    var scene = new BABYLON.Scene(engine);
+                    scene.autoClear = true;
+                    scene.clearColor = new BABYLON.Color4(0, 0, 0, 1);
+
+                    var outputTexture = new BABYLON.RenderTargetTexture(
+                        "output",
+                        { width: width, height: height },
+                        scene,
+                        {
+                            colorAttachment: engine.wrapNativeTexture(outputNativeTexture),
+                            generateDepthBuffer: true,
+                            generateStencilBuffer: false
+                        });
+
+                    var camera = new BABYLON.FreeCamera("camera", new BABYLON.Vector3(0, 0, -1), scene);
+                    camera.setTarget(BABYLON.Vector3.Zero());
+                    camera.mode = BABYLON.Camera.ORTHOGRAPHIC_CAMERA;
+                    camera.orthoTop = 1;
+                    camera.orthoBottom = -1;
+                    camera.orthoLeft = -1;
+                    camera.orthoRight = 1;
+                    camera.outputRenderTarget = outputTexture;
+
+                    // Clip-space quad passed straight through the vertex shader, so no
+                    // projection matrix is involved and it lines up with the target exactly.
+                    var quad = new BABYLON.Mesh("quad", scene);
+                    var vertexData = new BABYLON.VertexData();
+                    vertexData.positions = [
+                        -1, -1, 0,
+                         1, -1, 0,
+                         1,  1, 0,
+                        -1,  1, 0
+                    ];
+                    vertexData.uvs = [
+                        0, 0,
+                        1, 0,
+                        1, 1,
+                        0, 1
+                    ];
+                    vertexData.indices = [0, 1, 2, 0, 2, 3];
+                    vertexData.applyToMesh(quad);
+                    quad.alwaysSelectAsActiveMesh = true;
+
+                    var material = new BABYLON.ShaderMaterial(
+                        "fragCoordShader",
+                        scene,
+                        { vertexSource: vertexShader, fragmentSource: fragmentShader },
+                        {
+                            attributes: vertexShader.indexOf("attribute vec2 uv") !== -1
+                                ? ["position", "uv"]
+                                : ["position"],
+                            uniforms: ["targetSize"],
+                            samplers: WITH_INPUT_TEXTURE ? ["inputSampler"] : []
+                        });
+                    material.onError = function (_effect, errors) {
+                        console.error("ShaderMaterial compilation error: " + errors);
+                    };
+                    material.backFaceCulling = false;
+                    material.depthFunction = BABYLON.Constants.ALWAYS;
+                    material.setVector2("targetSize", new BABYLON.Vector2(width, height));
+
+                    if (WITH_INPUT_TEXTURE) {
+                        // Decreasing red ramp makes a vertical mirror unambiguous; blue
+                        // encodes the low bits of the row index to catch off-by-one errors.
+                        var data = new Uint8Array(width * height * 4);
+                        for (var y = 0; y < height; ++y) {
+                            for (var x = 0; x < width; ++x) {
+                                var i = (y * width + x) * 4;
+                                data[i] = 255 - y * 4;
+                                data[i + 1] = 0;
+                                data[i + 2] = y * 4;
+                                data[i + 3] = 255;
+                            }
+                        }
+                        var raw = engine.createRawTexture(
+                            data,
+                            width,
+                            height,
+                            BABYLON.Constants.TEXTUREFORMAT_RGBA,
+                            false /* generateMipMaps */,
+                            false /* invertY */,
+                            BABYLON.Constants.TEXTURE_NEAREST_SAMPLINGMODE);
+                        var wrapper = new BABYLON.Texture(null, scene);
+                        wrapper._texture = raw;
+                        wrapper.wrapU = BABYLON.Constants.TEXTURE_CLAMP_ADDRESSMODE;
+                        wrapper.wrapV = BABYLON.Constants.TEXTURE_CLAMP_ADDRESSMODE;
+                        material.setTexture("inputSampler", wrapper);
+                    }
+
+                    quad.material = material;
+                    globalThis.__scene = scene;
+                };
+
+                globalThis.render = function () {
+                    var scene = globalThis.__scene;
+                    return scene.whenReadyAsync().then(function () {
+                        scene.render();
+                    });
+                };
+            })();
+        )";
+
+        // Inject the caller's shaders as JS string literals.
+        const auto toJsStringLiteral = [](const std::string& source) {
+            std::string result = "\"";
+            for (char c : source)
+            {
+                if (c == '\n')
+                {
+                    result += "\\n";
+                }
+                else if (c == '"')
+                {
+                    result += "\\\"";
+                }
+                else if (c == '\\')
+                {
+                    result += "\\\\";
+                }
+                else
+                {
+                    result += c;
+                }
+            }
+            result += "\"";
+            return result;
+        };
+
+        const auto replaceToken = [](std::string& text, const std::string& token, const std::string& value) {
+            for (size_t pos = text.find(token); pos != std::string::npos; pos = text.find(token, pos))
+            {
+                text.replace(pos, token.size(), value);
+                pos += value.size();
+            }
+        };
+
+        std::string finalScript = script;
+        replaceToken(finalScript, "VERTEX_SHADER_SOURCE", toJsStringLiteral(vertexShader));
+        replaceToken(finalScript, "FRAGMENT_SHADER_SOURCE", toJsStringLiteral(fragmentShader));
+        replaceToken(finalScript, "WITH_INPUT_TEXTURE", withInputTexture ? "true" : "false");
+
+        loader.Eval(finalScript, "frag_coord_orientation_test.js");
+
+        std::promise<void> startupDone;
+        loader.Dispatch([&outputExternalTexture, &startupDone, width, height](Napi::Env env) {
+            auto jsOutput = outputExternalTexture.CreateForJavaScript(env);
+            env.Global().Get("startup").As<Napi::Function>().Call({
+                jsOutput,
+                Napi::Number::New(env, width),
+                Napi::Number::New(env, height),
+            });
+            startupDone.set_value();
+        });
+        startupDone.get_future().wait();
+
+        device.FinishRenderingCurrentFrame();
+        device.StartRenderingCurrentFrame();
+
+        std::promise<void> renderDone;
+        loader.Dispatch([&renderDone](Napi::Env env) {
+            auto jsPromise = env.Global().Get("render").As<Napi::Function>().Call({}).As<Napi::Promise>();
+
+            auto jsOnFulfilled = Napi::Function::New(env, [&renderDone](const Napi::CallbackInfo&) {
+                renderDone.set_value();
+            });
+            auto jsOnRejected = Napi::Function::New(env, [&renderDone](const Napi::CallbackInfo& info) {
+                renderDone.set_exception(std::make_exception_ptr(
+                    std::runtime_error{Napi::GetErrorString(info[0].As<Napi::Error>())}));
+            });
+
+            jsPromise.Get("then").As<Napi::Function>().Call(jsPromise, {jsOnFulfilled, jsOnRejected});
+        });
+
+        auto renderFuture = renderDone.get_future();
+        EXPECT_EQ(renderFuture.wait_for(std::chrono::seconds(30)), std::future_status::ready)
+            << "render timed out";
+        EXPECT_NO_THROW(renderFuture.get()) << "render rejected";
+
+        device.FinishRenderingCurrentFrame();
+
+        auto pixels = Helpers::ReadPixels(device.GetPlatformInfo(), outputTexture, width, height);
+        Helpers::DestroyTexture(outputTexture);
+        return pixels;
+    }
+}
+
+// gl_FragCoord.y must follow the GL convention of increasing upwards, so the top
+// row of the image (row 0 in memory) has to hold the largest value. Without the
+// gl_FragCoord correction the ramp comes out upside down on D3D/Metal/Vulkan.
+TEST(ShaderCompilation, FragCoordYIncreasesUpwards)
+{
+#if defined(SKIP_EXTERNAL_TEXTURE_TESTS) || defined(SKIP_RENDER_TESTS)
+    GTEST_SKIP();
+#else
+    constexpr uint32_t WIDTH = 8;
+    constexpr uint32_t HEIGHT = 64;
+
+    const std::string vertexShader =
+        "precision highp float;\n"
+        "attribute vec3 position;\n"
+        "void main(void) { gl_Position = vec4(position, 1.0); }\n";
+
+    const std::string fragmentShader =
+        "precision highp float;\n"
+        "uniform vec2 targetSize;\n"
+        "void main(void) {\n"
+        "    gl_FragColor = vec4(gl_FragCoord.y / targetSize.y, 0.0, 0.0, 1.0);\n"
+        "}\n";
+
+    auto pixels = RenderFullScreenQuad(WIDTH, HEIGHT, vertexShader, fragmentShader, false);
+    ASSERT_EQ(pixels.size(), static_cast<size_t>(WIDTH) * HEIGHT * 4);
+
+    const auto red = [&pixels](uint32_t row) {
+        return static_cast<int>(pixels[static_cast<size_t>(row) * WIDTH * 4]);
+    };
+
+    std::cout << "row 0 red=" << red(0)
+              << ", row " << (HEIGHT / 2) << " red=" << red(HEIGHT / 2)
+              << ", row " << (HEIGHT - 1) << " red=" << red(HEIGHT - 1) << std::endl;
+
+    // The ramp must run bright at the top to dark at the bottom.
+    EXPECT_GT(red(0), 200) << "top row should hold the largest gl_FragCoord.y";
+    EXPECT_LT(red(HEIGHT - 1), 55) << "bottom row should hold the smallest gl_FragCoord.y";
+
+    // Monotonicity is checked instead of exact values so the test stays valid
+    // under any monotonic transfer function the backend may apply.
+    for (uint32_t row = 1; row < HEIGHT; ++row)
+    {
+        ASSERT_LE(red(row), red(row - 1))
+            << "gl_FragCoord.y ramp is not monotonically decreasing at row " << row;
+    }
+#endif
+}
+
+// Indexing a screen-sized texture with gl_FragCoord must give the same image as
+// indexing it with the interpolated UVs of a full-screen quad; this only holds if the
+// gl_FragCoord correction and FlipSamplerCoordinatesTraverser compose to a no-op.
+// The two addressing modes are compared against each other rather than against the
+// source pixels so the test does not depend on createRawTexture's memory layout.
+TEST(ShaderCompilation, FragCoordAndUVAddressATextureIdentically)
+{
+#if defined(SKIP_EXTERNAL_TEXTURE_TESTS) || defined(SKIP_RENDER_TESTS)
+    GTEST_SKIP();
+#else
+    constexpr uint32_t WIDTH = 8;
+    constexpr uint32_t HEIGHT = 64;
+
+    const std::string vertexShader =
+        "precision highp float;\n"
+        "attribute vec3 position;\n"
+        "attribute vec2 uv;\n"
+        "varying vec2 vUV;\n"
+        "void main(void) {\n"
+        "    vUV = uv;\n"
+        "    gl_Position = vec4(position, 1.0);\n"
+        "}\n";
+
+    const std::string uvShader =
+        "precision highp float;\n"
+        "varying vec2 vUV;\n"
+        "uniform vec2 targetSize;\n"
+        "uniform sampler2D inputSampler;\n"
+        "void main(void) {\n"
+        "    gl_FragColor = texture2D(inputSampler, vUV);\n"
+        "}\n";
+
+    const std::string fragCoordShader =
+        "precision highp float;\n"
+        "varying vec2 vUV;\n"
+        "uniform vec2 targetSize;\n"
+        "uniform sampler2D inputSampler;\n"
+        "void main(void) {\n"
+        "    gl_FragColor = texture2D(inputSampler, gl_FragCoord.xy / targetSize);\n"
+        "}\n";
+
+    auto uvPixels = RenderFullScreenQuad(WIDTH, HEIGHT, vertexShader, uvShader, true);
+    auto fragCoordPixels = RenderFullScreenQuad(WIDTH, HEIGHT, vertexShader, fragCoordShader, true);
+
+    ASSERT_EQ(uvPixels.size(), static_cast<size_t>(WIDTH) * HEIGHT * 4);
+    ASSERT_EQ(fragCoordPixels.size(), uvPixels.size());
+
+    const auto red = [](const std::vector<uint8_t>& pixels, uint32_t row) {
+        return static_cast<int>(pixels[static_cast<size_t>(row) * WIDTH * 4]);
+    };
+
+    // Guard against a vacuous pass: the source must actually vary down the image.
+    ASSERT_GT(std::abs(red(uvPixels, 0) - red(uvPixels, HEIGHT - 1)), 200)
+        << "the source texture must vary from top to bottom for this test to mean anything";
+
+    std::cout << "uv       rows: " << red(uvPixels, 0) << " .. " << red(uvPixels, HEIGHT - 1) << std::endl;
+    std::cout << "fragCoord rows: " << red(fragCoordPixels, 0) << " .. " << red(fragCoordPixels, HEIGHT - 1) << std::endl;
+
+    for (uint32_t row = 0; row < HEIGHT; ++row)
+    {
+        ASSERT_EQ(red(fragCoordPixels, row), red(uvPixels, row))
+            << "row " << row << " differs between gl_FragCoord and uv addressing";
+    }
+#endif
+}

--- a/Apps/UnitTests/Source/Tests.ShaderCompilation.FragCoord.cpp
+++ b/Apps/UnitTests/Source/Tests.ShaderCompilation.FragCoord.cpp
@@ -10,7 +10,6 @@
 
 #include "Helpers.h"
 
-#include <chrono>
 #include <cstdlib>
 #include <future>
 #include <iostream>
@@ -249,10 +248,7 @@ namespace
             jsPromise.Get("then").As<Napi::Function>().Call(jsPromise, {jsOnFulfilled, jsOnRejected});
         });
 
-        auto renderFuture = renderDone.get_future();
-        EXPECT_EQ(renderFuture.wait_for(std::chrono::seconds(30)), std::future_status::ready)
-            << "render timed out";
-        EXPECT_NO_THROW(renderFuture.get()) << "render rejected";
+        renderDone.get_future().get();
 
         device.FinishRenderingCurrentFrame();
 
@@ -321,6 +317,55 @@ TEST(ShaderCompilation, FragCoordYMatchesInterpolatedUV)
         ASSERT_LE(std::abs(values.first - values.second), 6)
             << "gl_FragCoord.y disagrees with the interpolated vUV.y at row " << row
             << " (gl_FragCoord=" << values.first << ", vUV=" << values.second << ")";
+    }
+#endif
+}
+
+// `return gl_FragCoord;` parents the symbol on TIntermBranch, which MakeReplacements
+// must handle; without that the compiler throws "Cannot replace symbol".
+TEST(ShaderCompilation, FragCoordDirectReturnMatchesInterpolatedUV)
+{
+#if defined(SKIP_EXTERNAL_TEXTURE_TESTS) || defined(SKIP_RENDER_TESTS)
+    GTEST_SKIP();
+#else
+    constexpr uint32_t WIDTH = 8;
+    constexpr uint32_t HEIGHT = 64;
+
+    const std::string vertexShader =
+        "precision highp float;\n"
+        "attribute vec3 position;\n"
+        "attribute vec2 uv;\n"
+        "varying vec2 vUV;\n"
+        "void main(void) { vUV = uv; gl_Position = vec4(position, 1.0); }\n";
+
+    const std::string fragmentShader =
+        "precision highp float;\n"
+        "uniform vec2 targetSize;\n"
+        "varying vec2 vUV;\n"
+        "vec4 fragCoord() { return gl_FragCoord; }\n"
+        "void main(void) {\n"
+        "    gl_FragColor = vec4(fragCoord().y / targetSize.y, vUV.y, 0.0, 1.0);\n"
+        "}\n";
+
+    auto pixels = RenderFullScreenQuad(WIDTH, HEIGHT, vertexShader, fragmentShader, false);
+    ASSERT_EQ(pixels.size(), static_cast<size_t>(WIDTH) * HEIGHT * 4);
+
+    const auto texel = [&pixels](uint32_t row) {
+        const size_t offset = static_cast<size_t>(row) * WIDTH * 4;
+        return std::make_pair(static_cast<int>(pixels[offset]), static_cast<int>(pixels[offset + 1]));
+    };
+
+    const auto first = texel(0);
+    const auto last = texel(HEIGHT - 1);
+    ASSERT_GT(std::abs(first.second - last.second), 200)
+        << "vUV.y reference ramp did not vary across the target";
+
+    for (uint32_t row = 0; row < HEIGHT; ++row)
+    {
+        const auto values = texel(row);
+        ASSERT_LE(std::abs(values.first - values.second), 6)
+            << "gl_FragCoord.y disagrees with the interpolated vUV.y at row " << row
+            << " after a direct return (gl_FragCoord=" << values.first << ", vUV=" << values.second << ")";
     }
 #endif
 }

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/BgfxShaderInfo.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/BgfxShaderInfo.h
@@ -62,6 +62,10 @@ namespace Babylon::Graphics
         }
         return false;
     }
+    /// Uniform declared in fragment shaders that read gl_FragCoord, holding the bound
+    /// framebuffer's width/height in .x/.y. Deliberately outside the u_ namespace Babylon.js
+    /// uses so it cannot collide with a shader uniform.
+    inline constexpr const char* FRAGCOORD_TARGET_SIZE_UNIFORM_NAME{"bnFragCoordTargetSize"};
 
     struct BgfxShaderInfo
     {

--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -3066,6 +3066,20 @@ namespace Babylon
             encoder->setUniform({it.first}, value.Data.data(), value.ElementLength);
         }
 
+        // Resolves the gl_FragCoord Y flip injected by ShaderCompilerTraversers::FlipFragCoordY.
+        // Must be the framebuffer's height, not the bgfx view rect's, which
+        // SetBgfxViewPortAndScissor narrows to the viewport when one is set.
+        if (const UniformInfo* fragCoordTargetSize = m_currentProgram->FragCoordTargetSizeUniform())
+        {
+            const Graphics::FrameBuffer& frameBuffer = GetBoundFrameBuffer();
+            const float targetSize[4]{
+                static_cast<float>(frameBuffer.Width()),
+                static_cast<float>(frameBuffer.Height()),
+                0.0f,
+                0.0f};
+            encoder->setUniform(fragCoordTargetSize->Handle, targetSize, 1);
+        }
+
         // Generic divisor-driven attributes are per-vertex inputs in the base shader. Recompile a
         // variant that routes each one to the exact i_data slot used by the instance buffer.
         // Built-ins keep the compiler-assigned base slots carried by Program.

--- a/Plugins/NativeEngine/Source/Program.cpp
+++ b/Plugins/NativeEngine/Source/Program.cpp
@@ -103,6 +103,9 @@ namespace Babylon
                 throw std::runtime_error{"Multiple built-in instance attributes use the same shader location."};
             }
         }
+
+        // Cached because DrawInternal consults it on every draw.
+        m_fragCoordTargetSizeUniform = GetUniformInfo(Graphics::FRAGCOORD_TARGET_SIZE_UNIFORM_NAME);
     }
 
     void Program::SetSources(std::string vertexSource, std::string fragmentSource)

--- a/Plugins/NativeEngine/Source/Program.h
+++ b/Plugins/NativeEngine/Source/Program.h
@@ -69,6 +69,8 @@ namespace Babylon
         bgfx::ProgramHandle Handle() const { return m_handle; }
         const std::map<uint16_t, UniformValue>& Uniforms() const { return m_uniforms; }
         const std::map<std::string, uint32_t>& VertexAttributeLocations() const { return m_vertexAttributeLocations; }
+        // Null for shaders that never read gl_FragCoord; the compiler omits the uniform there.
+        const UniformInfo* FragCoordTargetSizeUniform() const { return m_fragCoordTargetSizeUniform; }
 
         // Compiler-assigned i_data slot for each built-in attribute location.
         const std::map<uint32_t, uint32_t>& BuiltInInstanceDataSlots() const { return m_builtInInstanceDataSlots; }
@@ -82,6 +84,7 @@ namespace Babylon
         std::map<uint16_t, UniformInfo> m_uniformInfos;
         std::map<std::string, uint32_t> m_vertexAttributeLocations;
         std::map<uint32_t, uint32_t> m_builtInInstanceDataSlots;
+        const UniformInfo* m_fragCoordTargetSizeUniform{nullptr};
         std::string m_vertexSource;
         std::string m_fragmentSource;
         std::map<std::map<std::string, uint32_t>, bgfx::ProgramHandle> m_instancedVariants;

--- a/Plugins/ShaderCache/Source/ShaderCacheImpl.cpp
+++ b/Plugins/ShaderCache/Source/ShaderCacheImpl.cpp
@@ -41,7 +41,9 @@ namespace Babylon::Plugins::ShaderCache
     // 4: store the compiler-assigned built-in instance-data slots.
     // 5: shader binary packaging bumped to bgfx BGFX_SHADER_BIN_VERSION 12 (raw
     //    SRV/UAV masks + tex meta); stale v4 cache entries would be rejected by bgfx.
-    static const uint32_t CACHE_VERSION = 5;
+    // 6: FlipFragCoordY rewrites gl_FragCoord and injects bnFragCoordTargetSize;
+    //    version-5 entries for those shaders skip compilation and omit the uniform.
+    static const uint32_t CACHE_VERSION = 6;
 
     void ShaderCacheImpl::Clear()
     {

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerDXBC.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerDXBC.cpp
@@ -104,6 +104,8 @@ namespace Babylon::Plugins
         ShaderCompilerTraversers::IdGenerator ids{};
         // Flip 2D texture sample coordinates (replaces the former ProcessSamplerFlip texture() macro).
         ShaderCompilerTraversers::FlipSamplerCoordinates(program);
+        // Must precede the uniform struct move, which collects the uniform this declares.
+        ShaderCompilerTraversers::FlipFragCoordY(program, ids);
         auto cutScope = ShaderCompilerTraversers::ChangeUniformTypes(program, ids);
         auto utstScope = ShaderCompilerTraversers::MoveNonSamplerUniformsIntoStruct(program, ids);
         std::map<std::string, std::string> vertexAttributeRenaming = {};

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerDXIL.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerDXIL.cpp
@@ -180,6 +180,8 @@ namespace Babylon::Plugins
         ShaderCompilerTraversers::IdGenerator ids{};
         // Flip 2D texture sample coordinates (replaces the former ProcessSamplerFlip texture() macro).
         ShaderCompilerTraversers::FlipSamplerCoordinates(program);
+        // Must precede the uniform struct move, which collects the uniform this declares.
+        ShaderCompilerTraversers::FlipFragCoordY(program, ids);
         auto cutScope = ShaderCompilerTraversers::ChangeUniformTypes(program, ids);
         auto utstScope = ShaderCompilerTraversers::MoveNonSamplerUniformsIntoStruct(program, ids);
         std::map<std::string, std::string> vertexAttributeRenaming = {};

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerMetal.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerMetal.cpp
@@ -109,6 +109,8 @@ namespace Babylon::Plugins
         ShaderCompilerTraversers::IdGenerator ids{};
         // Flip 2D texture sample coordinates (replaces the former ProcessSamplerFlip texture() macro).
         ShaderCompilerTraversers::FlipSamplerCoordinates(program);
+        // Must precede the uniform struct move, which collects the uniform this declares.
+        ShaderCompilerTraversers::FlipFragCoordY(program, ids);
         auto cutScope = ShaderCompilerTraversers::ChangeUniformTypes(program, ids);
         auto utstScope = ShaderCompilerTraversers::MoveNonSamplerUniformsIntoStruct(program, ids);
         std::map<std::string, std::string> vertexAttributeRenaming = {};

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
@@ -86,6 +86,16 @@ namespace Babylon::ShaderCompilerTraversers
                         branch->setFalseBlock(replacement);
                     }
                 }
+                else if (auto* flow = parent->getAsBranchNode())
+                {
+                    // `return gl_FragCoord;` (and similar) parents the symbol on TIntermBranch.
+                    if (flow->getExpression() != symbol)
+                    {
+                        throw std::runtime_error{"Cannot replace symbol: unexpected branch expression"};
+                    }
+                    RemoveAllTreeNodes(flow->getExpression());
+                    flow->setExpression(replacement);
+                }
                 else
                 {
                     throw std::runtime_error{"Cannot replace symbol: node type handler unimplemented"};
@@ -1421,6 +1431,15 @@ namespace Babylon::ShaderCompilerTraversers
                         {
                             selection->setFalseBlock(replacement);
                         }
+                    }
+                    else if (auto* flow = parent->getAsBranchNode())
+                    {
+                        if (flow->getExpression() != oldSymbol)
+                        {
+                            throw std::runtime_error{
+                                "SamplerFunctionParameterSplitter: unexpected branch expression when rewriting body sampler reference"};
+                        }
+                        flow->setExpression(replacement);
                     }
                     else
                     {

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.cpp
@@ -2354,6 +2354,133 @@ namespace Babylon::ShaderCompilerTraversers
 
             TIntermediate* m_intermediate{};
         };
+
+        /// Presents gl_FragCoord in OpenGL's coordinate space on the top-left-origin backends
+        /// (D3D, Metal, Vulkan). FlipSamplerCoordinates already flips every sample coordinate, so
+        /// gl_FragCoord was the one input left in physical space -- making
+        /// `texelFetch(tex, ivec2(gl_FragCoord.xy), 0)` read the mirrored row.
+        ///
+        /// The flip is `targetHeight - gl_FragCoord.y`, with no -1 term: the hardware yields
+        /// p + 0.5 for physical row p, and p == height - 1 - y, so the GL value y + 0.5 is exactly
+        /// height minus the incoming value.
+        ///
+        /// The height cannot come from bgfx's u_viewRect, which SetBgfxViewPortAndScissor narrows
+        /// to the viewport, while gl_FragCoord is relative to the whole render target.
+        class FragCoordYFlipTraverser final : private TIntermTraverser
+        {
+        public:
+            static void Traverse(TProgram& program, IdGenerator& ids)
+            {
+                auto* intermediate{program.getIntermediate(EShLangFragment)};
+                if (intermediate == nullptr)
+                {
+                    return;
+                }
+
+                FragCoordYFlipTraverser traverser{intermediate};
+                intermediate->getTreeRoot()->traverse(&traverser);
+
+                if (traverser.m_symbolsToParents.empty())
+                {
+                    return;
+                }
+
+                // Declared as a linker object so MoveNonSamplerUniformsIntoStruct sweeps it into
+                // the "Frame" struct with every other non-sampler uniform.
+                TType targetSizeType{EbtFloat, EvqUniform, 4};
+                TIntermSymbol* targetSize{intermediate->addSymbol(TIntermSymbol{ids.Next(), Graphics::FRAGCOORD_TARGET_SIZE_UNIFORM_NAME, targetSizeType})};
+
+                auto* linkerObjects = FindLinkerObjects(intermediate->getTreeRoot()->getAsAggregate());
+                if (linkerObjects == nullptr)
+                {
+                    throw std::runtime_error{"FragCoordYFlip: fragment stage has no linker objects sequence."};
+                }
+                linkerObjects->getSequence().push_back(targetSize);
+
+                traverser.ApplyReplacements(targetSize);
+            }
+
+        protected:
+            void visitSymbol(TIntermSymbol* symbol) override
+            {
+                // Linker object references declare gl_FragCoord rather than read it.
+                if (symbol->getName() != "gl_FragCoord" || IsLinkerObject(path))
+                {
+                    return;
+                }
+
+                m_symbolsToParents.emplace_back(symbol, getParentNode());
+            }
+
+        private:
+            FragCoordYFlipTraverser(TIntermediate* intermediate)
+                : TIntermTraverser{true, false, false}
+                , m_intermediate{intermediate}
+            {
+            }
+
+            static TIntermAggregate* FindLinkerObjects(TIntermAggregate* root)
+            {
+                if (root == nullptr)
+                {
+                    return nullptr;
+                }
+
+                for (auto* node : root->getSequence())
+                {
+                    auto* aggregate = node != nullptr ? node->getAsAggregate() : nullptr;
+                    if (aggregate != nullptr && aggregate->getOp() == EOpLinkerObjects)
+                    {
+                        return aggregate;
+                    }
+                }
+
+                return nullptr;
+            }
+
+            void ApplyReplacements(TIntermSymbol* targetSize)
+            {
+                for (const auto& [symbol, parent] : m_symbolsToParents)
+                {
+                    // Not batched into one MakeReplacements call: that maps one replacement per
+                    // symbol *name*, so every gl_FragCoord reference would share one subtree and
+                    // that node would end up with multiple parents.
+                    MakeReplacements({{"gl_FragCoord", BuildFlippedFragCoord(symbol, targetSize)}}, {{symbol, parent}});
+                }
+            }
+
+            /// Builds `vec4(gl_FragCoord.x, targetSize.y - gl_FragCoord.y, .z, .w)`. The whole
+            /// vector is rebuilt rather than patching .y because a reference may be swizzled,
+            /// indexed, or passed along whole, and the parent node is not inspected here.
+            TIntermTyped* BuildFlippedFragCoord(TIntermSymbol* fragCoord, TIntermSymbol* targetSize)
+            {
+                const TSourceLoc& loc{fragCoord->getLoc()};
+                TType floatType{EbtFloat, EvqTemporary, 1};
+                TType vec4Type{EbtFloat, EvqTemporary, 4};
+
+                // Each component gets its own symbol copy so no node ends up with two parents.
+                auto component = [&](int index) {
+                    TIntermTyped* copy{m_intermediate->addSymbol(*fragCoord)};
+                    TIntermTyped* element{m_intermediate->addIndex(EOpIndexDirect, copy, m_intermediate->addConstantUnion(index, loc), loc)};
+                    element->setType(floatType);
+                    return element;
+                };
+
+                TIntermTyped* height{m_intermediate->addIndex(EOpIndexDirect, m_intermediate->addSymbol(*targetSize), m_intermediate->addConstantUnion(1, loc), loc)};
+                height->setType(floatType);
+
+                TIntermTyped* flippedY{m_intermediate->addBinaryMath(EOpSub, height, component(1), loc)};
+
+                TIntermAggregate* constructed{m_intermediate->makeAggregate(component(0), loc)};
+                constructed = m_intermediate->growAggregate(constructed, flippedY, loc);
+                constructed = m_intermediate->growAggregate(constructed, component(2), loc);
+                constructed = m_intermediate->growAggregate(constructed, component(3), loc);
+                return m_intermediate->setAggregateOperator(constructed, EOpConstructVec4, vec4Type, loc);
+            }
+
+            TIntermediate* m_intermediate{};
+            std::vector<std::pair<TIntermSymbol*, TIntermNode*>> m_symbolsToParents{};
+        };
     }
 
     ScopeT MoveNonSamplerUniformsIntoStruct(TProgram& program, IdGenerator& ids)
@@ -2409,5 +2536,10 @@ namespace Babylon::ShaderCompilerTraversers
     void FlipSamplerCoordinates(TProgram& program)
     {
         FlipSamplerCoordinatesTraverser::Traverse(program);
+    }
+
+    void FlipFragCoordY(TProgram& program, IdGenerator& ids)
+    {
+        FragCoordYFlipTraverser::Traverse(program, ids);
     }
 }

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.h
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerTraversers.h
@@ -179,4 +179,10 @@ namespace Babylon::ShaderCompilerTraversers
     /// Must only be used on the backends that apply ProcessSamplerFlip (D3D, Metal, Vulkan); the
     /// OpenGL backend shares bgfx's V-orientation and must not flip.
     void FlipSamplerCoordinates(glslang::TProgram& program);
+
+    /// Rewrite every read of gl_FragCoord to present it in OpenGL's bottom-left-origin space.
+    /// Must run before MoveNonSamplerUniformsIntoStruct so the target-size uniform it declares is
+    /// collected with the others, and only on the backends that apply FlipSamplerCoordinates
+    /// (D3D, Metal, Vulkan); OpenGL already matches WebGL's origin.
+    void FlipFragCoordY(glslang::TProgram& program, IdGenerator& ids);
 }

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerVulkan.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerVulkan.cpp
@@ -277,6 +277,8 @@ namespace Babylon::Plugins
         ShaderCompilerTraversers::IdGenerator ids{};
         // Flip 2D texture sample coordinates (replaces the former ProcessSamplerFlip texture() macro).
         ShaderCompilerTraversers::FlipSamplerCoordinates(program);
+        // Must precede the uniform struct move, which collects the uniform this declares.
+        ShaderCompilerTraversers::FlipFragCoordY(program, ids);
         auto cutScope = ShaderCompilerTraversers::ChangeUniformTypes(program, ids);
         auto utstScope = ShaderCompilerTraversers::MoveNonSamplerUniformsIntoStruct(program, ids);
         std::map<std::string, std::string> vertexAttributeRenaming = {};


### PR DESCRIPTION
`gl_FragCoord.y` was never flipped on the backends that rasterize with a top-left origin (D3D, Metal, Vulkan), so shaders reading it saw a vertically mirrored coordinate compared to WebGL/OpenGL. This breaks any shader that addresses a screen-sized texture by fragment position.

`ShaderCompilerTraversers::FlipFragCoordY` rewrites each `gl_FragCoord` read to `vec4(x, targetHeight - y, z, w)` on those backends. The height comes from a new `bnFragCoordTargetSize` uniform that `NativeEngine` sets per draw from the bound framebuffer; bgfx's `u_viewRect` cannot be used because it is narrowed to the viewport, while `gl_FragCoord` is relative to the whole render target.

Also switches parallel shader compile off with `null` instead of `delete`, matching the other C++-hosted shader compilation tests.

Three unit tests pin the orientation without depending on a backend's readback order: one checks `gl_FragCoord.y` against the interpolated UV ramp of a full-screen quad, one that a direct `return gl_FragCoord;` compiles and matches that ramp, and one that `gl_FragCoord` and UV address a screen-sized texture identically.

Additive only — no existing behavior changes on OpenGL.