### PR TITLE
Update JsRuntimeHost to latest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ FetchContent_Declare(ios-cmake
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(JsRuntimeHost
     GIT_REPOSITORY https://github.com/BabylonJS/JsRuntimeHost.git
-    GIT_TAG cb988baadb2d2087f4a8cc2942ada9221e1f5699)
+    GIT_TAG 0d26362700edd52a48c38ab83b1090e53e7cfeba)
 FetchContent_Declare(metal-cpp
     GIT_REPOSITORY https://github.com/bkaradzic/metal-cpp.git
     GIT_TAG metal-cpp_26


### PR DESCRIPTION
## Summary

Update JsRuntimeHost from [`cb988baa`](https://github.com/BabylonJS/JsRuntimeHost/commit/cb988baadb2d2087f4a8cc2942ada9221e1f5699) to [`0d263627`](https://github.com/BabylonJS/JsRuntimeHost/commit/0d26362700edd52a48c38ab83b1090e53e7cfeba), picking up three fixes merged since the current pin:

- [BabylonJS/JsRuntimeHost#220](https://github.com/BabylonJS/JsRuntimeHost/pull/220) — prevent zero-delay `setInterval` from flooding and starving the JS dispatch queue. In BN this could indefinitely delay async shader-compilation continuations and hang scene readiness.
- [BabylonJS/JsRuntimeHost#230](https://github.com/BabylonJS/JsRuntimeHost/pull/230) — support UTF-16LE/UTF-16BE in `TextDecoder`, needed by Emscripten `EXPORT_ES6` modules such as SPZ and CSG2/manifold.
- [BabylonJS/JsRuntimeHost#231](https://github.com/BabylonJS/JsRuntimeHost/pull/231) — preserve embedded NUL bytes in XHR string responses, needed for Emscripten modules with inline WASM payloads.

## Validation

- Configured Win32 x64 against the updated dependency and confirmed FetchContent resolved the exact pinned SHA.
- Built the Debug Playground target successfully.
- Ran the `Nested BBG` validation test, which exercises the timer-starvation regression path: **1/1 passed, exit 0**.
- The three upstream changes include their own focused JsRuntimeHost unit coverage.