### PR TITLE
Fix textured materials rendering black on Apple platforms

### DIFF
--- a/Plugins/ShaderCompiler/Source/ShaderCompilerMetal.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerMetal.cpp
@@ -58,6 +58,16 @@ namespace
                 // Using rfind ensures the correct "Texture" is removed from WebGL uniforms with "texture" in their original name. (e.g., "shadowTexture1")
                 imageName.replace(imageName.rfind("Texture"), std::string::npos, "");
                 compiler->set_name(resource.id, imageName);
+
+                // Apply the same rename to the parser's IR. The Compiler transpiles a private
+                // copy, and AppendSamplers reads the app-facing sampler name back from the
+                // parser's IR so that a name SPIRV-Cross mangled for a target-language keyword
+                // collision can be recovered. Without this the parser still holds "<name>Texture",
+                // that is the name written into the bgfx uniform table, and Babylon.js -- which
+                // looks the sampler up by "<name>" -- gets null from getUniforms and never calls
+                // setTexture. Every textured material then samples bgfx's default texture and
+                // renders black, with no error anywhere.
+                parser->get_parsed_ir().set_name(resource.id, imageName);
             }
         }
 

--- a/Plugins/ShaderCompiler/Source/ShaderCompilerMetal.cpp
+++ b/Plugins/ShaderCompiler/Source/ShaderCompilerMetal.cpp
@@ -59,14 +59,8 @@ namespace
                 imageName.replace(imageName.rfind("Texture"), std::string::npos, "");
                 compiler->set_name(resource.id, imageName);
 
-                // Apply the same rename to the parser's IR. The Compiler transpiles a private
-                // copy, and AppendSamplers reads the app-facing sampler name back from the
-                // parser's IR so that a name SPIRV-Cross mangled for a target-language keyword
-                // collision can be recovered. Without this the parser still holds "<name>Texture",
-                // that is the name written into the bgfx uniform table, and Babylon.js -- which
-                // looks the sampler up by "<name>" -- gets null from getUniforms and never calls
-                // setTexture. Every textured material then samples bgfx's default texture and
-                // renders black, with no error anywhere.
+                // The Compiler transpiles a private copy of the IR, so rename the parser's copy
+                // too: AppendSamplers reads the sampler's app-facing name from there.
                 parser->get_parsed_ir().set_name(resource.id, imageName);
             }
         }


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

Every textured material renders black on macOS and iOS. Live at master; Android and Windows are unaffected.

## Cause

Regression from #1796. On the Metal path, `SplitSamplersIntoSamplersAndTextures` splits `sampler2D <name>` into a texture `<name>Texture` plus a sampler `<name>`, and `ShaderCompilerMetal.cpp` strips the suffix back to `<name>` because that is the name Babylon.js passes to `getUniforms()`. #1796 made `AppendSamplers` read that name from the parser's `ParsedIR`, but `Compiler` transpiles a private copy, so the rename is discarded. bgfx then registers `<name>Texture`, `GetUniformInfo("<name>")` misses, and `setTexture` is never called, so the sampler reads bgfx's default texture.

Metal is the only backend that renames, which is why #1796's D3D11 validation passed.

## Why not revert #1796

It is load-bearing on D3D. Names emitted into the bgfx uniform table for a shader declaring `diffuseSampler` and `Texture2D`:

| build | `diffuseSampler` | `Texture2D` |
|---|---|---|
| Metal, master | emits `diffuseSamplerTexture` | emits `Texture2DTexture` |
| Metal, this PR | correct | correct |
| D3D, master | correct | correct |
| D3D, #1796 reverted | correct | emits `_Texture2D` — #1796's bug |

OpenGL is unaffected either way.

## Validation

macOS at `c8a8071`, rebuilt with this as the only change: the textured box goes from black to correct, differing in exactly the 23,104 pixels of the box. Playground validation suite `ran=302 passed=302 failed=0`, and `Gaussian Splatting Compressed ply SH` — which failed on unpatched macOS — now passes.

| before | after |
|---|---|
| ![before](https://github.com/user-attachments/assets/7a139818-4958-4c4d-b30b-6da0c0acaf9e) | ![after](https://github.com/user-attachments/assets/8604f726-2e6b-45db-87db-3579816dc4e8) |

## Why CI did not catch it

No CI job renders through real Metal: Playground validation is Linux-only, `build-macos.yml` uses `BABYLON_NATIVE_TESTS_USE_NOOP_METAL_DEVICE=ON`, and `build-ios.yml` runs no rendering tests.