### PR TITLE
Fix bimg zero-depth (non-volume) texture handling

### DIFF
--- a/Plugins/NativeEngine/Source/NativeEngine.cpp
+++ b/Plugins/NativeEngine/Source/NativeEngine.cpp
@@ -212,7 +212,9 @@ namespace Babylon
             }
 
             assert(image->m_offset == 0);
-            assert(image->m_depth == 1);
+            // bimg encodes "not a volume texture" as zero depth, so a 2D image reports
+            // m_depth == 0 rather than 1. Use isVolume rather than comparing m_depth.
+            assert(!bimg::isVolume(*image));
             assert(image->m_numLayers == 1);
             assert(image->m_numMips == 1);
             assert(!image->m_cubeMap);
@@ -226,7 +228,7 @@ namespace Babylon
                 // bimg loads grayscale textures with and without alpha as R8 and RG8 respectively.
                 // Unpack to RGB and RGBA such that RGB is the grayscale and the A is the alpha.
                 bimg::ImageContainer* oldImage{image};
-                image = bimg::imageAlloc(&allocator, bimg::TextureFormat::RGBA8, static_cast<uint16_t>(image->m_width), static_cast<uint16_t>(image->m_height), 1, 1, false, false);
+                image = bimg::imageAlloc(&allocator, bimg::TextureFormat::RGBA8, static_cast<uint16_t>(image->m_width), static_cast<uint16_t>(image->m_height), /*depth*/ 0, 1, false, false);
                 TransformImage(oldImage, image, oldImage->m_format == bimg::TextureFormat::R8 ? UnpackR8 : UnpackRG8);
                 bimg::imageFree(oldImage);
             }
@@ -274,7 +276,7 @@ namespace Babylon
                 image->m_format == bimg::TextureFormat::RGBA32F ||
                 image->m_format == bimg::TextureFormat::RGBA32U);
 
-            assert(image->m_depth == 1);
+            assert(!bimg::isVolume(*image));
             assert(image->m_numLayers == 1);
             assert(image->m_numMips == 1);
             assert(image->m_cubeMap == false);
@@ -1734,7 +1736,7 @@ namespace Babylon
             throw Napi::Error::New(Env(), "The data size does not match width, height, and format");
         }
 
-        bimg::ImageContainer* image{bimg::imageAlloc(&Graphics::DeviceContext::GetDefaultAllocator(), format, width, height, 1, 1, false, false, bytes)};
+        bimg::ImageContainer* image{bimg::imageAlloc(&Graphics::DeviceContext::GetDefaultAllocator(), format, width, height, /*depth*/ 0, 1, false, false, bytes)};
 
         // Unlike the async load paths, this one runs on the JavaScript thread, so a std::exception
         // escaping here would not be routed to an onError callback. Surface it as a JS error.
@@ -2744,7 +2746,7 @@ namespace Babylon
         imageBitmap.Set("data", buffer);
         imageBitmap.Set("width", Napi::Value::From(env, image->m_width));
         imageBitmap.Set("height", Napi::Value::From(env, image->m_height));
-        imageBitmap.Set("depth", Napi::Value::From(env, image->m_depth));
+        imageBitmap.Set("depth", Napi::Value::From(env, bimg::imageGetNumSlices(*image)));
         imageBitmap.Set("numLayers", Napi::Value::From(env, image->m_numLayers));
         imageBitmap.Set("format", Napi::Value::From(env, static_cast<uint32_t>(image->m_format)));
 
@@ -2799,7 +2801,7 @@ namespace Babylon
             throw Napi::Error::New(env, "Invalid source image dimensions for ResizeImageBitmap.");
         }
 
-        bimg::ImageContainer* image = bimg::imageAlloc(&Graphics::DeviceContext::GetDefaultAllocator(), format, width, height, 1, 1, false, false, data.Data());
+        bimg::ImageContainer* image = bimg::imageAlloc(&Graphics::DeviceContext::GetDefaultAllocator(), format, width, height, /*depth*/ 0, 1, false, false, data.Data());
         if (image == nullptr)
         {
             throw Napi::Error::New(env, "Unable to allocate image for ResizeImageBitmap.");


### PR DESCRIPTION
## Problem

bimg [`371d9009` "Use zero depth to mean not a volume texture" (#150)](https://github.com/bkaradzic/bimg/commit/371d90098b1fd017cd00205979d5ef74b8c3ed62) changed the meaning of `ImageContainer::m_depth`, so that **zero** now means "not a volume texture":

- `image_decode.cpp` sets `m_depth = 0` for decoded images, so a 2D PNG/JPG reports `0` rather than `1`.
- `imageAlloc` dropped its `_depth = bx::max<uint32_t>(1, _depth)` clamp and now stores `_depth` verbatim, so passing `1` flags the resulting container as a volume texture.
- Two new helpers, `bimg::isVolume()` and `bimg::imageGetNumSlices()`, express the convention.

Babylon Native picked this up in #1841 (bgfx.cmake bumped to `9e56bab`), but the NativeEngine call sites were not updated along with it:

- `ParseImage` and `PrepareImage` assert `image->m_depth == 1`. That assert now **fails in Debug for every decoded image**.
- Three `imageAlloc` calls pass a depth of `1` for 2D images, which now marks those containers as volume textures.

## Fix

| Site | Change |
| --- | --- |
| `ParseImage`, `PrepareImage` | `assert(image->m_depth == 1)` -> `assert(!bimg::isVolume(*image))` |
| grayscale unpack, `LoadRawTexture`, `ResizeImageBitmap` | `imageAlloc(..., /*depth*/ 1, ...)` -> `/*depth*/ 0` |
| `CreateImageBitmap` | reports `bimg::imageGetNumSlices(*image)`, so the JavaScript-visible `depth` stays `1` for a 2D image |

The `imageGetSize` call sites are intentionally left alone: `imageGetSize` still clamps `_depth` to a minimum of one, so passing `1` there remains correct. `imageConvert`, `imageGenerateMips` and `imageGetRawData` propagate or clamp `m_depth` themselves and need no change.

## Verification

A standalone probe linked against the fetched bimg (`371d9009`), parsing a real PNG:

```
72x72  m_depth=0  isVolume=0  imageGetNumSlices=1  cubeMap=0
OLD  assert(image->m_depth == 1)      => FAIL
NEW  assert(!bimg::isVolume(*image))  => PASS
```

Win32 x64 Debug validation on the patched build:

- tests 1-52: 52/52 validated
- tests 58-310 and 314-719: **245/245 passed, 0 failed, exit 0**
- no assertion fired

Scissor tests (indices 52-57 and 311-313) crash in Debug inside `bgfx::d3d11::RendererContextD3D11::submit`. An unpatched baseline build crashes at the same test, so that failure is pre-existing and unrelated to this change.