### PR TITLE
Make external texture disposal deterministic

### DIFF
--- a/Apps/UnitTests/CMakeLists.txt
+++ b/Apps/UnitTests/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SOURCES
     "Source/App.cpp"
     "Source/Tests.Device.FrameEncoder.cpp"
     "Source/Tests.ExternalTexture.cpp"
+    "Source/Tests.ExternalTexture.Lifecycle.cpp"
     "Source/Tests.ExternalTexture.DeviceLoss.cpp"
     "Source/Tests.ExternalTexture.LayerCount.cpp"
     "Source/Tests.ExternalTexture.Msaa.cpp"

--- a/Apps/UnitTests/Source/Tests.ExternalTexture.Lifecycle.cpp
+++ b/Apps/UnitTests/Source/Tests.ExternalTexture.Lifecycle.cpp
@@ -105,10 +105,10 @@ namespace
                 auto global = env.Global();
                 auto engine = global.Get("_externalEngine").As<Napi::Object>();
                 engine.Get("dispose").As<Napi::Function>().Call(engine, {});
-                global.Delete("_externalTextureOwner");
-                global.Delete("_externalInternalTexture");
-                global.Delete("_externalNativeTexture");
-                global.Delete("_externalEngine");
+                global.Set("_externalTextureOwner", env.Undefined());
+                global.Set("_externalInternalTexture", env.Undefined());
+                global.Set("_externalNativeTexture", env.Undefined());
+                global.Set("_externalEngine", env.Undefined());
                 cleanedUp.set_value();
             }
             catch (...)

--- a/Apps/UnitTests/Source/Tests.ExternalTexture.Lifecycle.cpp
+++ b/Apps/UnitTests/Source/Tests.ExternalTexture.Lifecycle.cpp
@@ -1,0 +1,139 @@
+#include <gtest/gtest.h>
+
+#include <Babylon/AppRuntime.h>
+#include <Babylon/Graphics/Device.h>
+#include <Babylon/Graphics/Texture.h>
+#include <Babylon/Polyfills/Console.h>
+#include <Babylon/Polyfills/Window.h>
+#include <Babylon/Plugins/ExternalTexture.h>
+#include <Babylon/Plugins/NativeEngine.h>
+#include <Babylon/ScriptLoader.h>
+#include <napi/pointer.h>
+
+#include "Helpers.h"
+
+#include <future>
+#include <iostream>
+
+extern Babylon::Graphics::Configuration g_deviceConfig;
+
+namespace
+{
+    using NativeTexture = Babylon::Graphics::Texture;
+
+    void TestJavaScriptDisposePreventsUpdate(bool useThinTexture)
+    {
+        Babylon::Graphics::Device device{g_deviceConfig};
+
+        Babylon::AppRuntime::Options options{};
+        options.UnhandledExceptionHandler = [](const Napi::Error& error) {
+            std::cerr << "[Uncaught Error] " << Napi::GetErrorString(error) << std::endl;
+            std::quick_exit(1);
+        };
+        Babylon::AppRuntime runtime{options};
+
+        runtime.Dispatch([&device](Napi::Env env) {
+            env.Global().Set("globalThis", env.Global());
+            device.AddToJavaScript(env);
+            Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
+                std::cout << message << std::endl;
+            });
+            Babylon::Polyfills::Window::Initialize(env);
+            Babylon::Plugins::NativeEngine::Initialize(env);
+        });
+
+        Babylon::ScriptLoader loader{runtime};
+        loader.LoadScript("app:///Assets/babylon.max.js");
+
+        device.StartRenderingCurrentFrame();
+
+        auto nativeTexture = Helpers::CreateTexture(device.GetPlatformInfo().Device, 256, 256);
+        Babylon::Plugins::ExternalTexture externalTexture{nativeTexture};
+        Helpers::DestroyTexture(nativeTexture);
+
+        std::promise<Babylon::Graphics::Texture*> disposed;
+        loader.Dispatch([&externalTexture, useThinTexture, &disposed](Napi::Env env) {
+            try
+            {
+                auto global = env.Global();
+                auto babylon = global.Get("BABYLON").As<Napi::Object>();
+                auto jsNativeTexture = externalTexture.CreateForJavaScript(env);
+                auto* texture = jsNativeTexture.As<Napi::Pointer<NativeTexture>>().Get();
+                auto engine = babylon.Get("NativeEngine").As<Napi::Function>().New({});
+                auto internalTexture = engine.Get("wrapNativeTexture").As<Napi::Function>().Call(engine, {jsNativeTexture}).As<Napi::Object>();
+                auto textureOwner = useThinTexture
+                    ? babylon.Get("ThinTexture").As<Napi::Function>().New({internalTexture})
+                    : internalTexture;
+
+                global.Set("_externalNativeTexture", jsNativeTexture);
+                global.Set("_externalEngine", engine);
+                global.Set("_externalInternalTexture", internalTexture);
+                global.Set("_externalTextureOwner", textureOwner);
+
+                textureOwner.Get("dispose").As<Napi::Function>().Call(textureOwner, {});
+                disposed.set_value(texture);
+            }
+            catch (...)
+            {
+                disposed.set_exception(std::current_exception());
+            }
+        });
+
+        auto* texture = disposed.get_future().get();
+        ASSERT_NE(texture, nullptr);
+        EXPECT_FALSE(texture->IsValid());
+
+        device.FinishRenderingCurrentFrame();
+
+        for (uint32_t size : {128u, 64u})
+        {
+            device.StartRenderingCurrentFrame();
+
+            auto replacement = Helpers::CreateTexture(device.GetPlatformInfo().Device, size, size);
+            externalTexture.Update(replacement);
+            Helpers::DestroyTexture(replacement);
+
+            EXPECT_FALSE(texture->IsValid());
+
+            device.FinishRenderingCurrentFrame();
+        }
+
+        std::promise<void> cleanedUp;
+        loader.Dispatch([&cleanedUp](Napi::Env env) {
+            try
+            {
+                auto global = env.Global();
+                auto engine = global.Get("_externalEngine").As<Napi::Object>();
+                engine.Get("dispose").As<Napi::Function>().Call(engine, {});
+                global.Delete("_externalTextureOwner");
+                global.Delete("_externalInternalTexture");
+                global.Delete("_externalNativeTexture");
+                global.Delete("_externalEngine");
+                cleanedUp.set_value();
+            }
+            catch (...)
+            {
+                cleanedUp.set_exception(std::current_exception());
+            }
+        });
+        cleanedUp.get_future().get();
+    }
+}
+
+TEST(ExternalTexture, JavaScriptDisposeInternalTexturePreventsUpdate)
+{
+#ifdef SKIP_EXTERNAL_TEXTURE_TESTS
+    GTEST_SKIP();
+#else
+    TestJavaScriptDisposePreventsUpdate(false);
+#endif
+}
+
+TEST(ExternalTexture, JavaScriptDisposeThinTexturePreventsUpdate)
+{
+#ifdef SKIP_EXTERNAL_TEXTURE_TESTS
+    GTEST_SKIP();
+#else
+    TestJavaScriptDisposePreventsUpdate(true);
+#endif
+}

--- a/Apps/UnitTests/Source/Tests.ExternalTexture.cpp
+++ b/Apps/UnitTests/Source/Tests.ExternalTexture.cpp
@@ -2,16 +2,123 @@
 
 #include <Babylon/AppRuntime.h>
 #include <Babylon/Graphics/Device.h>
+#include <Babylon/Graphics/Texture.h>
 #include <Babylon/Polyfills/Console.h>
 #include <Babylon/Polyfills/Window.h>
 #include <Babylon/Plugins/NativeEngine.h>
 #include <Babylon/Plugins/ExternalTexture.h>
+#include <Babylon/ScriptLoader.h>
+#include <napi/pointer.h>
 
 #include "Helpers.h"
 
+#include <future>
 #include <iostream>
 
 extern Babylon::Graphics::Configuration g_deviceConfig;
+
+namespace
+{
+    using NativeTexture = Babylon::Graphics::Texture;
+
+    void TestJavaScriptDisposePreventsUpdate(bool useThinTexture)
+    {
+        Babylon::Graphics::Device device{g_deviceConfig};
+
+        Babylon::AppRuntime::Options options{};
+        options.UnhandledExceptionHandler = [](const Napi::Error& error) {
+            std::cerr << "[Uncaught Error] " << Napi::GetErrorString(error) << std::endl;
+            std::quick_exit(1);
+        };
+        Babylon::AppRuntime runtime{options};
+
+        runtime.Dispatch([&device](Napi::Env env) {
+            env.Global().Set("globalThis", env.Global());
+            device.AddToJavaScript(env);
+            Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
+                std::cout << message << std::endl;
+            });
+            Babylon::Polyfills::Window::Initialize(env);
+            Babylon::Plugins::NativeEngine::Initialize(env);
+        });
+
+        Babylon::ScriptLoader loader{runtime};
+        loader.LoadScript("app:///Assets/babylon.max.js");
+
+        device.StartRenderingCurrentFrame();
+
+        auto nativeTexture = Helpers::CreateTexture(device.GetPlatformInfo().Device, 256, 256);
+        Babylon::Plugins::ExternalTexture externalTexture{nativeTexture};
+        Helpers::DestroyTexture(nativeTexture);
+
+        std::promise<Babylon::Graphics::Texture*> disposed;
+        loader.Dispatch([&externalTexture, useThinTexture, &disposed](Napi::Env env) {
+            try
+            {
+                auto global = env.Global();
+                auto babylon = global.Get("BABYLON").As<Napi::Object>();
+                auto jsNativeTexture = externalTexture.CreateForJavaScript(env);
+                auto* texture = jsNativeTexture.As<Napi::Pointer<NativeTexture>>().Get();
+                auto engine = babylon.Get("NativeEngine").As<Napi::Function>().New({});
+                auto internalTexture = engine.Get("wrapNativeTexture").As<Napi::Function>().Call(engine, {jsNativeTexture}).As<Napi::Object>();
+                auto textureOwner = useThinTexture
+                    ? babylon.Get("ThinTexture").As<Napi::Function>().New({internalTexture})
+                    : internalTexture;
+
+                global.Set("_externalNativeTexture", jsNativeTexture);
+                global.Set("_externalEngine", engine);
+                global.Set("_externalInternalTexture", internalTexture);
+                global.Set("_externalTextureOwner", textureOwner);
+
+                textureOwner.Get("dispose").As<Napi::Function>().Call(textureOwner, {});
+                disposed.set_value(texture);
+            }
+            catch (...)
+            {
+                disposed.set_exception(std::current_exception());
+            }
+        });
+
+        auto* texture = disposed.get_future().get();
+        ASSERT_NE(texture, nullptr);
+        EXPECT_FALSE(texture->IsValid());
+
+        device.FinishRenderingCurrentFrame();
+
+        for (uint32_t size : {128u, 64u})
+        {
+            device.StartRenderingCurrentFrame();
+
+            auto replacement = Helpers::CreateTexture(device.GetPlatformInfo().Device, size, size);
+            externalTexture.Update(replacement);
+            Helpers::DestroyTexture(replacement);
+
+            EXPECT_FALSE(texture->IsValid());
+
+            device.FinishRenderingCurrentFrame();
+        }
+
+        std::promise<void> cleanedUp;
+        loader.Dispatch([&cleanedUp](Napi::Env env) {
+            try
+            {
+                auto global = env.Global();
+                auto engine = global.Get("_externalEngine").As<Napi::Object>();
+                engine.Get("dispose").As<Napi::Function>().Call(engine, {});
+                global.Delete("_externalTextureOwner");
+                global.Delete("_externalInternalTexture");
+                global.Delete("_externalNativeTexture");
+                global.Delete("_externalEngine");
+                cleanedUp.set_value();
+            }
+            catch (...)
+            {
+                cleanedUp.set_exception(std::current_exception());
+            }
+        });
+        cleanedUp.get_future().get();
+    }
+}
 
 TEST(ExternalTexture, Construction)
 {
@@ -69,6 +176,24 @@ TEST(ExternalTexture, CreateForJavaScript)
     done.get_future().wait();
 
     device.FinishRenderingCurrentFrame();
+#endif
+}
+
+TEST(ExternalTexture, JavaScriptDisposeInternalTexturePreventsUpdate)
+{
+#ifdef SKIP_EXTERNAL_TEXTURE_TESTS
+    GTEST_SKIP();
+#else
+    TestJavaScriptDisposePreventsUpdate(false);
+#endif
+}
+
+TEST(ExternalTexture, JavaScriptDisposeThinTexturePreventsUpdate)
+{
+#ifdef SKIP_EXTERNAL_TEXTURE_TESTS
+    GTEST_SKIP();
+#else
+    TestJavaScriptDisposePreventsUpdate(true);
 #endif
 }
 

--- a/Apps/UnitTests/Source/Tests.ExternalTexture.cpp
+++ b/Apps/UnitTests/Source/Tests.ExternalTexture.cpp
@@ -2,13 +2,10 @@
 
 #include <Babylon/AppRuntime.h>
 #include <Babylon/Graphics/Device.h>
-#include <Babylon/Graphics/Texture.h>
 #include <Babylon/Polyfills/Console.h>
 #include <Babylon/Polyfills/Window.h>
 #include <Babylon/Plugins/NativeEngine.h>
 #include <Babylon/Plugins/ExternalTexture.h>
-#include <Babylon/ScriptLoader.h>
-#include <napi/pointer.h>
 
 #include "Helpers.h"
 
@@ -16,109 +13,6 @@
 #include <iostream>
 
 extern Babylon::Graphics::Configuration g_deviceConfig;
-
-namespace
-{
-    using NativeTexture = Babylon::Graphics::Texture;
-
-    void TestJavaScriptDisposePreventsUpdate(bool useThinTexture)
-    {
-        Babylon::Graphics::Device device{g_deviceConfig};
-
-        Babylon::AppRuntime::Options options{};
-        options.UnhandledExceptionHandler = [](const Napi::Error& error) {
-            std::cerr << "[Uncaught Error] " << Napi::GetErrorString(error) << std::endl;
-            std::quick_exit(1);
-        };
-        Babylon::AppRuntime runtime{options};
-
-        runtime.Dispatch([&device](Napi::Env env) {
-            env.Global().Set("globalThis", env.Global());
-            device.AddToJavaScript(env);
-            Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
-                std::cout << message << std::endl;
-            });
-            Babylon::Polyfills::Window::Initialize(env);
-            Babylon::Plugins::NativeEngine::Initialize(env);
-        });
-
-        Babylon::ScriptLoader loader{runtime};
-        loader.LoadScript("app:///Assets/babylon.max.js");
-
-        device.StartRenderingCurrentFrame();
-
-        auto nativeTexture = Helpers::CreateTexture(device.GetPlatformInfo().Device, 256, 256);
-        Babylon::Plugins::ExternalTexture externalTexture{nativeTexture};
-        Helpers::DestroyTexture(nativeTexture);
-
-        std::promise<Babylon::Graphics::Texture*> disposed;
-        loader.Dispatch([&externalTexture, useThinTexture, &disposed](Napi::Env env) {
-            try
-            {
-                auto global = env.Global();
-                auto babylon = global.Get("BABYLON").As<Napi::Object>();
-                auto jsNativeTexture = externalTexture.CreateForJavaScript(env);
-                auto* texture = jsNativeTexture.As<Napi::Pointer<NativeTexture>>().Get();
-                auto engine = babylon.Get("NativeEngine").As<Napi::Function>().New({});
-                auto internalTexture = engine.Get("wrapNativeTexture").As<Napi::Function>().Call(engine, {jsNativeTexture}).As<Napi::Object>();
-                auto textureOwner = useThinTexture
-                    ? babylon.Get("ThinTexture").As<Napi::Function>().New({internalTexture})
-                    : internalTexture;
-
-                global.Set("_externalNativeTexture", jsNativeTexture);
-                global.Set("_externalEngine", engine);
-                global.Set("_externalInternalTexture", internalTexture);
-                global.Set("_externalTextureOwner", textureOwner);
-
-                textureOwner.Get("dispose").As<Napi::Function>().Call(textureOwner, {});
-                disposed.set_value(texture);
-            }
-            catch (...)
-            {
-                disposed.set_exception(std::current_exception());
-            }
-        });
-
-        auto* texture = disposed.get_future().get();
-        ASSERT_NE(texture, nullptr);
-        EXPECT_FALSE(texture->IsValid());
-
-        device.FinishRenderingCurrentFrame();
-
-        for (uint32_t size : {128u, 64u})
-        {
-            device.StartRenderingCurrentFrame();
-
-            auto replacement = Helpers::CreateTexture(device.GetPlatformInfo().Device, size, size);
-            externalTexture.Update(replacement);
-            Helpers::DestroyTexture(replacement);
-
-            EXPECT_FALSE(texture->IsValid());
-
-            device.FinishRenderingCurrentFrame();
-        }
-
-        std::promise<void> cleanedUp;
-        loader.Dispatch([&cleanedUp](Napi::Env env) {
-            try
-            {
-                auto global = env.Global();
-                auto engine = global.Get("_externalEngine").As<Napi::Object>();
-                engine.Get("dispose").As<Napi::Function>().Call(engine, {});
-                global.Delete("_externalTextureOwner");
-                global.Delete("_externalInternalTexture");
-                global.Delete("_externalNativeTexture");
-                global.Delete("_externalEngine");
-                cleanedUp.set_value();
-            }
-            catch (...)
-            {
-                cleanedUp.set_exception(std::current_exception());
-            }
-        });
-        cleanedUp.get_future().get();
-    }
-}
 
 TEST(ExternalTexture, Construction)
 {
@@ -176,24 +70,6 @@ TEST(ExternalTexture, CreateForJavaScript)
     done.get_future().wait();
 
     device.FinishRenderingCurrentFrame();
-#endif
-}
-
-TEST(ExternalTexture, JavaScriptDisposeInternalTexturePreventsUpdate)
-{
-#ifdef SKIP_EXTERNAL_TEXTURE_TESTS
-    GTEST_SKIP();
-#else
-    TestJavaScriptDisposePreventsUpdate(false);
-#endif
-}
-
-TEST(ExternalTexture, JavaScriptDisposeThinTexturePreventsUpdate)
-{
-#ifdef SKIP_EXTERNAL_TEXTURE_TESTS
-    GTEST_SKIP();
-#else
-    TestJavaScriptDisposePreventsUpdate(true);
 #endif
 }
 

--- a/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
+++ b/Core/Graphics/InternalInclude/Babylon/Graphics/Texture.h
@@ -6,6 +6,7 @@ namespace Babylon::Graphics
 {
     class DeviceContext;
 
+    // This class is not thread-safe. Callers must serialize all access.
     class Texture final
     {
     public:
@@ -19,7 +20,7 @@ namespace Babylon::Graphics
 
         bool IsValid() const;
 
-        void Create2D(uint16_t width, uint16_t height, bool hasMips, uint16_t numLayers, bgfx::TextureFormat::Enum format, uint64_t flags);
+        void Create2D(uint16_t width, uint16_t height, bool hasMips, uint16_t numLayers, bgfx::TextureFormat::Enum format, uint64_t flags, uintptr_t nativeTextureHandle = 0);
         void Update2D(uint16_t layer, uint8_t mip, uint16_t x, uint16_t y, uint16_t width, uint16_t height, const bgfx::Memory* mem, uint16_t pitch = UINT16_MAX);
 
         void Create3D(uint16_t width, uint16_t height, uint16_t depth, bool hasMips, bgfx::TextureFormat::Enum format, uint64_t flags);
@@ -28,7 +29,7 @@ namespace Babylon::Graphics
         void CreateCube(uint16_t size, bool hasMips, uint16_t numLayers, bgfx::TextureFormat::Enum format, uint64_t flags);
         void UpdateCube(uint16_t layer, uint8_t side, uint8_t mip, uint16_t x, uint16_t y, uint16_t width, uint16_t height, const bgfx::Memory* mem, uint16_t pitch = UINT16_MAX);
 
-        void Attach(bgfx::TextureHandle handle, bool ownsHandle, uint16_t width, uint16_t height, bool hasMips, uint16_t numLayers, bgfx::TextureFormat::Enum format, uint64_t flags);
+        void Attach(bgfx::TextureHandle handle, uint16_t width, uint16_t height, bool hasMips, uint16_t numLayers, bgfx::TextureFormat::Enum format, uint64_t flags);
 
         bgfx::TextureHandle Handle() const;
         uint16_t Width() const;
@@ -64,11 +65,16 @@ namespace Babylon::Graphics
         }
 
     private:
-        // Resets every piece of shape metadata to its default. Each Create*/Attach calls this
-        // before assigning the subset that applies to it, so a field a given path does not set
-        // (m_depth is only meaningful for Create3D) cannot survive from the previous, differently
-        // shaped texture this object described.
-        void ResetMetadata();
+        void SetMetadata(
+            uint16_t width,
+            uint16_t height,
+            uint16_t depth,
+            bool hasMips,
+            bool isCube,
+            bool is3D,
+            uint16_t numLayers,
+            bgfx::TextureFormat::Enum format,
+            uint64_t flags);
 
         bgfx::TextureHandle m_handle{bgfx::kInvalidHandle};
         bool m_ownsHandle{false};

--- a/Core/Graphics/Source/Texture.cpp
+++ b/Core/Graphics/Source/Texture.cpp
@@ -43,41 +43,46 @@ namespace Babylon::Graphics
         return bgfx::isValid(m_handle);
     }
 
-    void Texture::ResetMetadata()
+    void Texture::SetMetadata(
+        uint16_t width,
+        uint16_t height,
+        uint16_t depth,
+        bool hasMips,
+        bool isCube,
+        bool is3D,
+        uint16_t numLayers,
+        bgfx::TextureFormat::Enum format,
+        uint64_t flags)
     {
-        m_width = 0;
-        m_height = 0;
-        m_depth = 0;
-        m_hasMips = false;
-        m_isCube = false;
-        m_is3D = false;
-        m_numLayers = 0;
-        m_format = bgfx::TextureFormat::Enum::Unknown;
-        m_flags = BGFX_TEXTURE_NONE;
+        m_width = width;
+        m_height = height;
+        m_depth = depth;
+        m_hasMips = hasMips;
+        m_isCube = isCube;
+        m_is3D = is3D;
+        m_numLayers = numLayers;
+        m_format = format;
+        m_flags = flags;
     }
 
-    void Texture::Create2D(uint16_t width, uint16_t height, bool hasMips, uint16_t numLayers, bgfx::TextureFormat::Enum format, uint64_t flags)
+    void Texture::Create2D(uint16_t width, uint16_t height, bool hasMips, uint16_t numLayers, bgfx::TextureFormat::Enum format, uint64_t flags, uintptr_t nativeTextureHandle)
     {
         Dispose();
-        ResetMetadata();
 
-        // make sure render targets are filled with 0 : https://registry.khronos.org/webgl/specs/latest/1.0/#TEXIMAGE2D
-        const auto* mem = (flags & BGFX_TEXTURE_RT) ? GetZeroImageMemory(width, height, hasMips, numLayers, format) : nullptr;
+        // Create Babylon-owned textures with BGFX_TEXTURE_BLIT_DST to match web behavior.
+        const auto createFlags = nativeTextureHandle == 0 ? flags | BGFX_TEXTURE_BLIT_DST : flags;
 
-        // Always create with BGFX_TEXTURE_BLIT_DST to match web behavior.
-        m_handle = bgfx::createTexture2D(width, height, hasMips, numLayers, format, flags | BGFX_TEXTURE_BLIT_DST, mem);
+        // Make sure render targets are filled with 0 : https://registry.khronos.org/webgl/specs/latest/1.0/#TEXIMAGE2D
+        const auto* mem = nativeTextureHandle == 0 && (flags & BGFX_TEXTURE_RT) ? GetZeroImageMemory(width, height, hasMips, numLayers, format) : nullptr;
+
+        m_handle = bgfx::createTexture2D(width, height, hasMips, numLayers, format, createFlags, mem, nativeTextureHandle);
         if (!bgfx::isValid(m_handle))
         {
             throw std::runtime_error{"Failed to create texture"};
         }
 
         m_ownsHandle = true;
-        m_width = width;
-        m_height = height;
-        m_hasMips = hasMips;
-        m_numLayers = numLayers;
-        m_format = format;
-        m_flags = flags;
+        SetMetadata(width, height, 0, hasMips, false, false, numLayers, format, flags);
     }
 
     void Texture::Update2D(uint16_t layer, uint8_t mip, uint16_t x, uint16_t y, uint16_t width, uint16_t height, const bgfx::Memory* mem, uint16_t pitch)
@@ -88,7 +93,6 @@ namespace Babylon::Graphics
     void Texture::Create3D(uint16_t width, uint16_t height, uint16_t depth, bool hasMips, bgfx::TextureFormat::Enum format, uint64_t flags)
     {
         Dispose();
-        ResetMetadata();
 
         m_handle = bgfx::createTexture3D(width, height, depth, hasMips, format, flags);
         if (!bgfx::isValid(m_handle))
@@ -97,14 +101,7 @@ namespace Babylon::Graphics
         }
 
         m_ownsHandle = true;
-        m_width = width;
-        m_height = height;
-        m_depth = depth;
-        m_hasMips = hasMips;
-        m_numLayers = 1;
-        m_format = format;
-        m_flags = flags;
-        m_is3D = true;
+        SetMetadata(width, height, depth, hasMips, false, true, 1, format, flags);
     }
 
     void Texture::Update3D(uint8_t mip, uint16_t x, uint16_t y, uint16_t z, uint16_t width, uint16_t height, uint16_t depth, const bgfx::Memory* mem)
@@ -115,17 +112,15 @@ namespace Babylon::Graphics
     void Texture::CreateCube(uint16_t size, bool hasMips, uint16_t numLayers, bgfx::TextureFormat::Enum format, uint64_t flags)
     {
         Dispose();
-        ResetMetadata();
 
         m_handle = bgfx::createTextureCube(size, hasMips, numLayers, format, flags);
+        if (!bgfx::isValid(m_handle))
+        {
+            throw std::runtime_error{"Failed to create cube texture"};
+        }
+
         m_ownsHandle = true;
-        m_width = size;
-        m_height = size;
-        m_hasMips = hasMips;
-        m_numLayers = numLayers;
-        m_format = format;
-        m_flags = flags;
-        m_isCube = true;
+        SetMetadata(size, size, 0, hasMips, true, false, numLayers, format, flags);
     }
 
     void Texture::UpdateCube(uint16_t layer, uint8_t side, uint8_t mip, uint16_t x, uint16_t y, uint16_t width, uint16_t height, const bgfx::Memory* mem, uint16_t pitch)
@@ -133,20 +128,15 @@ namespace Babylon::Graphics
         bgfx::updateTextureCube(m_handle, layer, side, mip, x, y, width, height, mem, pitch);
     }
 
-    void Texture::Attach(bgfx::TextureHandle handle, bool ownsHandle, uint16_t width, uint16_t height, bool hasMips, uint16_t numLayers, bgfx::TextureFormat::Enum format, uint64_t flags)
+    void Texture::Attach(bgfx::TextureHandle handle, uint16_t width, uint16_t height, bool hasMips, uint16_t numLayers, bgfx::TextureFormat::Enum format, uint64_t flags)
     {
         Dispose();
-        ResetMetadata();
 
         assert(bgfx::isValid(handle));
         m_handle = handle;
-        m_ownsHandle = ownsHandle;
-        m_width = width;
-        m_height = height;
-        m_hasMips = hasMips;
-        m_numLayers = numLayers;
-        m_format = format;
-        m_flags = flags;
+
+        m_ownsHandle = false;
+        SetMetadata(width, height, 0, hasMips, false, false, numLayers, format, flags);
     }
 
     bgfx::TextureHandle Texture::Handle() const

--- a/Plugins/ExternalTexture/Include/Babylon/Plugins/ExternalTexture.h
+++ b/Plugins/ExternalTexture/Include/Babylon/Plugins/ExternalTexture.h
@@ -33,6 +33,8 @@ namespace Babylon::Plugins
 
         // Creates a JavaScript value wrapping this external texture.
         // Wrap the returned value with `engine.wrapNativeTexture` on the JS side to get a Babylon.js `InternalTexture`.
+        // Disposing the InternalTexture releases Babylon Native's rendering resources immediately;
+        // otherwise they remain until JavaScript finalization. The external texture remains caller-owned.
         // If layerIndex is set, the JavaScript texture views only that array layer (single-slice); otherwise the entire texture.
         // This method must be called from the JavaScript thread. The caller must ensure no other thread
         // is concurrently calling any other operations on this object, including move operations.

--- a/Plugins/ExternalTexture/Include/Babylon/Plugins/ExternalTexture.h
+++ b/Plugins/ExternalTexture/Include/Babylon/Plugins/ExternalTexture.h
@@ -47,6 +47,8 @@ namespace Babylon::Plugins
         Napi::Promise AddToContextAsync(Napi::Env, std::optional<uint16_t> layerIndex = {}) const;
 
         // Updates to a new texture. If layerIndex is set, views only that array layer (single-slice).
+        // Do not call this concurrently with JavaScript use or disposal of a texture returned by CreateForJavaScript;
+        // Graphics::Texture is not thread-safe, so Update must be serialized with those JavaScript operations.
         void Update(Graphics::TextureT, std::optional<Graphics::TextureFormatT> = {}, std::optional<uint16_t> layerIndex = {});
 
     private:

--- a/Plugins/ExternalTexture/Readme.md
+++ b/Plugins/ExternalTexture/Readme.md
@@ -68,11 +68,13 @@ function YOUR_JS_FUNCTION(externalTexture, width, height) {
 
 This class assumes that the native texture was created using the same graphics device used to create the Babylon::Device. See [Properly Initialize `Babylon::Graphics::Device`](#properly-initialize-babylongraphicsdevice).
 
-`ExternalTexture::CreateForJavaScript` synchronously returns a `Napi::Value` wrapping a bgfx texture handle that is backed directly by the native texture. The returned value can be passed to `engine.wrapNativeTexture` on the JS side.
+`ExternalTexture::CreateForJavaScript` synchronously returns a `Napi::Value` wrapping a Babylon Native texture that is backed directly by the native texture. The returned value can be passed to `engine.wrapNativeTexture` on the JS side.
 
 It is safe to create multiple JS objects from the same `Babylon::Plugins::ExternalTexture` via `ExternalTexture::CreateForJavaScript`.
 
 Once the JS texture is available on the JS side, use `engine.wrapNativeTexture` to create an Babylon.js `InternalTexture`.
+
+If the `InternalTexture` is stored in a `ThinTexture`, call `ThinTexture.dispose()` as soon as it will no longer be used; otherwise, call `InternalTexture.dispose()` directly. Disposal immediately releases Babylon Native's rendering resources for that texture. The caller can then release the externally owned texture and its GPU memory without waiting for JavaScript finalization. The lightweight native wrapper remains allocated until finalization but no longer holds rendering resources, and `ExternalTexture::Update` does not make it usable again.
 
 ## Example 1: Copy rendering content (D3D12)
 

--- a/Plugins/ExternalTexture/Source/ExternalTexture_Base.h
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Base.h
@@ -61,31 +61,30 @@ namespace Babylon::Plugins
             return BGFX_TEXTURE_NONE;
         }
 
-        // Re-attaches every registered Graphics::Texture to a fresh bgfx handle backed by
+        // Recreates every registered Graphics::Texture with a fresh bgfx handle backed by
         // `ptr`. Caller must hold m_mutex (called from the locked region of Impl::Update).
         void UpdateTextures(Graphics::TextureT ptr, std::optional<uint16_t> layerIndex)
         {
-            for (auto* texture : m_textures)
+            for (auto it = m_textures.begin(); it != m_textures.end();)
             {
-                bgfx::TextureHandle handle = bgfx::createTexture2D(
+                auto* texture = *it;
+                if (!texture->IsValid())
+                {
+                    it = m_textures.erase(it);
+                    continue;
+                }
+
+                texture->Create2D(
                     Width(),
                     Height(),
                     HasMips(),
                     NumLayers(),
                     Format(),
                     Flags(),
-                    0,
-                    NativeTextureHandle(ptr)
-                );
-
-                if (!bgfx::isValid(handle))
-                {
-                    throw std::runtime_error{"Failed to create external texture"};
-                }
-
-                texture->Attach(handle, true, m_info.Width, m_info.Height, HasMips(), m_info.NumLayers, m_info.Format, m_info.Flags);
+                    NativeTextureHandle(ptr));
                 texture->ViewFirstLayer(layerIndex.value_or(0));
                 texture->ViewNumLayers(layerIndex.has_value() ? 1 : 0);
+                ++it;
             }
         }
 

--- a/Plugins/ExternalTexture/Source/ExternalTexture_Shared.h
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Shared.h
@@ -52,13 +52,13 @@ namespace Babylon::Plugins
         texture->ViewFirstLayer(layerIndex.value_or(0));
         texture->ViewNumLayers(layerIndex.has_value() ? 1 : 0);
 
-        auto* result = texture.release();
+        auto* result = texture.get();
         if (!m_textures.insert(result).second)
         {
-            assert(!"Failed to insert texture");
+            throw std::runtime_error{"Failed to insert texture"};
         }
 
-        return result;
+        return texture.release();
     }
 
     void ExternalTexture::ImplBase::DestroyTexture(Graphics::Texture* texture)

--- a/Plugins/ExternalTexture/Source/ExternalTexture_Shared.h
+++ b/Plugins/ExternalTexture/Source/ExternalTexture_Shared.h
@@ -36,36 +36,29 @@ namespace Babylon::Plugins
     {
         std::scoped_lock lock{m_mutex};
 
-        bgfx::TextureHandle handle = bgfx::createTexture2D(
+        auto texture = std::make_unique<Graphics::Texture>(context);
+        texture->Create2D(
             m_info.Width,
             m_info.Height,
             HasMips(),
             m_info.NumLayers,
             m_info.Format,
             m_info.Flags,
-            0,
-            NativeTextureHandle(static_cast<Impl*>(this)->Get())
-        );
+            NativeTextureHandle(static_cast<Impl*>(this)->Get()));
 
         DEBUG_TRACE("ExternalTexture [0x%p] CreateForJavaScript %d x %d %d mips %d layers. Format : %d Flags : %d. (bgfx handle id %d)",
-            this, int(m_info.Width), int(m_info.Height), int(HasMips()), int(m_info.NumLayers), int(m_info.Format), int(m_info.Flags), int(handle.idx));
+            this, int(m_info.Width), int(m_info.Height), int(HasMips()), int(m_info.NumLayers), int(m_info.Format), int(m_info.Flags), int(texture->Handle().idx));
 
-        if (!bgfx::isValid(handle))
-        {
-            throw std::runtime_error{"Failed to create external texture"};
-        }
-
-        auto* texture = new Graphics::Texture{context};
-        texture->Attach(handle, true, m_info.Width, m_info.Height, HasMips(), m_info.NumLayers, m_info.Format, m_info.Flags);
         texture->ViewFirstLayer(layerIndex.value_or(0));
         texture->ViewNumLayers(layerIndex.has_value() ? 1 : 0);
 
-        if (!m_textures.insert(texture).second)
+        auto* result = texture.release();
+        if (!m_textures.insert(result).second)
         {
             assert(!"Failed to insert texture");
         }
 
-        return texture;
+        return result;
     }
 
     void ExternalTexture::ImplBase::DestroyTexture(Graphics::Texture* texture)

--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -222,7 +222,7 @@ namespace Babylon::Polyfills::Internal
             m_texture = std::make_unique<Graphics::Texture>(m_graphicsContext);
         }
 
-        m_texture->Attach(bgfx::getTexture(m_frameBuffer->Handle()), false, m_width, m_height, false, 1, bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT);
+        m_texture->Attach(bgfx::getTexture(m_frameBuffer->Handle()), m_width, m_height, false, 1, bgfx::TextureFormat::RGBA8, BGFX_TEXTURE_RT);
         // Hand the blit view id reserved during the preceding Context::Flush to the texture so
         // NativeEngine::CopyTexture blits on a view ordered before the consuming layer.
         m_texture->BlitViewId(m_blitViewId, m_blitViewIdGeneration);


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

## Context

An `InternalTexture` created by `ExternalTexture::CreateForJavaScript` could become usable again after disposal if its `ExternalTexture` was updated before JavaScript finalization. This prevented callers from deterministically releasing native rendering resources.

## Behavior

Disposed JavaScript textures now remain disposed across later external texture updates. The externally supplied platform texture remains caller-owned and can be released after JavaScript disposal without waiting for garbage collection.