### PR TITLE
Bump JsRuntimeHost to a6b98eaa (forward std streams)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ FetchContent_Declare(ios-cmake
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(JsRuntimeHost
     GIT_REPOSITORY https://github.com/BabylonJS/JsRuntimeHost.git
-    GIT_TAG 0d26362700edd52a48c38ab83b1090e53e7cfeba)
+    GIT_TAG a6b98eaa1a9887b35adceed21f8c7d44c4f38e43)
 FetchContent_Declare(metal-cpp
     GIT_REPOSITORY https://github.com/bkaradzic/metal-cpp.git
     GIT_TAG metal-cpp_26


### PR DESCRIPTION
## Summary
Bump `JsRuntimeHost` from `0d263627` to `a6b98eaa` (current `main`).

## What's included
- [JsRuntimeHost#233](https://github.com/BabylonJS/JsRuntimeHost/pull/233) — Forward native standard streams to platform diagnostics

Master already had through [JsRuntimeHost#220](https://github.com/BabylonJS/JsRuntimeHost/pull/220) (setInterval queue fix). This is the single remaining commit on `main`.

## Test plan
- [ ] CI green across engines/platforms