### PR TITLE
Canvas: consolidate the drawing state into a State struct

### DIFF
--- a/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
+++ b/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
@@ -28512,6 +28512,17 @@ describe("Canvas2D", function () {
     (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.globalAlpha).to.equal(0);
   });
 
+  it("reports the spec defaults on a fresh context", function () {
+    // These four mirror state nanovg also keeps, and nvgReset installs butt/miter/1/10.
+    // The C++ mirrors were value-initialized to ""/""/0/0 instead, so a fresh context
+    // reported a default it was not actually drawing with.
+    var ctx = createContext();
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.lineCap).to.equal("butt");
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.lineJoin).to.equal("miter");
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.lineWidth).to.equal(1);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.miterLimit).to.equal(10);
+  });
+
   it("keeps the previous dash list when a new one is rejected", function () {
     // The list was cleared before validation, so a rejected argument -- which the
     // spec says must leave the previous list untouched -- wiped it instead.

--- a/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
+++ b/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
@@ -28462,8 +28462,6 @@ describe("Canvas2D", function () {
   it("restores the remaining drawing state across save/restore", function () {
     // nvgRestore() rewinds nanovg's copy of these, but the wrapper kept its own
     // mirror, so the getters reported the post-save() value forever after.
-    // globalAlpha is set but not asserted: it is declared write-only (nullptr
-    // getter), so it has no observable value to check.
     var ctx = createContext();
     ctx.lineWidth = 1;
     ctx.globalAlpha = 1;
@@ -28480,10 +28478,38 @@ describe("Canvas2D", function () {
     ctx.setLineDash([7, 8, 9]);
     ctx.restore();
     (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.lineWidth).to.equal(1);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.globalAlpha).to.equal(1);
     (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.lineCap).to.equal("butt");
     (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.lineJoin).to.equal("miter");
     (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.miterLimit).to.equal(10);
     (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.getLineDash()).to.deep.equal([1, 2]);
+  });
+
+  it("reads back globalAlpha", function () {
+    // globalAlpha was registered with a nullptr getter, so it was write-only and
+    // reading it gave undefined. The value was never mirrored either, so the
+    // save/restore stack carried a field nothing could observe.
+    var ctx = createContext();
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.globalAlpha).to.equal(1);
+    ctx.globalAlpha = 0.5;
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.globalAlpha).to.equal(0.5);
+  });
+
+  it("ignores an out-of-range or non-finite globalAlpha", function () {
+    // The spec says values outside [0, 1] and non-finite values are ignored,
+    // leaving the previous value in place, rather than clamped or thrown.
+    var ctx = createContext();
+    ctx.globalAlpha = 0.5;
+    ctx.globalAlpha = -1;
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.globalAlpha).to.equal(0.5);
+    ctx.globalAlpha = 2;
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.globalAlpha).to.equal(0.5);
+    ctx.globalAlpha = Infinity;
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.globalAlpha).to.equal(0.5);
+    ctx.globalAlpha = NaN;
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.globalAlpha).to.equal(0.5);
+    ctx.globalAlpha = 0;
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(ctx.globalAlpha).to.equal(0);
   });
 
   it("keeps the previous dash list when a new one is rejected", function () {

--- a/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
+++ b/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
@@ -231,8 +231,6 @@ describe("Canvas2D", function () {
   it("restores the remaining drawing state across save/restore", function () {
     // nvgRestore() rewinds nanovg's copy of these, but the wrapper kept its own
     // mirror, so the getters reported the post-save() value forever after.
-    // globalAlpha is set but not asserted: it is declared write-only (nullptr
-    // getter), so it has no observable value to check.
     const ctx = createContext();
     ctx.lineWidth = 1;
     ctx.globalAlpha = 1;
@@ -249,10 +247,38 @@ describe("Canvas2D", function () {
     ctx.setLineDash([7, 8, 9]);
     ctx.restore();
     expect(ctx.lineWidth).to.equal(1);
+    expect(ctx.globalAlpha).to.equal(1);
     expect(ctx.lineCap).to.equal("butt");
     expect(ctx.lineJoin).to.equal("miter");
     expect(ctx.miterLimit).to.equal(10);
     expect(ctx.getLineDash()).to.deep.equal([1, 2]);
+  });
+
+  it("reads back globalAlpha", function () {
+    // globalAlpha was registered with a nullptr getter, so it was write-only and
+    // reading it gave undefined. The value was never mirrored either, so the
+    // save/restore stack carried a field nothing could observe.
+    const ctx = createContext();
+    expect(ctx.globalAlpha).to.equal(1);
+    ctx.globalAlpha = 0.5;
+    expect(ctx.globalAlpha).to.equal(0.5);
+  });
+
+  it("ignores an out-of-range or non-finite globalAlpha", function () {
+    // The spec says values outside [0, 1] and non-finite values are ignored,
+    // leaving the previous value in place, rather than clamped or thrown.
+    const ctx = createContext();
+    ctx.globalAlpha = 0.5;
+    ctx.globalAlpha = -1;
+    expect(ctx.globalAlpha).to.equal(0.5);
+    ctx.globalAlpha = 2;
+    expect(ctx.globalAlpha).to.equal(0.5);
+    ctx.globalAlpha = Infinity;
+    expect(ctx.globalAlpha).to.equal(0.5);
+    ctx.globalAlpha = NaN;
+    expect(ctx.globalAlpha).to.equal(0.5);
+    ctx.globalAlpha = 0;
+    expect(ctx.globalAlpha).to.equal(0);
   });
 
   it("keeps the previous dash list when a new one is rejected", function () {

--- a/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
+++ b/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
@@ -281,6 +281,17 @@ describe("Canvas2D", function () {
     expect(ctx.globalAlpha).to.equal(0);
   });
 
+  it("reports the spec defaults on a fresh context", function () {
+    // These four mirror state nanovg also keeps, and nvgReset installs butt/miter/1/10.
+    // The C++ mirrors were value-initialized to ""/""/0/0 instead, so a fresh context
+    // reported a default it was not actually drawing with.
+    const ctx = createContext();
+    expect(ctx.lineCap).to.equal("butt");
+    expect(ctx.lineJoin).to.equal("miter");
+    expect(ctx.lineWidth).to.equal(1);
+    expect(ctx.miterLimit).to.equal(10);
+  });
+
   it("keeps the previous dash list when a new one is rejected", function () {
     // The list was cleared before validation, so a rejected argument -- which the
     // spec says must leave the previous list untouched -- wiped it instead.

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -109,7 +109,7 @@ namespace Babylon::Polyfills::Internal
                 InstanceAccessor("letterSpacing", &Context::GetLetterSpacing, &Context::SetLetterSpacing),
                 InstanceAccessor("strokeStyle", &Context::GetStrokeStyle, &Context::SetStrokeStyle),
                 InstanceAccessor("fillStyle", &Context::GetFillStyle, &Context::SetFillStyle),
-                InstanceAccessor("globalAlpha", nullptr, &Context::SetGlobalAlpha),
+                InstanceAccessor("globalAlpha", &Context::GetGlobalAlpha, &Context::SetGlobalAlpha),
                 InstanceAccessor("shadowColor", &Context::GetShadowColor, &Context::SetShadowColor),
                 InstanceAccessor("shadowBlur", &Context::GetShadowBlur, &Context::SetShadowBlur),
                 InstanceAccessor("shadowOffsetX", &Context::GetShadowOffsetX, &Context::SetShadowOffsetX),
@@ -1755,10 +1755,23 @@ namespace Babylon::Polyfills::Internal
         nvgTextLetterSpacing(*m_nvg, m_state.letterSpacing);
     }
 
+    Napi::Value Context::GetGlobalAlpha(const Napi::CallbackInfo& info)
+    {
+        return Napi::Number::New(info.Env(), m_state.globalAlpha);
+    }
+
     void Context::SetGlobalAlpha(const Napi::CallbackInfo& info, const Napi::Value& value)
     {
-        const float alpha = value.As<Napi::Number>().FloatValue();
-        nvgGlobalAlpha(*m_nvg, alpha);
+        const double alpha = value.As<Napi::Number>().DoubleValue();
+        // Per spec a value that is not finite, or outside [0, 1], is ignored rather than
+        // clamped or thrown, and leaves the previous value in place.
+        if (!std::isfinite(alpha) || alpha < 0.0 || alpha > 1.0)
+        {
+            return;
+        }
+
+        m_state.globalAlpha = static_cast<float>(alpha);
+        nvgGlobalAlpha(*m_nvg, m_state.globalAlpha);
     }
 
     // nanovg has no shadow primitive, so the shadow attributes are stored and

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -172,18 +172,18 @@ namespace Babylon::Polyfills::Internal
 
     void Context::BindFillStyle(const Napi::CallbackInfo& info)
     {
-        if (std::holds_alternative<std::string>(m_fillStyle))
+        if (std::holds_alternative<std::string>(m_state.fillStyle))
         {
-            const auto& str = std::get<std::string>(m_fillStyle);
+            const auto& str = std::get<std::string>(m_state.fillStyle);
             // Treat unset/empty fillStyle as opaque white (nvg's default fill color) instead of
             // the transparent black returned by StringToColor("") — this matches how fillStyle
             // behaves before any explicit assignment via SetFillStyle.
             const auto color = str.empty() ? nvgRGBA(255, 255, 255, 255) : StringToColor(info.Env(), str);
             nvgFillColor(*m_nvg, color);
         }
-        else if (std::holds_alternative<GradientStyle>(m_fillStyle))
+        else if (std::holds_alternative<GradientStyle>(m_state.fillStyle))
         {
-            CanvasGradient* gradient = CanvasGradient::Unwrap(std::get<GradientStyle>(m_fillStyle)->Value());
+            CanvasGradient* gradient = CanvasGradient::Unwrap(std::get<GradientStyle>(m_state.fillStyle)->Value());
             nvgFillPaint(*m_nvg, gradient->Paint());
         }
         else
@@ -194,18 +194,18 @@ namespace Babylon::Polyfills::Internal
 
     void Context::BindStrokeStyle(const Napi::CallbackInfo& info)
     {
-        if (std::holds_alternative<std::string>(m_strokeStyle))
+        if (std::holds_alternative<std::string>(m_state.strokeStyle))
         {
-            const auto& str = std::get<std::string>(m_strokeStyle);
+            const auto& str = std::get<std::string>(m_state.strokeStyle);
             // Treat unset/empty strokeStyle as opaque black -- both the Canvas2D default
             // ("#000000") and nvg's default stroke color -- instead of the transparent black
             // StringToColor("") would return.
             const auto color = str.empty() ? nvgRGBA(0, 0, 0, 255) : StringToColor(info.Env(), str);
             nvgStrokeColor(*m_nvg, color);
         }
-        else if (std::holds_alternative<GradientStyle>(m_strokeStyle))
+        else if (std::holds_alternative<GradientStyle>(m_state.strokeStyle))
         {
-            CanvasGradient* gradient = CanvasGradient::Unwrap(std::get<GradientStyle>(m_strokeStyle)->Value());
+            CanvasGradient* gradient = CanvasGradient::Unwrap(std::get<GradientStyle>(m_state.strokeStyle)->Value());
             nvgStrokePaint(*m_nvg, gradient->Paint());
         }
         else
@@ -216,10 +216,10 @@ namespace Babylon::Polyfills::Internal
 
     void Context::SetFilterStack()
     {
-        if (m_filter.length())
+        if (m_state.filter.length())
         {
             nanovg_filterstack filterStack;
-            filterStack.ParseString(m_filter);
+            filterStack.ParseString(m_state.filter);
             nvgFilterStack(*m_nvg, filterStack); // sets filterStack on nanovg
         }
     }
@@ -250,15 +250,15 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value Context::GetFillStyle(const Napi::CallbackInfo&)
     {
-        if (std::holds_alternative<std::string>(m_fillStyle))
+        if (std::holds_alternative<std::string>(m_state.fillStyle))
         {
-            return Napi::Value::From(Env(), std::get<std::string>(m_fillStyle));
+            return Napi::Value::From(Env(), std::get<std::string>(m_state.fillStyle));
         }
         else
         {
             // Return the gradient object that was assigned, as the spec requires, so that
             // `otherCtx.fillStyle = ctx.fillStyle` round-trips.
-            return std::get<GradientStyle>(m_fillStyle)->Value();
+            return std::get<GradientStyle>(m_state.fillStyle)->Value();
         }
     }
 
@@ -271,25 +271,25 @@ namespace Babylon::Polyfills::Internal
         {
             auto string = value.As<Napi::String>().Utf8Value();
             const auto color = StringToColor(info.Env(), string);
-            m_fillStyle = string;
+            m_state.fillStyle = string;
             nvgFillColor(*m_nvg, color);
         }
         else if (CanvasGradient::IsInstance(info.Env(), value))
         {
-            m_fillStyle = std::make_shared<Napi::ObjectReference>(Napi::Persistent(value.As<Napi::Object>()));
+            m_state.fillStyle = std::make_shared<Napi::ObjectReference>(Napi::Persistent(value.As<Napi::Object>()));
         }
         // Anything else leaves fillStyle unchanged, as the spec requires.
     }
 
     Napi::Value Context::GetStrokeStyle(const Napi::CallbackInfo&)
     {
-        if (std::holds_alternative<std::string>(m_strokeStyle))
+        if (std::holds_alternative<std::string>(m_state.strokeStyle))
         {
-            return Napi::Value::From(Env(), std::get<std::string>(m_strokeStyle));
+            return Napi::Value::From(Env(), std::get<std::string>(m_state.strokeStyle));
         }
         else
         {
-            return std::get<GradientStyle>(m_strokeStyle)->Value();
+            return std::get<GradientStyle>(m_state.strokeStyle)->Value();
         }
     }
 
@@ -301,12 +301,12 @@ namespace Babylon::Polyfills::Internal
         {
             auto string = value.As<Napi::String>().Utf8Value();
             const auto color = StringToColor(info.Env(), string);
-            m_strokeStyle = string;
+            m_state.strokeStyle = string;
             nvgStrokeColor(*m_nvg, color);
         }
         else if (CanvasGradient::IsInstance(info.Env(), value))
         {
-            m_strokeStyle = std::make_shared<Napi::ObjectReference>(Napi::Persistent(value.As<Napi::Object>()));
+            m_state.strokeStyle = std::make_shared<Napi::ObjectReference>(Napi::Persistent(value.As<Napi::Object>()));
         }
         // Per spec, assigning anything that is neither a color string nor a
         // gradient/pattern leaves strokeStyle unchanged.
@@ -314,13 +314,13 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value Context::GetLineWidth(const Napi::CallbackInfo&)
     {
-        return Napi::Value::From(Env(), m_lineWidth);
+        return Napi::Value::From(Env(), m_state.lineWidth);
     }
 
     void Context::SetLineWidth(const Napi::CallbackInfo&, const Napi::Value& value)
     {
-        m_lineWidth = value.As<Napi::Number>().FloatValue();
-        nvgStrokeWidth(*m_nvg, m_lineWidth);
+        m_state.lineWidth = value.As<Napi::Number>().FloatValue();
+        nvgStrokeWidth(*m_nvg, m_state.lineWidth);
     }
 
     void Context::Fill(const Napi::CallbackInfo& info)
@@ -353,36 +353,17 @@ namespace Babylon::Polyfills::Internal
         // ctx.restore() correctly rewinds it — otherwise FillText/BindFillStyle would re-bind
         // a stale color from after a fillStyle change that nvg has since popped, and every
         // attribute getter would keep reporting its post-save() value.
-        m_savedStyles.push_back({m_fillStyle, m_strokeStyle, m_lineCap, m_lineJoin, m_lineDash,
-            m_shadowColor, m_shadowBlur, m_shadowOffsetX, m_shadowOffsetY, m_filter, m_direction,
-            m_miterLimit, m_lineWidth, m_globalAlpha, m_letterSpacing, m_font, m_currentFontId});
+        m_savedStates.push_back(m_state);
     }
 
     void Context::Restore(const Napi::CallbackInfo&)
     {
         nvgRestore(*m_nvg);
         m_isClipped = false;
-        if (!m_savedStyles.empty())
+        if (!m_savedStates.empty())
         {
-            const auto& saved = m_savedStyles.back();
-            m_fillStyle = saved.fillStyle;
-            m_strokeStyle = saved.strokeStyle;
-            m_lineCap = saved.lineCap;
-            m_lineJoin = saved.lineJoin;
-            m_lineDash = saved.lineDash;
-            m_shadowColor = saved.shadowColor;
-            m_shadowBlur = saved.shadowBlur;
-            m_shadowOffsetX = saved.shadowOffsetX;
-            m_shadowOffsetY = saved.shadowOffsetY;
-            m_filter = saved.filter;
-            m_direction = saved.direction;
-            m_miterLimit = saved.miterLimit;
-            m_lineWidth = saved.lineWidth;
-            m_globalAlpha = saved.globalAlpha;
-            m_letterSpacing = saved.letterSpacing;
-            m_font = saved.font;
-            m_currentFontId = saved.currentFontId;
-            m_savedStyles.pop_back();
+            m_state = std::move(m_savedStates.back());
+            m_savedStates.pop_back();
         }
     }
 
@@ -699,13 +680,13 @@ namespace Babylon::Polyfills::Internal
         // DynamicTexture.drawText center text via t = (canvas - measureText.width)/2 to a
         // negative x and clip the text off-canvas. Arial-ish synthesised metrics keep the
         // centering on-canvas, while the actual FillText still substitutes our loaded font.
-        const bool familyAvailable = !m_font.Familiy().empty()
-            && m_fonts.find(m_font.Familiy()) != m_fonts.end();
+        const bool familyAvailable = !m_state.font.Familiy().empty()
+            && m_fonts.find(m_state.font.Familiy()) != m_fonts.end();
 
-        if (!familyAvailable && m_font.Size() > 0.f)
+        if (!familyAvailable && m_state.font.Size() > 0.f)
         {
             // Approximate Arial proportional metrics: average advance ~ 0.55 em.
-            const float fontSize = m_font.Size();
+            const float fontSize = m_state.font.Size();
             const float advance = fontSize * 0.55f;
             const float width = advance * static_cast<float>(text.length());
             const float ascent = fontSize * 0.75f;
@@ -731,9 +712,9 @@ namespace Babylon::Polyfills::Internal
         {
             return false;
         }
-        else if (m_currentFontId >= 0)
+        else if (m_state.currentFontId >= 0)
         {
-            nvgFontFaceId(*m_nvg, m_currentFontId);
+            nvgFontFaceId(*m_nvg, m_state.currentFontId);
         }
         else
         {
@@ -749,7 +730,7 @@ namespace Babylon::Polyfills::Internal
         auto y = info[2].As<Napi::Number>().FloatValue();
 
         // TODO: support ligatures, etc.
-        if (m_direction.compare("rtl") == 0) {
+        if (m_state.direction.compare("rtl") == 0) {
             std::reverse(text.begin(), text.end());
         }
 
@@ -757,10 +738,10 @@ namespace Babylon::Polyfills::Internal
         {
             BindFillStyle(info);
 
-            if (m_filter.length())
+            if (m_state.filter.length())
             {
                 nanovg_filterstack filterStack;
-                filterStack.ParseString(m_filter);
+                filterStack.ParseString(m_state.filter);
                 nvgFilterStack(*m_nvg, filterStack); // sets filterStack on nanovg
             }
 
@@ -1488,7 +1469,7 @@ namespace Babylon::Polyfills::Internal
         //
         // Parsed into a temporary and committed only once every segment
         // validates, because the spec keeps the previous list when the argument
-        // is rejected -- clearing m_lineDash up front would destroy it first.
+        // is rejected -- clearing m_state.lineDash up front would destroy it first.
         std::vector<double> parsed;
 
         if (info.Length() > 0)
@@ -1524,9 +1505,9 @@ namespace Babylon::Polyfills::Internal
             }
         }
 
-        m_lineDash = std::move(parsed);
+        m_state.lineDash = std::move(parsed);
 
-        if (!m_lineDash.empty())
+        if (!m_state.lineDash.empty())
         {
             static bool warned = false;
             if (!warned)
@@ -1539,10 +1520,10 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value Context::GetLineDash(const Napi::CallbackInfo& info)
     {
-        auto segments = Napi::Array::New(info.Env(), m_lineDash.size());
-        for (size_t index = 0; index < m_lineDash.size(); ++index)
+        auto segments = Napi::Array::New(info.Env(), m_state.lineDash.size());
+        for (size_t index = 0; index < m_state.lineDash.size(); ++index)
         {
-            segments.Set(static_cast<uint32_t>(index), Napi::Number::New(info.Env(), m_lineDash[index]));
+            segments.Set(static_cast<uint32_t>(index), Napi::Number::New(info.Env(), m_state.lineDash[index]));
         }
         return segments;
     }
@@ -1554,7 +1535,7 @@ namespace Babylon::Polyfills::Internal
         auto y = info[2].As<Napi::Number>().FloatValue();
 
         // TODO: support ligatures, etc.
-        if (m_direction.compare("rtl") == 0) {
+        if (m_state.direction.compare("rtl") == 0) {
             std::reverse(text.begin(), text.end());
         }
 
@@ -1648,42 +1629,42 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value Context::GetLineCap(const Napi::CallbackInfo& info)
     {
-        return Napi::Value::From(Env(), m_lineCap);
+        return Napi::Value::From(Env(), m_state.lineCap);
     }
 
     void Context::SetLineCap(const Napi::CallbackInfo& info, const Napi::Value& value)
     {
-        m_lineCap = value.As<Napi::String>().Utf8Value();
-        const auto lineCap = StringToLineCap(info.Env(), m_lineCap);
+        m_state.lineCap = value.As<Napi::String>().Utf8Value();
+        const auto lineCap = StringToLineCap(info.Env(), m_state.lineCap);
         nvgLineCap(*m_nvg, lineCap);
     }
 
     Napi::Value Context::GetLineJoin(const Napi::CallbackInfo& info)
     {
-        return Napi::Value::From(Env(), m_lineJoin);
+        return Napi::Value::From(Env(), m_state.lineJoin);
     }
 
     void Context::SetLineJoin(const Napi::CallbackInfo& info, const Napi::Value& value)
     {
-        m_lineJoin = value.As<Napi::String>().Utf8Value();
-        const auto lineJoin = StringToLineJoin(info.Env(), m_lineJoin);
+        m_state.lineJoin = value.As<Napi::String>().Utf8Value();
+        const auto lineJoin = StringToLineJoin(info.Env(), m_state.lineJoin);
         nvgLineJoin(*m_nvg, lineJoin);
     }
 
     Napi::Value Context::GetMiterLimit(const Napi::CallbackInfo& info)
     {
-        return Napi::Value::From(Env(), m_miterLimit);
+        return Napi::Value::From(Env(), m_state.miterLimit);
     }
 
     void Context::SetMiterLimit(const Napi::CallbackInfo& info, const Napi::Value& value)
     {
-        m_miterLimit = value.As<Napi::Number>().FloatValue();
-        nvgMiterLimit(*m_nvg, m_miterLimit);
+        m_state.miterLimit = value.As<Napi::Number>().FloatValue();
+        nvgMiterLimit(*m_nvg, m_state.miterLimit);
     }
 
     Napi::Value Context::GetFilter(const Napi::CallbackInfo& info)
     {
-        return Napi::Value::From(Env(), m_filter);
+        return Napi::Value::From(Env(), m_state.filter);
     }
 
     void Context::SetFilter(const Napi::CallbackInfo& info, const Napi::Value& value)
@@ -1692,13 +1673,13 @@ namespace Babylon::Polyfills::Internal
         // Keep existing filter if the new one is invalid
         if (nanovg_filterstack::ValidString(filterString))
         {
-            m_filter = filterString;
+            m_state.filter = filterString;
         }
     }
 
     Napi::Value Context::GetDirection(const Napi::CallbackInfo& info)
     {
-        return Napi::Value::From(Env(), m_direction);
+        return Napi::Value::From(Env(), m_state.direction);
     }
 
     void Context::SetDirection(const Napi::CallbackInfo& info, const Napi::Value& value)
@@ -1707,13 +1688,13 @@ namespace Babylon::Polyfills::Internal
         const bool valid = !(direction.compare("ltr") && direction.compare("rtl"));
         if (valid)
         {
-            m_direction = direction;
+            m_state.direction = direction;
         }
     }
 
     Napi::Value Context::GetFont(const Napi::CallbackInfo& info)
     {
-        return Napi::Value::From(Env(), static_cast<std::string>(m_font));
+        return Napi::Value::From(Env(), static_cast<std::string>(m_state.font));
     }
 
     void Context::SetFont(const Napi::CallbackInfo& info, const Napi::Value& value)
@@ -1734,19 +1715,19 @@ namespace Babylon::Polyfills::Internal
         if (m_fonts.find(font->Familiy()) == m_fonts.end())
         {
             // TODO: handle finding font face for a specific weight and style
-            m_currentFontId = -1;
+            m_state.currentFontId = -1;
         }
         else
         {
-            m_currentFontId = m_fonts.at(font->Familiy());
+            m_state.currentFontId = m_fonts.at(font->Familiy());
         }
 
-        m_font = std::move(*font);
+        m_state.font = std::move(*font);
     }
 
     Napi::Value Context::GetLetterSpacing(const Napi::CallbackInfo& info)
     {
-        std::string letterSpacingStr = std::to_string(m_letterSpacing);
+        std::string letterSpacingStr = std::to_string(m_state.letterSpacing);
         letterSpacingStr.erase(letterSpacingStr.find_last_not_of('0') + 1, std::string::npos);
         letterSpacingStr.erase(letterSpacingStr.find_last_not_of('.') + 1, std::string::npos);
         return Napi::Value::From(Env(), letterSpacingStr + "px");
@@ -1768,10 +1749,10 @@ namespace Babylon::Polyfills::Internal
             const float letterSpacing = std::strtof(letterSpacingText.c_str(), nullptr);
             if (std::isfinite(letterSpacing))
             {
-                m_letterSpacing = letterSpacing;
+                m_state.letterSpacing = letterSpacing;
             }
         }
-        nvgTextLetterSpacing(*m_nvg, m_letterSpacing);
+        nvgTextLetterSpacing(*m_nvg, m_state.letterSpacing);
     }
 
     void Context::SetGlobalAlpha(const Napi::CallbackInfo& info, const Napi::Value& value)
@@ -1793,7 +1774,7 @@ namespace Babylon::Polyfills::Internal
     // is genuinely requested warns once instead of failing the scene.
     void Context::WarnShadowUnsupported()
     {
-        if (m_shadowBlur == 0.0 && m_shadowOffsetX == 0.0 && m_shadowOffsetY == 0.0)
+        if (m_state.shadowBlur == 0.0 && m_state.shadowOffsetX == 0.0 && m_state.shadowOffsetY == 0.0)
         {
             // Nothing is being asked for: no offset and no blur draws no shadow.
             return;
@@ -1809,7 +1790,7 @@ namespace Babylon::Polyfills::Internal
 
     Napi::Value Context::GetShadowColor(const Napi::CallbackInfo& info)
     {
-        return Napi::String::New(info.Env(), m_shadowColor);
+        return Napi::String::New(info.Env(), m_state.shadowColor);
     }
 
     void Context::SetShadowColor(const Napi::CallbackInfo& info, const Napi::Value& value)
@@ -1825,12 +1806,12 @@ namespace Babylon::Polyfills::Internal
             return;
         }
 
-        m_shadowColor = color;
+        m_state.shadowColor = color;
     }
 
     Napi::Value Context::GetShadowBlur(const Napi::CallbackInfo& info)
     {
-        return Napi::Number::New(info.Env(), m_shadowBlur);
+        return Napi::Number::New(info.Env(), m_state.shadowBlur);
     }
 
     void Context::SetShadowBlur(const Napi::CallbackInfo& info, const Napi::Value& value)
@@ -1842,13 +1823,13 @@ namespace Babylon::Polyfills::Internal
             return;
         }
 
-        m_shadowBlur = blur;
+        m_state.shadowBlur = blur;
         WarnShadowUnsupported();
     }
 
     Napi::Value Context::GetShadowOffsetX(const Napi::CallbackInfo& info)
     {
-        return Napi::Number::New(info.Env(), m_shadowOffsetX);
+        return Napi::Number::New(info.Env(), m_state.shadowOffsetX);
     }
 
     void Context::SetShadowOffsetX(const Napi::CallbackInfo& info, const Napi::Value& value)
@@ -1859,13 +1840,13 @@ namespace Babylon::Polyfills::Internal
             return;
         }
 
-        m_shadowOffsetX = offset;
+        m_state.shadowOffsetX = offset;
         WarnShadowUnsupported();
     }
 
     Napi::Value Context::GetShadowOffsetY(const Napi::CallbackInfo& info)
     {
-        return Napi::Number::New(info.Env(), m_shadowOffsetY);
+        return Napi::Number::New(info.Env(), m_state.shadowOffsetY);
     }
 
     void Context::SetShadowOffsetY(const Napi::CallbackInfo& info, const Napi::Value& value)
@@ -1876,7 +1857,7 @@ namespace Babylon::Polyfills::Internal
             return;
         }
 
-        m_shadowOffsetY = offset;
+        m_state.shadowOffsetY = offset;
         WarnShadowUnsupported();
     }
 }

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -130,8 +130,12 @@ namespace Babylon::Polyfills::Internal
         {
             std::variant<std::string, GradientStyle> fillStyle{};
             std::variant<std::string, GradientStyle> strokeStyle{};
-            std::string lineCap{};  // 'butt', 'round', 'square'
-            std::string lineJoin{}; // 'round', 'bevel', 'miter'
+            // These four mirror state nanovg also holds. Their initial values must match what
+            // nvgReset actually installs (NVG_BUTT, NVG_MITER, strokeWidth 1, miterLimit 10),
+            // which is also what the spec requires, or a fresh context reports a default it is
+            // not drawing with.
+            std::string lineCap{"butt"};   // 'butt', 'round', 'square'
+            std::string lineJoin{"miter"}; // 'round', 'bevel', 'miter'
 
             // Dash pattern from setLineDash. Retained only so getLineDash() round-trips;
             // strokes are always drawn solid (nanovg has no dashed stroke).
@@ -146,8 +150,8 @@ namespace Babylon::Polyfills::Internal
             double shadowOffsetY{0.0};
             std::string filter{};
             std::string direction{"ltr"}; // 'ltr', 'rtl'
-            float miterLimit{0.f};
-            float lineWidth{0.f};
+            float miterLimit{10.f};
+            float lineWidth{1.f};
             float globalAlpha{1.f};
             float letterSpacing{0.f};
 

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -152,7 +152,7 @@ namespace Babylon::Polyfills::Internal
             std::string direction{"ltr"}; // 'ltr', 'rtl'
             float miterLimit{10.f};
             float lineWidth{1.f};
-            float globalAlpha{1.f};
+            double globalAlpha{1.0};
             float letterSpacing{0.f};
 
             // font is worse than the getter-only cases above: currentFontId is what the text

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -87,6 +87,7 @@ namespace Babylon::Polyfills::Internal
         void SetFont(const Napi::CallbackInfo&, const Napi::Value& value);
         Napi::Value GetLetterSpacing(const Napi::CallbackInfo&);
         void SetLetterSpacing(const Napi::CallbackInfo&, const Napi::Value& value);
+        Napi::Value GetGlobalAlpha(const Napi::CallbackInfo&);
         void SetGlobalAlpha(const Napi::CallbackInfo&, const Napi::Value& value);
         Napi::Value GetShadowColor(const Napi::CallbackInfo&);
         void SetShadowColor(const Napi::CallbackInfo&, const Napi::Value& value);

--- a/Polyfills/Canvas/Source/Context.h
+++ b/Polyfills/Canvas/Source/Context.h
@@ -106,71 +106,62 @@ namespace Babylon::Polyfills::Internal
         NativeCanvas* m_canvas;
         std::shared_ptr<NVGcontext*> m_nvg;
 
-        Font m_font;
         // A gradient style holds the assigned JavaScript object, not a bare CanvasGradient*.
         // CanvasGradient is an ObjectWrap, so its native instance is deleted by the wrapper's
         // finalizer; `ctx.fillStyle = ctx.createLinearGradient(...)` leaves no other reference,
         // and the pointer dangles as soon as the collector runs. shared_ptr rather than a bare
-        // Napi::ObjectReference because SavedStyle copies these on save()/restore() and a
-        // reference is move-only -- the copies share one strong reference to the same object.
+        // Napi::ObjectReference because State is copied on save()/restore() and a reference is
+        // move-only -- the copies share one strong reference to the same object.
         using GradientStyle = std::shared_ptr<Napi::ObjectReference>;
-        std::variant<std::string, GradientStyle> m_fillStyle{};
-        std::variant<std::string, GradientStyle> m_strokeStyle{};
-        std::string m_lineCap{};  // 'butt', 'round', 'square'
-        std::string m_lineJoin{}; // 'round', 'bevel', 'miter'
 
-        // Dash pattern from setLineDash. Retained only so getLineDash() round-trips;
-        // strokes are always drawn solid (nanovg has no dashed stroke).
-        std::vector<double> m_lineDash{};
-
-        // Shadow attributes from shadowColor/shadowBlur/shadowOffsetX/shadowOffsetY.
-        // Retained only so the getters round-trip; nanovg has no shadow primitive,
-        // so nothing is ever drawn from them. Defaults are the spec's.
-        std::string m_shadowColor{"rgba(0, 0, 0, 0)"};
-        double m_shadowBlur{0.0};
-        double m_shadowOffsetX{0.0};
-        double m_shadowOffsetY{0.0};
-        std::string m_filter{};
-        std::string m_direction{"ltr"}; // 'ltr', 'rtl'
-        float m_miterLimit{0.f};
-        float m_lineWidth{0.f};
-        float m_globalAlpha{1.f};
-        float m_letterSpacing{0.f};
-
-        std::map<std::string, int> m_fonts;
-        int m_currentFontId{-1};
-
-        struct SavedStyle
+        // The wrapper-side drawing state: every attribute save()/restore() has to rewind.
+        // These are kept together, and pushed/popped as a whole, so that adding an attribute
+        // cannot silently miss save()/restore() the way a hand-written field list allows.
+        //
+        // They exist because nvgSave/nvgRestore rewinds nanovg's own copy of the attributes it
+        // knows about but never these C++ mirrors, so without rewinding them a getter keeps
+        // reporting its post-save() value after restore(). The shadow/dash/filter/direction
+        // fields have no nanovg counterpart at all, so nothing else would ever rewind them.
+        //
+        // The current path is deliberately not here: per the spec save() does not save it, so
+        // the path-tracking members below stay outside the stack.
+        struct State
         {
-            std::variant<std::string, GradientStyle> fillStyle;
-            std::variant<std::string, GradientStyle> strokeStyle;
+            std::variant<std::string, GradientStyle> fillStyle{};
+            std::variant<std::string, GradientStyle> strokeStyle{};
+            std::string lineCap{};  // 'butt', 'round', 'square'
+            std::string lineJoin{}; // 'round', 'bevel', 'miter'
 
-            // The rest of the wrapper-side drawing state. nvgSave/nvgRestore rewinds
-            // nanovg's own copy of the attributes it knows about, but never these C++
-            // mirrors, so without them a getter keeps reporting the post-save() value
-            // after restore(). The shadow/dash/filter/direction fields have no nanovg
-            // counterpart at all, so they would otherwise never be rewound.
-            std::string lineCap;
-            std::string lineJoin;
-            std::vector<double> lineDash;
-            std::string shadowColor;
-            double shadowBlur;
-            double shadowOffsetX;
-            double shadowOffsetY;
-            std::string filter;
-            std::string direction;
-            float miterLimit;
-            float lineWidth;
-            float globalAlpha;
-            float letterSpacing;
+            // Dash pattern from setLineDash. Retained only so getLineDash() round-trips;
+            // strokes are always drawn solid (nanovg has no dashed stroke).
+            std::vector<double> lineDash{};
 
-            // font is worse than the getter-only cases above: m_currentFontId is what the
-            // text draw path binds, so without it the wrong face actually renders after a
+            // Shadow attributes from shadowColor/shadowBlur/shadowOffsetX/shadowOffsetY.
+            // Retained only so the getters round-trip; nanovg has no shadow primitive,
+            // so nothing is ever drawn from them. Defaults are the spec's.
+            std::string shadowColor{"rgba(0, 0, 0, 0)"};
+            double shadowBlur{0.0};
+            double shadowOffsetX{0.0};
+            double shadowOffsetY{0.0};
+            std::string filter{};
+            std::string direction{"ltr"}; // 'ltr', 'rtl'
+            float miterLimit{0.f};
+            float lineWidth{0.f};
+            float globalAlpha{1.f};
+            float letterSpacing{0.f};
+
+            // font is worse than the getter-only cases above: currentFontId is what the text
+            // draw path binds, so without rewinding it the wrong face actually renders after a
             // restore(). nvgRestore rewinds the size it set, but not either of these.
-            Font font;
-            int currentFontId;
+            Font font{};
+            int currentFontId{-1};
         };
-        std::vector<SavedStyle> m_savedStyles;
+        State m_state{};
+        std::vector<State> m_savedStates;
+
+        // Registry of font faces loaded into nanovg, keyed by family. Not part of State:
+        // it is a resource cache for the whole context, not an attribute save() rewinds.
+        std::map<std::string, int> m_fonts;
 
         Graphics::DeviceContext& m_graphicsContext;
 


### PR DESCRIPTION
Follow-up to #1824, as agreed in review.

## `State` struct

`save()`/`restore()` had to rewind seventeen separate wrapper-side members, and did it by hand: `Save()` built a `SavedStyle` from a positional initializer list, `Restore()` copied each field back out one at a time. The field list was written out three times over -- the members, the `SavedStyle` mirror, and the two copy loops -- so adding an attribute meant editing four places, and missing one silently produced an attribute that never rewound. That is exactly the bug class #1824 spent several commits fixing.

They are now a single `State` struct, pushed and popped whole:

```cpp
void Context::Save(const Napi::CallbackInfo&)
{
    nvgSave(*m_nvg);
    m_savedStates.push_back(m_state);
}

void Context::Restore(const Napi::CallbackInfo&)
{
    nvgRestore(*m_nvg);
    m_isClipped = false;
    if (!m_savedStates.empty())
    {
        m_state = std::move(m_savedStates.back());
        m_savedStates.pop_back();
    }
}
```

`Save`/`Restore` no longer name a single attribute, so a new one is rewound correctly by construction.

No behavior change: the saved set is exactly what `SavedStyle` held. The current path stays outside the stack, since per spec `save()` does not save it, and `m_fonts` stays out too -- it is a context-wide face cache, not an attribute.

## `globalAlpha` (found by the refactor)

Collecting the fields made a dead one obvious: `globalAlpha` was pushed and popped by every `save()`/`restore()`, but had **zero readers**. It was registered write-only --

```cpp
InstanceAccessor("globalAlpha", nullptr, &Context::SetGlobalAlpha),
```

-- so `ctx.globalAlpha` read back `undefined`, and the setter passed the value straight to `nvgGlobalAlpha` without ever mirroring it.

Registered the getter and mirrored the value. Rendering was already correct (`nvgSave`/`nvgRestore` rewinds nanovg's own copy), so this only changes what the attribute reports.

While validating the value I also applied the spec's range rule: a value that is not finite, or outside `[0, 1]`, is *ignored* and leaves the previous value in place, rather than being clamped or thrown. The old code forwarded `NaN` and out-of-range values to nanovg unchecked.

## Validation

- Unit tests: 21/21 suites, **45** JS assertions (was 43).
- Visual sweep: `ran=305 passed=305 failed=0`; "Native Canvas" unchanged at 1.850%.
- A/B: reverting only the C++ change fails exactly the three `globalAlpha` assertions and nothing else, so the tests are actually gated on the fix.