### PR TITLE
Bump JsRuntimeHost to cb988ba

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ FetchContent_Declare(ios-cmake
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(JsRuntimeHost
     GIT_REPOSITORY https://github.com/BabylonJS/JsRuntimeHost.git
-    GIT_TAG 9271f13b654665e343aa0e80ad872b4674534163)
+    GIT_TAG cb988baadb2d2087f4a8cc2942ada9221e1f5699)
 FetchContent_Declare(metal-cpp
     GIT_REPOSITORY https://github.com/bkaradzic/metal-cpp.git
     GIT_TAG metal-cpp_26


### PR DESCRIPTION
Moves the JsRuntimeHost pin from `9271f13` (2026-07-28) to `cb988ba`, which is current JsRuntimeHost `master`. That picks up three fixes:

- BabylonJS/JsRuntimeHost#223 — keep escaped handles alive when their escapable scope closes (use-after-free)
- BabylonJS/JsRuntimeHost#225 — QuickJS: report success from the `napi_throw` family
- BabylonJS/JsRuntimeHost#227 — fix V8 N-API leaking every promise ever created

## Validation

Windows/x64, RelWithDebInfo, MSVC 14.44 — run against both engines whose N-API ports these fixes touch:

| Engine | UnitTests | Validation sweep | Peak |
|---|---|---|---:|
| V8 | 21/21 | `ran=305 passed=305 failed=0` | 2598 MB |
| QuickJS | 21/21 | `ran=305 passed=305 failed=0` | 1910 MB |

To be clear about what this does and does not buy: the bump is **behaviour-neutral on this suite**. A same-tree V8 baseline on the old pin also measured `305/305` at 2558 MB, so the promise leak is not large enough to surface over 305 tests. The value here is the three correctness fixes, not a measurable win on the current suite.

It does matter at larger scale. On the NativeDawn branch, whose sweep runs 632 tests, the same pin difference is the gap between the sweep completing at ~5.4 GB and aborting partway through at ~12.1 GB.