### PR TITLE
Restore NativeDraco free-function compatibility exports

### DIFF
--- a/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
+++ b/Apps/UnitTests/JavaScript/dist/tests.javaScript.all.js
@@ -28985,9 +28985,73 @@ function hexToBytes(hex) {
   var SPHERE_VERTICES = 62;
   var SPHERE_INDICES = 273;
 
+  function expectDecodedQuad(decoded) {
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(decoded.totalVertices).to.equal(positions.length / 3);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(decoded.indices.length).to.equal(indices.length);
+
+    var attribute = decoded.attributes.find(function (a) {return a.kind === "position";});
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(attribute, "decoded position attribute").to.not.equal(undefined);
+
+    var corner = function corner(buffer, i) {return (
+        [buffer[i * 3], buffer[i * 3 + 1], buffer[i * 3 + 2]].
+        map(function (v) {return v.toFixed(2);}).
+        join(","));};
+
+    var expectedCorners = [];
+    var actualCorners = [];
+    for (var i = 0; i < indices.length; ++i) {
+      expectedCorners.push(corner(positions, indices[i]));
+      actualCorners.push(corner(attribute.data, decoded.indices[i]));
+    }
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(actualCorners.sort()).to.deep.equal(expectedCorners.sort());
+  }
+
+  function captureError(callback) {
+    try {
+      callback();
+    } catch (error) {
+      if (error instanceof Error) {
+        return "".concat(error.name, ": ").concat(error.message);
+      }
+      throw new Error("Expected an Error object, received ".concat(String(error)));
+    }
+    throw new Error("Expected callback to throw");
+  }
+
   it("publishes the codec version it was built against", function () {
     (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.DracoCodec.Version).to.be.a("string");
     (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.DracoCodec.Version).to.match(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("keeps the compatibility entry points interoperable with DracoCodec", function () {
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.decodeDracoMesh).to.be.a("function");
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(_native.encodeDracoMesh).to.be.a("function");
+
+    var compatibilityEncoded = _native.encodeDracoMesh(
+      [{ kind: "position", dracoName: "POSITION", size: 3, data: positions }],
+      indices,
+      {});
+    expectDecodedQuad(_native.DracoCodec.Decode(
+      compatibilityEncoded.data,
+      { position: compatibilityEncoded.attributeIds.position }));
+
+    var groupedEncoded = _native.DracoCodec.Encode(
+      [{ kind: "position", dracoName: "POSITION", size: 3, data: positions }],
+      indices,
+      {});
+    expectDecodedQuad(_native.decodeDracoMesh(
+      groupedEncoded.data,
+      { position: groupedEncoded.attributeIds.position }));
+  });
+
+  it("propagates compatibility entry point errors", function () {
+    var emptyData = new Uint8Array(0);
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(captureError(function () {return _native.decodeDracoMesh(emptyData);})).
+    to.equal(captureError(function () {return _native.DracoCodec.Decode(emptyData);}));
+
+    var noAttributes = [];
+    (0,chai__WEBPACK_IMPORTED_MODULE_3__.expect)(captureError(function () {return _native.encodeDracoMesh(noAttributes, null, {});})).
+    to.equal(captureError(function () {return _native.DracoCodec.Encode(noAttributes, null, {});}));
   });
 
   it("decodes a mesh produced by the reference glTF encoder", function () {

--- a/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
+++ b/Apps/UnitTests/JavaScript/src/tests.javaScript.all.ts
@@ -754,9 +754,73 @@ function hexToBytes(hex: string): Uint8Array {
   const SPHERE_VERTICES = 62;
   const SPHERE_INDICES = 273;
 
+  function expectDecodedQuad(decoded: any) {
+    expect(decoded.totalVertices).to.equal(positions.length / 3);
+    expect(decoded.indices.length).to.equal(indices.length);
+
+    const attribute = decoded.attributes.find((a: any) => a.kind === "position");
+    expect(attribute, "decoded position attribute").to.not.equal(undefined);
+
+    const corner = (buffer: any, i: number) =>
+      [buffer[i * 3], buffer[i * 3 + 1], buffer[i * 3 + 2]]
+        .map((v: number) => v.toFixed(2))
+        .join(",");
+
+    const expectedCorners: string[] = [];
+    const actualCorners: string[] = [];
+    for (let i = 0; i < indices.length; ++i) {
+      expectedCorners.push(corner(positions, indices[i]));
+      actualCorners.push(corner(attribute.data, decoded.indices[i]));
+    }
+    expect(actualCorners.sort()).to.deep.equal(expectedCorners.sort());
+  }
+
+  function captureError(callback: () => unknown): string {
+    try {
+      callback();
+    } catch (error) {
+      if (error instanceof Error) {
+        return `${error.name}: ${error.message}`;
+      }
+      throw new Error(`Expected an Error object, received ${String(error)}`);
+    }
+    throw new Error("Expected callback to throw");
+  }
+
   it("publishes the codec version it was built against", function () {
     expect(_native.DracoCodec.Version).to.be.a("string");
     expect(_native.DracoCodec.Version).to.match(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("keeps the compatibility entry points interoperable with DracoCodec", function () {
+    expect(_native.decodeDracoMesh).to.be.a("function");
+    expect(_native.encodeDracoMesh).to.be.a("function");
+
+    const compatibilityEncoded = _native.encodeDracoMesh(
+      [{ kind: "position", dracoName: "POSITION", size: 3, data: positions }],
+      indices,
+      {});
+    expectDecodedQuad(_native.DracoCodec.Decode(
+      compatibilityEncoded.data,
+      { position: compatibilityEncoded.attributeIds.position }));
+
+    const groupedEncoded = _native.DracoCodec.Encode(
+      [{ kind: "position", dracoName: "POSITION", size: 3, data: positions }],
+      indices,
+      {});
+    expectDecodedQuad(_native.decodeDracoMesh(
+      groupedEncoded.data,
+      { position: groupedEncoded.attributeIds.position }));
+  });
+
+  it("propagates compatibility entry point errors", function () {
+    const emptyData = new Uint8Array(0);
+    expect(captureError(() => _native.decodeDracoMesh(emptyData)))
+      .to.equal(captureError(() => _native.DracoCodec.Decode(emptyData)));
+
+    const noAttributes: any[] = [];
+    expect(captureError(() => _native.encodeDracoMesh(noAttributes, null, {})))
+      .to.equal(captureError(() => _native.DracoCodec.Encode(noAttributes, null, {})));
   });
 
   it("decodes a mesh produced by the reference glTF encoder", function () {

--- a/Plugins/NativeDraco/Include/Babylon/Plugins/NativeDraco.h
+++ b/Plugins/NativeDraco/Include/Babylon/Plugins/NativeDraco.h
@@ -5,8 +5,7 @@
 
 namespace Babylon::Plugins::NativeDraco
 {
-    // Exposes `_native.decodeDracoMesh(dataView, attributes?)`, a synchronous
-    // native replacement for Babylon's WebAssembly Draco decoder. Babylon.js
-    // routes its DracoDecoder to this function when it is present.
+    // Exposes the versioned `_native.DracoCodec` API and the compatible
+    // `_native.decodeDracoMesh` / `_native.encodeDracoMesh` entry points.
     void BABYLON_API Initialize(Napi::Env env);
 }

--- a/Plugins/NativeDraco/README.md
+++ b/Plugins/NativeDraco/README.md
@@ -9,11 +9,11 @@ The plugin is **off by default**. Enable it with `-D BABYLON_NATIVE_PLUGIN_NATIV
 ## Limitations
 
 - **glTF bitstream subset.** Draco is built with `DRACO_GLTF_BITSTREAM=ON`. NativeDraco is intended to produce and consume glTF-compatible Draco data (Babylon.js defaults to the glTF-only decoder). The subset still supports mesh encoding, normals, and standard Edgebreaker; it constrains the output rather than disabling encoding, and avoids features outside the glTF profile (e.g. predictive valence at slower speeds) that the default decoder may reject. Attribute deduplication may be compiled out of the subset; `Encode` guards those passes on the feature macros Draco publishes.
-- **No consumer yet.** Nothing in the pinned `babylonjs` package calls `_native.DracoCodec`. The grouping and the entry-point names have therefore not faced a real consumer and may still move.
+- **Pinned Babylon.js release.** The repository's stock `babylonjs` 9.21.2 bundle does not probe a native Draco API. NativeDraco's unit tests therefore exercise both export forms directly without replacing or overriding the pinned package.
 
 ## Design
 
-The API is exposed as a single `DracoCodec` object on the `_native` global rather than as free functions, so that:
+The versioned API is exposed as a `DracoCodec` object on the `_native` global. `Initialize` also publishes `decodeDracoMesh` and `encodeDracoMesh`, backed by the same implementations as `DracoCodec.Decode` and `DracoCodec.Encode`, for compatibility with Babylon.js native codec feature probes. The grouped API is retained so that:
 
 1. **One feature probe.** JavaScript checks for the object once instead of once per entry point.
 2. **The object can carry a version.** Draco's bitstream is versioned; a caller holding a stream this build is too old to read otherwise has no way to find out ahead of time. A bare function name cannot express that.
@@ -61,6 +61,8 @@ interface INative {
     };
     Version: string;
   };
+  decodeDracoMesh: INative["DracoCodec"]["Decode"];
+  encodeDracoMesh: INative["DracoCodec"]["Encode"];
 }
 ```
 

--- a/Plugins/NativeDraco/Source/NativeDraco.cpp
+++ b/Plugins/NativeDraco/Source/NativeDraco.cpp
@@ -520,5 +520,9 @@ namespace Babylon::Plugins::NativeDraco
         codec.Set("Encode", Napi::Function::New(env, EncodeDracoMesh, "Encode"));
         codec.Set("Version", Napi::String::New(env, draco::kDracoVersion));
         native.Set("DracoCodec", codec);
+
+        // Compatibility entry points for Babylon.js native codec feature probes.
+        native.Set("decodeDracoMesh", Napi::Function::New(env, DecodeDracoMesh, "decodeDracoMesh"));
+        native.Set("encodeDracoMesh", Napi::Function::New(env, EncodeDracoMesh, "encodeDracoMesh"));
     }
 }


### PR DESCRIPTION
## Summary

- restore `_native.decodeDracoMesh` and `_native.encodeDracoMesh` as compatibility entry points
- retain the grouped `_native.DracoCodec.Decode`, `Encode`, and `Version` API
- cover cross-export encode/decode round trips and identical malformed-input error propagation
- update the NativeDraco API documentation

## Compatibility scope

BabylonNative's unchanged stock runtime bundle is `babylonjs` 9.21.2. That bundle does not contain either native Draco feature probe. I also checked the published `babylonjs` and `@babylonjs/core` packages at 9.21.2 and at the current 9.26.0 release; neither contains `_native.decodeDracoMesh` or `_native.encodeDracoMesh`.

These exports therefore prepare NativeDraco for the Babylon.js native decoder/encoder interface without claiming that a released Babylon.js version currently selects this path. The signatures match that interface: synchronous decode returns `{ indices, attributes, totalVertices }`, and synchronous encode returns `{ data: Int8Array, attributeIds }`.

No dependency pin, lockfile, scene, reference, gate, or exclusion changed.

## Validation

Configured and built with NativeDraco enabled:

```text
cmake -S . -B build\win32 -G "Visual Studio 17 2022" -A x64 -DGRAPHICS_API=D3D11 -DBABYLON_NATIVE_PLUGIN_NATIVEXR=OFF -DBABYLON_NATIVE_PLUGIN_NATIVEDRACO=ON
npm run build  # Apps\UnitTests\JavaScript, before the native copy/build
cmake --build build\win32 --target UnitTests --config Release -- /m:2 /verbosity:minimal
```

Negative control on unchanged exports with the new regression tests:

```text
UnitTests.exe --gtest_filter=JavaScript.All
63 passing, 10 pending, 2 failing
```

The failures explicitly reported the missing compatibility function and showed that its missing-function `TypeError` did not match the grouped decoder's native malformed-input error.

After the export change:

```text
UnitTests.exe --gtest_filter=JavaScript.All
65 passing, 10 pending
[ PASSED ] JavaScript.All
```

This is API/unit coverage against stock pinned assets; no stock visual-test outcome is claimed because the released bundle does not probe these entry points.